### PR TITLE
Add BTC38 public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3290,5 +3290,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-15",
     "notes": "Lineage-sensitive product transition. After balance migration, customers could no longer deposit, withdraw, or trade on Coinbase Pro, and transaction history remained accessible only until the end of 2023."
+  },
+  {
+    "id": "hei_ex_000160",
+    "slug": "btc38",
+    "canonical_name": "BTC38",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": "2013-08-23",
+    "death_date": "2019-06-12",
+    "country_or_origin": "China",
+    "summary": "China-based cryptocurrency exchange launched in 2013 that was publicly marked inaccessible and dead by mid-June 2019.",
+    "official_url_original": "http://www.btc38.com/",
+    "official_domain_original": "btc38.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/http://www.btc38.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2019-06-12 dead-side update."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1132,5 +1132,33 @@
     "source_count": 3,
     "sort_order": 2,
     "notes": "HEI uses 2023-12-31 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000191",
+    "exchange_id": "hei_ex_000160",
+    "event_type": "service_outage",
+    "event_date": "2019-06-12",
+    "title": "BTC38 site failed to load",
+    "description": "By 2019-06-12, public exchange-status sources reported that the BTC38 website kept loading without completing.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000192",
+    "exchange_id": "hei_ex_000160",
+    "event_type": "shutdown_effective",
+    "event_date": "2019-06-12",
+    "title": "BTC38 marked dead",
+    "description": "Public exchange-status sources marked BTC38 as dead by 2019-06-12.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2019-06-12 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4048,5 +4048,50 @@
     "reliability": "high",
     "claim_scope": "status",
     "notes": "Official help page stating Coinbase Pro was discontinued in December 2023."
+  },
+  {
+    "id": "hei_src_000485",
+    "exchange_id": "hei_ex_000160",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former BTC38 site",
+    "url": "http://www.btc38.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/http://www.btc38.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000486",
+    "exchange_id": "hei_ex_000160",
+    "event_id": "hei_ev_000192",
+    "source_type": "news_article",
+    "title": "BTC38 review with 2019 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/btc38/",
+    "publisher": "Cryptowisser",
+    "published_at": "2019-06-12",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/btc38/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the exchange site failed to load on 2019-06-12 and was marked dead."
+  },
+  {
+    "id": "hei_src_000487",
+    "exchange_id": "hei_ex_000160",
+    "event_id": "hei_ev_000191",
+    "source_type": "status_page",
+    "title": "BTC38 exchange page marked inactive",
+    "url": "https://coinmarketcap.com/exchanges/btc38/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/btc38/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current status page marks BTC38 as inactive."
   }
 ]


### PR DESCRIPTION
## Summary
- add BTC38 canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date uses 2013-08-23 from public status sources
- death_date uses 2019-06-12 as the conservative terminal marker
- wording stays conservative and collapse-agnostic