### PR TITLE
Add Mercatox public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3356,5 +3356,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2021-07-15 dead-side update."
+  },
+  {
+    "id": "hei_ex_000163",
+    "slug": "mercatox",
+    "canonical_name": "Mercatox",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": "2015-10-01",
+    "death_date": "2025-04-01",
+    "country_or_origin": "Canada",
+    "summary": "Canada-linked cryptocurrency exchange that was publicly described as closed in early 2025, with user inquiries ending on 2025-04-01.",
+    "official_url_original": "https://mercatox.com/",
+    "official_domain_original": "mercatox.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://mercatox.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2025-04-01 user-inquiry end date from the public closure update."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1216,5 +1216,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-07-15 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000197",
+    "exchange_id": "hei_ex_000163",
+    "event_type": "shutdown_announced",
+    "event_date": "2025-02-01",
+    "title": "Mercatox closure update posted",
+    "description": "Public exchange-status sources stated that Mercatox had closed down operations and would cease responding to user inquiries on 2025-04-01.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Conservative announcement marker from the public closure update."
+  },
+  {
+    "id": "hei_ev_000198",
+    "exchange_id": "hei_ex_000163",
+    "event_type": "shutdown_effective",
+    "event_date": "2025-04-01",
+    "title": "Mercatox support ended",
+    "description": "Public closure text stated Mercatox would cease responding to user inquiries on 2025-04-01.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2025-04-01 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4183,5 +4183,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and shows no live market data."
+  },
+  {
+    "id": "hei_src_000494",
+    "exchange_id": "hei_ex_000163",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Mercatox site",
+    "url": "https://mercatox.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://mercatox.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000495",
+    "exchange_id": "hei_ex_000163",
+    "event_id": "hei_ev_000198",
+    "source_type": "news_article",
+    "title": "Mercatox review with 2025 closure update",
+    "url": "https://www.cryptowisser.com/exchange/mercatox/",
+    "publisher": "Cryptowisser",
+    "published_at": "2025-02-01",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/mercatox/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Mercatox closed operations and would stop responding to inquiries on 2025-04-01."
+  },
+  {
+    "id": "hei_src_000496",
+    "exchange_id": "hei_ex_000163",
+    "event_id": "hei_ev_000198",
+    "source_type": "status_page",
+    "title": "Mercatox exchange page untracked",
+    "url": "https://coinmarketcap.com/exchanges/mercatox/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/mercatox/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and shows no live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add Mercatox canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date uses 2015-10-01 conservatively
- death_date uses 2025-04-01 as the conservative terminal marker
- wording stays conservative and treats closure state as tracker-confirmed rather than officially announced