### PR TITLE
Add LakeBTC public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3334,5 +3334,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Bleutrade was originally from Brazil, later moved to Malta in 2018 and Portugal in 2020, and was marked dead after the site was inaccessible on 2023-03-23."
+  },
+  {
+    "id": "hei_ex_000162",
+    "slug": "lakebtc",
+    "canonical_name": "LakeBTC",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2021-07-15",
+    "country_or_origin": "China",
+    "summary": "China-linked cryptocurrency exchange that was publicly marked inaccessible and dead on 2021-07-15.",
+    "official_url_original": "https://lakebtc.com/",
+    "official_domain_original": "lakebtc.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://lakebtc.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2021-07-15 dead-side update."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1188,5 +1188,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2023-03-23 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000195",
+    "exchange_id": "hei_ex_000162",
+    "event_type": "service_outage",
+    "event_date": "2021-07-15",
+    "title": "LakeBTC site became inaccessible",
+    "description": "By 2021-07-15, public exchange-status sources reported that the LakeBTC website was unsuccessful to access.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000196",
+    "exchange_id": "hei_ex_000162",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-07-15",
+    "title": "LakeBTC marked dead",
+    "description": "Public exchange-status sources marked LakeBTC as dead on 2021-07-15.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-07-15 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4138,5 +4138,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and shows no meaningful live market data."
+  },
+  {
+    "id": "hei_src_000491",
+    "exchange_id": "hei_ex_000162",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former LakeBTC site",
+    "url": "https://lakebtc.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://lakebtc.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000492",
+    "exchange_id": "hei_ex_000162",
+    "event_id": "hei_ev_000196",
+    "source_type": "news_article",
+    "title": "LakeBTC review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/lakebtc/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-07-15",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/lakebtc/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the exchange website was inaccessible on 2021-07-15 and that LakeBTC was marked dead."
+  },
+  {
+    "id": "hei_src_000493",
+    "exchange_id": "hei_ex_000162",
+    "event_id": "hei_ev_000196",
+    "source_type": "status_page",
+    "title": "LakeBTC exchange page untracked",
+    "url": "https://coinmarketcap.com/exchanges/lakebtc/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/lakebtc/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and shows no live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add LakeBTC canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2021-07-15 as the conservative terminal marker
- wording stays conservative and treats the closure state as tracker-confirmed rather than officially announced