### PR TITLE
Add C-Trade public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3424,5 +3424,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2021-11-11 dead-side update."
+  },
+  {
+    "id": "hei_ex_000166",
+    "slug": "c-trade",
+    "canonical_name": "C-Trade",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": "2020-01-01",
+    "death_date": "2023-01-11",
+    "country_or_origin": "Seychelles",
+    "summary": "Seychelles-registered cryptocurrency derivatives exchange that became unusable by 2023-01-11 and was marked dead after posting a message about developing a new platform.",
+    "official_url_original": "https://www.c-trade.com/app",
+    "official_domain_original": "c-trade.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.c-trade.com/app",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2023-01-11 dead-side update. The 'new platform' notice is treated as context, not proof of a successful successor."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1300,5 +1300,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-11-11 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000203",
+    "exchange_id": "hei_ex_000166",
+    "event_type": "service_outage",
+    "event_date": "2023-01-11",
+    "title": "C-Trade platform became unusable",
+    "description": "By 2023-01-11, public exchange-status sources stated that the C-Trade platform was not possible to use.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000204",
+    "exchange_id": "hei_ex_000166",
+    "event_type": "shutdown_effective",
+    "event_date": "2023-01-11",
+    "title": "C-Trade marked dead",
+    "description": "Public exchange-status sources marked C-Trade as dead on 2023-01-11 after the exchange posted a notice about building a brand new platform.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2023-01-11 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4318,5 +4318,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and inactive, with no live market data."
+  },
+  {
+    "id": "hei_src_000503",
+    "exchange_id": "hei_ex_000166",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former C-Trade site",
+    "url": "https://www.c-trade.com/app",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://www.c-trade.com/app",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000504",
+    "exchange_id": "hei_ex_000166",
+    "event_id": "hei_ev_000204",
+    "source_type": "news_article",
+    "title": "C-Trade review with 2023 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/c-trade/",
+    "publisher": "Cryptowisser",
+    "published_at": "2023-01-11",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/c-trade/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the platform was not possible to use on 2023-01-11 and reproduces the 'brand new platform' message."
+  },
+  {
+    "id": "hei_src_000505",
+    "exchange_id": "hei_ex_000166",
+    "event_id": "hei_ev_000204",
+    "source_type": "status_page",
+    "title": "C-Trade exchange page untracked",
+    "url": "https://coinmarketcap.com/exchanges/c-trade/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/c-trade/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and shows no live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add C-Trade canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date uses 2020-01-01 conservatively
- death_date uses 2023-01-11 as the conservative terminal marker
- wording stays conservative and treats the “brand new platform” notice as context only, not as proof of a valid successor