### PR TITLE
Add Bleutrade public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3312,5 +3312,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2019-06-12 dead-side update."
+  },
+  {
+    "id": "hei_ex_000161",
+    "slug": "bleutrade",
+    "canonical_name": "Bleutrade",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2023-03-23",
+    "country_or_origin": "Brazil",
+    "summary": "Cryptocurrency exchange originally from Brazil that was later described as inaccessible and dead by March 2023 after earlier relocations to Malta and Portugal.",
+    "official_url_original": "https://bleutrade.com/",
+    "official_domain_original": "bleutrade.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://bleutrade.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Bleutrade was originally from Brazil, later moved to Malta in 2018 and Portugal in 2020, and was marked dead after the site was inaccessible on 2023-03-23."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1160,5 +1160,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2019-06-12 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000193",
+    "exchange_id": "hei_ex_000161",
+    "event_type": "relocation",
+    "event_date": "2020-05-25",
+    "title": "Bleutrade announced move to Portugal",
+    "description": "Bleutrade announced a move to Portugal and closure of its Malta office.",
+    "confidence": "medium",
+    "impact_level": "medium",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Useful lineage context, not the terminal event."
+  },
+  {
+    "id": "hei_ev_000194",
+    "exchange_id": "hei_ex_000161",
+    "event_type": "shutdown_effective",
+    "event_date": "2023-03-23",
+    "title": "Bleutrade marked dead",
+    "description": "Public exchange-status sources reported the website was inaccessible on 2023-03-23 and marked Bleutrade as dead.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2023-03-23 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4093,5 +4093,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current status page marks BTC38 as inactive."
+  },
+  {
+    "id": "hei_src_000488",
+    "exchange_id": "hei_ex_000161",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Bleutrade site",
+    "url": "https://bleutrade.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://bleutrade.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000489",
+    "exchange_id": "hei_ex_000161",
+    "event_id": "hei_ev_000194",
+    "source_type": "news_article",
+    "title": "Bleutrade review with 2023 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/bleutrade/",
+    "publisher": "Cryptowisser",
+    "published_at": "2023-03-23",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/bleutrade/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the site was inaccessible on 2023-03-23 and Bleutrade was marked dead."
+  },
+  {
+    "id": "hei_src_000490",
+    "exchange_id": "hei_ex_000161",
+    "event_id": "hei_ev_000194",
+    "source_type": "status_page",
+    "title": "Bleutrade exchange page with no tracked volume",
+    "url": "https://coinmarketcap.com/exchanges/bleutrade/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/bleutrade/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and shows no meaningful live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add Bleutrade canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2023-03-23 as the conservative terminal marker
- wording stays conservative and keeps the relocation history as context only