### PR TITLE
Add ACX public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3378,5 +3378,29 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2025-04-01 user-inquiry end date from the public closure update."
+  },
+  {
+    "id": "hei_ex_000164",
+    "slug": "acx",
+    "canonical_name": "ACX",
+    "aliases": [
+      "ACX.io"
+    ],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2021-07-15",
+    "country_or_origin": "Australia",
+    "summary": "Australian cryptocurrency exchange that was publicly described as inaccessible and dead by 2021-07-15.",
+    "official_url_original": "https://acx.io/",
+    "official_domain_original": "acx.io",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://acx.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2021-07-15 dead-side update."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1244,5 +1244,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2025-04-01 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000199",
+    "exchange_id": "hei_ex_000164",
+    "event_type": "service_outage",
+    "event_date": "2021-07-15",
+    "title": "ACX site became inaccessible",
+    "description": "By 2021-07-15, public exchange-status sources reported that the ACX website was not accessible.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000200",
+    "exchange_id": "hei_ex_000164",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-07-15",
+    "title": "ACX marked dead",
+    "description": "Public exchange-status sources marked ACX as dead on 2021-07-15.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-07-15 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4228,5 +4228,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and shows no live market data."
+  },
+  {
+    "id": "hei_src_000497",
+    "exchange_id": "hei_ex_000164",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former ACX site",
+    "url": "https://acx.io/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://acx.io/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000498",
+    "exchange_id": "hei_ex_000164",
+    "event_id": "hei_ev_000200",
+    "source_type": "news_article",
+    "title": "ACX review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/acx/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-07-15",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/acx/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that ACX was inaccessible on 2021-07-15 and marked dead."
+  },
+  {
+    "id": "hei_src_000499",
+    "exchange_id": "hei_ex_000164",
+    "event_id": "hei_ev_000200",
+    "source_type": "status_page",
+    "title": "ACX exchange page untracked",
+    "url": "https://coinmarketcap.com/exchanges/acx/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/acx/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and shows no live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add ACX canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2021-07-15 as the conservative terminal marker
- wording stays conservative and treats the closure state as tracker-confirmed rather than officially announced