### PR TITLE
Add persistent HEI dead candidate ledger v2

### DIFF
--- a/review/candidate-ledger/hei_dead_candidate_ledger_v2.json
+++ b/review/candidate-ledger/hei_dead_candidate_ledger_v2.json
@@ -1,0 +1,246 @@
+{
+  "generated_at": "2026-04-14",
+  "basis": {
+    "current_main_entities": 150,
+    "current_main_commit": "dba164d",
+    "last_batch": "hei_public_ready_batch_10_v3",
+    "rule": "Do not cut new batches from names already present in current main. Maintain this ledger as the persistent source of truth for candidate selection and batch burn-down."
+  },
+  "existing_in_main_upgrade_only": [
+    {
+      "canonical_name": "Bittrex Global",
+      "existing_id": "hei_ex_000031",
+      "action": "upgrade_existing",
+      "batch_status": "upgrade_only"
+    },
+    {
+      "canonical_name": "BX Thailand",
+      "existing_id": "hei_ex_000117",
+      "action": "upgrade_existing",
+      "batch_status": "upgrade_only"
+    },
+    {
+      "canonical_name": "COSS",
+      "existing_id": "hei_ex_000118",
+      "action": "re-review_existing",
+      "batch_status": "upgrade_only"
+    },
+    {
+      "canonical_name": "Vaultoro",
+      "existing_id": "hei_ex_000030",
+      "action": "re-review_existing",
+      "batch_status": "upgrade_only"
+    }
+  ],
+  "merged_from_ledger": [
+    {
+      "canonical_name": "Bitcurex",
+      "existing_id": "hei_ex_000141",
+      "kind": "dead",
+      "source_tier": "A",
+      "priority": "A3",
+      "batch_status": "merged"
+    },
+    {
+      "canonical_name": "Tradehill",
+      "existing_id": "hei_ex_000142",
+      "kind": "dead",
+      "source_tier": "A",
+      "priority": "A8",
+      "batch_status": "merged"
+    },
+    {
+      "canonical_name": "Coin.mx",
+      "existing_id": "hei_ex_000143",
+      "kind": "dead",
+      "source_tier": "A",
+      "priority": "A10",
+      "batch_status": "merged"
+    },
+    {
+      "canonical_name": "Yunbi",
+      "existing_id": "hei_ex_000148",
+      "kind": "dead",
+      "source_tier": "B",
+      "priority": "B5",
+      "batch_status": "merged"
+    },
+    {
+      "canonical_name": "Binance Uganda",
+      "existing_id": "hei_ex_000145",
+      "kind": "shutdown",
+      "source_tier": "B",
+      "priority": "B10",
+      "batch_status": "merged"
+    },
+    {
+      "canonical_name": "Binance Jersey",
+      "existing_id": "hei_ex_000149",
+      "kind": "shutdown",
+      "source_tier": "B",
+      "priority": "B11",
+      "batch_status": "merged"
+    },
+    {
+      "canonical_name": "Binance Singapore",
+      "existing_id": "hei_ex_000150",
+      "kind": "rebrand_or_shutdown",
+      "source_tier": "B",
+      "priority": "B9",
+      "batch_status": "merged"
+    }
+  ],
+  "a_tier_backlog": [
+    {
+      "canonical_name": "AAX",
+      "kind": "dead",
+      "priority": "A1",
+      "batch_status": "todo",
+      "notes": "Strong shutdown arc; needs final official terminal pin."
+    },
+    {
+      "canonical_name": "CampBX",
+      "kind": "dead",
+      "priority": "A2",
+      "batch_status": "todo",
+      "notes": "Historic U.S. exchange; good chance of clean dead-side record."
+    },
+    {
+      "canonical_name": "Bleutrade",
+      "kind": "dead",
+      "priority": "A4",
+      "batch_status": "todo",
+      "notes": "Shutdown-era evidence likely tractable."
+    },
+    {
+      "canonical_name": "BTC38",
+      "kind": "dead",
+      "priority": "A5",
+      "batch_status": "todo",
+      "notes": "Historic China exchange candidate."
+    },
+    {
+      "canonical_name": "Coinroom",
+      "kind": "dead",
+      "priority": "A6",
+      "batch_status": "todo",
+      "notes": "Needs careful cause handling; do not force scam label."
+    },
+    {
+      "canonical_name": "Mercatox",
+      "kind": "dead",
+      "priority": "A7",
+      "batch_status": "todo",
+      "notes": "Widely cited closure; needs cleaner final evidence pack."
+    },
+    {
+      "canonical_name": "LakeBTC",
+      "kind": "dead",
+      "priority": "A9",
+      "batch_status": "todo",
+      "notes": "Historic exchange with likely archive-first path."
+    },
+    {
+      "canonical_name": "CryptoBridge",
+      "kind": "dead",
+      "priority": "A11",
+      "batch_status": "todo",
+      "notes": "Historic closure candidate; evidence quality must be checked."
+    },
+    {
+      "canonical_name": "Bitsane",
+      "kind": "dead",
+      "priority": "A12",
+      "batch_status": "todo",
+      "notes": "Needs careful evidence review; keep cause conservative."
+    }
+  ],
+  "b_tier_backlog": [
+    {
+      "canonical_name": "Bter",
+      "kind": "dead",
+      "priority": "B1",
+      "batch_status": "todo",
+      "notes": "Historic exchange candidate."
+    },
+    {
+      "canonical_name": "C-CEX",
+      "kind": "dead",
+      "priority": "B2",
+      "batch_status": "todo",
+      "notes": "Historic alt exchange candidate."
+    },
+    {
+      "canonical_name": "EmpoEx",
+      "kind": "dead",
+      "priority": "B3",
+      "batch_status": "todo",
+      "notes": "Likely tractable but lower priority."
+    },
+    {
+      "canonical_name": "Comkort",
+      "kind": "dead",
+      "priority": "B4",
+      "batch_status": "todo",
+      "notes": "Historic collapse candidate."
+    },
+    {
+      "canonical_name": "Cryptonit",
+      "kind": "dead",
+      "priority": "B6",
+      "batch_status": "todo",
+      "notes": "Historic candidate; source quality uncertain."
+    },
+    {
+      "canonical_name": "CoinFalcon",
+      "kind": "dead_or_inactive",
+      "priority": "B7",
+      "batch_status": "todo",
+      "notes": "Needs status confirmation before batching."
+    },
+    {
+      "canonical_name": "Abucoins",
+      "kind": "dead",
+      "priority": "B8",
+      "batch_status": "todo",
+      "notes": "Low-volume candidate but plausible."
+    },
+    {
+      "canonical_name": "Coinbase Pro",
+      "kind": "rebrand",
+      "priority": "B12",
+      "batch_status": "todo",
+      "notes": "Historical surface / lineage candidate, not dead-side collapse."
+    }
+  ],
+  "lineage_candidates_needing_special_handling": [
+    {
+      "canonical_name": "GDAX",
+      "kind": "rebrand",
+      "batch_status": "watchlist",
+      "notes": "Should be handled as lineage to Coinbase Exchange, not as a naive new dead-side entity."
+    },
+    {
+      "canonical_name": "Huobi Global",
+      "kind": "rebrand",
+      "batch_status": "watchlist",
+      "notes": "Likely predecessor/brand-transition relation to HTX."
+    },
+    {
+      "canonical_name": "OKEx",
+      "kind": "rebrand",
+      "batch_status": "watchlist",
+      "notes": "Likely predecessor/brand-transition relation to OKX."
+    },
+    {
+      "canonical_name": "Bittrex U.S.",
+      "kind": "shutdown",
+      "batch_status": "watchlist",
+      "notes": "Must stay separate from existing Bittrex Global record."
+    }
+  ],
+  "next_cut_hint": {
+    "remaining_a_tier_count": 9,
+    "note": "After the last merged batch, only 9 A-tier names remain. The next 10-pack will require either one B-tier promotion or a refreshed ledger expansion."
+  }
+}

