### PR TITLE
Add C-CEX public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3246,5 +3246,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-14",
     "notes": "Treat cause conservatively as unknown. Public exchange-status sources say operations closed on 2019-04-01."
+  },
+  {
+    "id": "hei_ex_000158",
+    "slug": "c-cex",
+    "canonical_name": "C-CEX",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2019-06-27",
+    "country_or_origin": "Russia",
+    "summary": "Russian cryptocurrency exchange that became inaccessible by late June 2019 and was subsequently marked dead, although some later status pages still described it as suspended for reorganization.",
+    "official_url_original": "https://c-cex.com/",
+    "official_domain_original": "c-cex.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://c-cex.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2019-06-27 dead-side update, while acknowledging later status-page ambiguity about reorganization."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1076,5 +1076,33 @@
     "source_count": 1,
     "sort_order": 2,
     "notes": "HEI uses 2019-04-01 as the terminal date."
+  },
+  {
+    "id": "hei_ev_000187",
+    "exchange_id": "hei_ex_000158",
+    "event_type": "service_outage",
+    "event_date": "2019-06-27",
+    "title": "C-CEX became inaccessible",
+    "description": "By 2019-06-27, public exchange-status sources reported that the website was not accessible.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000188",
+    "exchange_id": "hei_ex_000158",
+    "event_type": "shutdown_effective",
+    "event_date": "2019-06-27",
+    "title": "C-CEX marked dead",
+    "description": "Public exchange-status sources marked C-CEX as dead or closed by 2019-06-27.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2019-06-27 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -3958,5 +3958,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current exchange-status page marks Cryptonit as inactive."
+  },
+  {
+    "id": "hei_src_000479",
+    "exchange_id": "hei_ex_000158",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former C-CEX site",
+    "url": "https://c-cex.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://c-cex.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000480",
+    "exchange_id": "hei_ex_000158",
+    "event_id": "hei_ev_000188",
+    "source_type": "news_article",
+    "title": "C-CEX review with 2019 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/c-cex",
+    "publisher": "Cryptowisser",
+    "published_at": "2019-06-27",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/c-cex",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the exchange appeared inaccessible on 2019-06-27 and was listed as dead."
+  },
+  {
+    "id": "hei_src_000481",
+    "exchange_id": "hei_ex_000158",
+    "event_id": "hei_ev_000187",
+    "source_type": "status_page",
+    "title": "C-CEX exchange page suspended for reorganization",
+    "url": "https://coinmarketcap.com/exchanges/c-cex/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/c-cex/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current status page still says services are suspended for reorganization, so HEI keeps cause conservative."
   }
 ]


### PR DESCRIPTION
## Summary
- add C-CEX canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2019-06-27 as the conservative terminal marker
- wording stays conservative because later status pages still referenced reorganization