### PR TITLE
Add Cryptox public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3402,5 +3402,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2021-07-15 dead-side update."
+  },
+  {
+    "id": "hei_ex_000165",
+    "slug": "cryptox",
+    "canonical_name": "Cryptox",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2021-11-11",
+    "country_or_origin": "Poland",
+    "summary": "Polish cryptocurrency exchange that was publicly described as inaccessible and dead by 2021-11-11.",
+    "official_url_original": "https://cryptox.pl/",
+    "official_domain_original": "cryptox.pl",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://cryptox.pl/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2021-11-11 dead-side update."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1272,5 +1272,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-07-15 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000201",
+    "exchange_id": "hei_ex_000165",
+    "event_type": "service_outage",
+    "event_date": "2021-11-11",
+    "title": "Cryptox site became inaccessible",
+    "description": "By 2021-11-11, public exchange-status sources reported that the Cryptox website was not accessible and there had been no prior maintenance notice.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000202",
+    "exchange_id": "hei_ex_000165",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-11-11",
+    "title": "Cryptox marked dead",
+    "description": "Public exchange-status sources marked Cryptox as dead on 2021-11-11.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-11-11 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4273,5 +4273,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and shows no live market data."
+  },
+  {
+    "id": "hei_src_000500",
+    "exchange_id": "hei_ex_000165",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Cryptox site",
+    "url": "https://cryptox.pl/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://cryptox.pl/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000501",
+    "exchange_id": "hei_ex_000165",
+    "event_id": "hei_ev_000202",
+    "source_type": "news_article",
+    "title": "Cryptox review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/cryptox/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-11-11",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/cryptox/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Cryptox was inaccessible on 2021-11-11 and marked dead."
+  },
+  {
+    "id": "hei_src_000502",
+    "exchange_id": "hei_ex_000165",
+    "event_id": "hei_ev_000202",
+    "source_type": "status_page",
+    "title": "Cryptox exchange page untracked",
+    "url": "https://coinmarketcap.com/exchanges/cryptox/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/cryptox/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and inactive, with no live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add Cryptox canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2021-11-11 as the conservative terminal marker
- wording stays conservative and treats the closure state as tracker-confirmed rather than officially announced