--- a/review/candidate-ledger/hei_dead_candidate_ledger_v2.md
+++ b/review/candidate-ledger/hei_dead_candidate_ledger_v2.md
@@ -1,0 +1,74 @@
+# HEI dead candidate ledger v2
+
+## Basis
+- Current main entities: 150
+- Current main commit: `dba164d`
+- Last merged batch: `hei_public_ready_batch_10_v3`
+- Rule: Do not cut new batches from names already present in current main. Maintain this ledger as the persistent source of truth for candidate selection and batch burn-down.
+
+## Existing in main: upgrade only
+1. Bittrex Global — upgrade_existing — hei_ex_000031 — upgrade_only
+2. BX Thailand — upgrade_existing — hei_ex_000117 — upgrade_only
+3. COSS — re-review_existing — hei_ex_000118 — upgrade_only
+4. Vaultoro — re-review_existing — hei_ex_000030 — upgrade_only
+
+## Already merged from this ledger
+1. Bitcurex — dead — hei_ex_000141 — A3 — merged
+2. Tradehill — dead — hei_ex_000142 — A8 — merged
+3. Coin.mx — dead — hei_ex_000143 — A10 — merged
+4. Yunbi — dead — hei_ex_000148 — B5 — merged
+5. Binance Uganda — shutdown — hei_ex_000145 — B10 — merged
+6. Binance Jersey — shutdown — hei_ex_000149 — B11 — merged
+7. Binance Singapore — rebrand_or_shutdown — hei_ex_000150 — B9 — merged
+
+## Remaining A-tier backlog
+1. AAX — dead — A1 — todo
+   - Strong shutdown arc; needs final official terminal pin.
+2. CampBX — dead — A2 — todo
+   - Historic U.S. exchange; good chance of clean dead-side record.
+3. Bleutrade — dead — A4 — todo
+   - Shutdown-era evidence likely tractable.
+4. BTC38 — dead — A5 — todo
+   - Historic China exchange candidate.
+5. Coinroom — dead — A6 — todo
+   - Needs careful cause handling; do not force scam label.
+6. Mercatox — dead — A7 — todo
+   - Widely cited closure; needs cleaner final evidence pack.
+7. LakeBTC — dead — A9 — todo
+   - Historic exchange with likely archive-first path.
+8. CryptoBridge — dead — A11 — todo
+   - Historic closure candidate; evidence quality must be checked.
+9. Bitsane — dead — A12 — todo
+   - Needs careful evidence review; keep cause conservative.
+
+## Remaining B-tier backlog
+1. Bter — dead — B1 — todo
+   - Historic exchange candidate.
+2. C-CEX — dead — B2 — todo
+   - Historic alt exchange candidate.
+3. EmpoEx — dead — B3 — todo
+   - Likely tractable but lower priority.
+4. Comkort — dead — B4 — todo
+   - Historic collapse candidate.
+5. Cryptonit — dead — B6 — todo
+   - Historic candidate; source quality uncertain.
+6. CoinFalcon — dead_or_inactive — B7 — todo
+   - Needs status confirmation before batching.
+7. Abucoins — dead — B8 — todo
+   - Low-volume candidate but plausible.
+8. Coinbase Pro — rebrand — B12 — todo
+   - Historical surface / lineage candidate, not dead-side collapse.
+
+## Lineage / special handling watchlist
+1. GDAX — rebrand — watchlist
+   - Should be handled as lineage to Coinbase Exchange, not as a naive new dead-side entity.
+2. Huobi Global — rebrand — watchlist
+   - Likely predecessor/brand-transition relation to HTX.
+3. OKEx — rebrand — watchlist
+   - Likely predecessor/brand-transition relation to OKX.
+4. Bittrex U.S. — shutdown — watchlist
+   - Must stay separate from existing Bittrex Global record.
+
+## Next cut hint
+- Remaining A-tier count: 9
+- After the last merged batch, only 9 A-tier names remain. The next 10-pack will require either one B-tier promotion or a refreshed ledger expansion.


### PR DESCRIPTION
## Summary
- add a persistent dead-side candidate ledger under `review/candidate-ledger/`
- record which prior ledger names have already been merged into `main`
- preserve remaining A-tier and B-tier backlog for future batch selection
- separate upgrade-only and lineage-sensitive tracks from new-candidate batching

## Files
- `review/candidate-ledger/hei_dead_candidate_ledger_v2.json`
- `review/candidate-ledger/hei_dead_candidate_ledger_v2.md`

## Why
`data-staging/latest` is ephemeral and overwritten, so it is not suitable as a long-lived burn-down ledger. This PR adds a persistent Git-tracked ledger that can be referenced when selecting future public-ready batches.

## Notes
- current main baseline in the ledger is commit `dba164d`
- current main entity count recorded in the ledger is `150`
- after the last merged batch, only 9 A-tier names remain, so the next 10-pack will require either one B-tier promotion or a refreshed ledger expansion