### PR TITLE
Add Coinbase Pro rebrand canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3268,5 +3268,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2019-06-27 dead-side update, while acknowledging later status-page ambiguity about reorganization."
+  },
+  {
+    "id": "hei_ex_000159",
+    "slug": "coinbase-pro",
+    "canonical_name": "Coinbase Pro",
+    "aliases": [],
+    "type": "cex",
+    "status": "rebranded",
+    "death_reason": "rebrand",
+    "launch_date": null,
+    "death_date": "2023-12-31",
+    "country_or_origin": "United States",
+    "summary": "Advanced trading surface under Coinbase that was replaced by Coinbase Advanced, with customer history access ending after December 2023.",
+    "official_url_original": "https://pro.coinbase.com/",
+    "official_domain_original": "pro.coinbase.com",
+    "official_url_status": "redirected_or_retired",
+    "archived_url": "https://web.archive.org/web/*/https://pro.coinbase.com/",
+    "predecessor_id": null,
+    "successor_id": "hei_ex_000012",
+    "confidence": "high",
+    "last_verified_at": "2026-04-15",
+    "notes": "Lineage-sensitive product transition. After balance migration, customers could no longer deposit, withdraw, or trade on Coinbase Pro, and transaction history remained accessible only until the end of 2023."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1104,5 +1104,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2019-06-27 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000189",
+    "exchange_id": "hei_ex_000159",
+    "event_type": "rebrand_announced",
+    "event_date": "2022-06-01",
+    "title": "Coinbase announced the transition away from Coinbase Pro",
+    "description": "Coinbase announced it would replace Coinbase Pro with Coinbase Advanced on Coinbase.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Announcement month used conservatively from official help text."
+  },
+  {
+    "id": "hei_ev_000190",
+    "exchange_id": "hei_ex_000159",
+    "event_type": "rebrand",
+    "event_date": "2023-12-31",
+    "title": "Coinbase Pro discontinued",
+    "description": "Coinbase documentation states Coinbase Pro was discontinued in December 2023 and replaced by Coinbase Advanced.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "rebranded",
+    "source_count": 3,
+    "sort_order": 2,
+    "notes": "HEI uses 2023-12-31 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4003,5 +4003,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current status page still says services are suspended for reorganization, so HEI keeps cause conservative."
+  },
+  {
+    "id": "hei_src_000482",
+    "exchange_id": "hei_ex_000159",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for Coinbase Pro",
+    "url": "https://pro.coinbase.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://pro.coinbase.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000483",
+    "exchange_id": "hei_ex_000159",
+    "event_id": "hei_ev_000190",
+    "source_type": "official_help",
+    "title": "Transitioning from Coinbase Pro to Coinbase Advanced",
+    "url": "https://help.coinbase.com/en/pro/managing-my-account/account-information/transitioning-to-advanced-trade",
+    "publisher": "Coinbase Help",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://help.coinbase.com/en/pro/managing-my-account/account-information/transitioning-to-advanced-trade",
+    "accessed_at": "2026-04-15",
+    "reliability": "high",
+    "claim_scope": "successor",
+    "notes": "Official help page stating Coinbase Pro would be replaced by Coinbase Advanced and that Pro trading functions would stop after migration."
+  },
+  {
+    "id": "hei_src_000484",
+    "exchange_id": "hei_ex_000159",
+    "event_id": "hei_ev_000190",
+    "source_type": "official_help",
+    "title": "Coinbase tax information",
+    "url": "https://help.coinbase.com/en/coinbase/taxes/general-information/tax-info",
+    "publisher": "Coinbase Help",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://help.coinbase.com/en/coinbase/taxes/general-information/tax-info",
+    "accessed_at": "2026-04-15",
+    "reliability": "high",
+    "claim_scope": "status",
+    "notes": "Official help page stating Coinbase Pro was discontinued in December 2023."
   }
 ]


### PR DESCRIPTION
## Summary
- add Coinbase Pro canonical entity/event/evidence records as a lineage-sensitive rebrand case

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- status is rebranded
- death_reason is rebrand
- successor_id points to hei_ex_000012
- death_date uses 2023-12-31 as the conservative terminal marker
- wording stays product-transition focused, not collapse-focused