### PR TITLE
Add Cryptonit public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3224,5 +3224,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-14",
     "notes": "Treat cause conservatively as regulation because KNF action is clear and closure followed later."
+  },
+  {
+    "id": "hei_ex_000157",
+    "slug": "cryptonit",
+    "canonical_name": "Cryptonit",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2019-04-01",
+    "country_or_origin": "United Kingdom",
+    "summary": "United Kingdom cryptocurrency exchange that was later marked inactive and publicly described as having closed operations by 2019-04-01.",
+    "official_url_original": "https://cryptonit.net/",
+    "official_domain_original": "cryptonit.net",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://cryptonit.net/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-14",
+    "notes": "Treat cause conservatively as unknown. Public exchange-status sources say operations closed on 2019-04-01."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1048,5 +1048,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "Uses the 2019-02-26 closure marker from public exchange-status sources."
+  },
+  {
+    "id": "hei_ev_000185",
+    "exchange_id": "hei_ex_000157",
+    "event_type": "service_outage",
+    "event_date": "2019-04-01",
+    "title": "Cryptonit marked closed",
+    "description": "By 2019-04-01, Cryptonit was publicly described as having closed down operations.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Conservative terminal marker from public exchange-status sources."
+  },
+  {
+    "id": "hei_ev_000186",
+    "exchange_id": "hei_ex_000157",
+    "event_type": "shutdown_effective",
+    "event_date": "2019-04-01",
+    "title": "Operations closed",
+    "description": "A public update stated that Cryptonit had closed down operations, referencing an announcement email to customers.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 1,
+    "sort_order": 2,
+    "notes": "HEI uses 2019-04-01 as the terminal date."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -3913,5 +3913,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Public closure marker used for the terminal date."
+  },
+  {
+    "id": "hei_src_000476",
+    "exchange_id": "hei_ex_000157",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Cryptonit site",
+    "url": "https://cryptonit.net/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-14",
+    "archived_url": "https://web.archive.org/web/*/https://cryptonit.net/",
+    "accessed_at": "2026-04-14",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000477",
+    "exchange_id": "hei_ex_000157",
+    "event_id": "hei_ev_000186",
+    "source_type": "news_article",
+    "title": "Cryptonit review with 2019 closure update",
+    "url": "https://www.cryptowisser.com/exchange/cryptonit/",
+    "publisher": "Cryptowisser",
+    "published_at": "2019-04-01",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/cryptonit/",
+    "accessed_at": "2026-04-14",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the exchange had closed down operations and references an email sent to customers."
+  },
+  {
+    "id": "hei_src_000478",
+    "exchange_id": "hei_ex_000157",
+    "event_id": "hei_ev_000185",
+    "source_type": "status_page",
+    "title": "Cryptonit exchange page marked inactive",
+    "url": "https://coinmarketcap.com/exchanges/cryptonit/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/cryptonit/",
+    "accessed_at": "2026-04-14",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current exchange-status page marks Cryptonit as inactive."
   }
 ]


### PR DESCRIPTION
## Summary
- add Cryptonit canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2019-04-01 as the conservative terminal marker
- current evidence is archive + public status sources, so wording stays conservative