### PR TITLE
Add NIX-E public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3446,5 +3446,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2023-01-11 dead-side update. The 'new platform' notice is treated as context, not proof of a successful successor."
+  },
+  {
+    "id": "hei_ex_000167",
+    "slug": "nix-e",
+    "canonical_name": "NIX-E",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2019-07-18",
+    "country_or_origin": "Russia",
+    "summary": "Russian cryptocurrency exchange that was publicly described as dead by 2019-07-18 after volume-reporting ceased, the site presented an invalid certificate, and trading activity appeared stale.",
+    "official_url_original": "https://www.nix-e.com/",
+    "official_domain_original": "nix-e.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.nix-e.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Cryptowisser review update uses 2019-07-18 as the dead-side marker, while Cryptowisser graveyard shows 2019-07-17 with business reasons."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1328,5 +1328,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2023-01-11 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000205",
+    "exchange_id": "hei_ex_000167",
+    "event_type": "service_outage",
+    "event_date": "2019-07-18",
+    "title": "NIX-E showed terminal warning signs",
+    "description": "By 2019-07-18, public exchange-status sources said NIX-E no longer reported volume to major sites, had an invalid site certificate, and appeared to have stale trading activity.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000206",
+    "exchange_id": "hei_ex_000167",
+    "event_type": "shutdown_effective",
+    "event_date": "2019-07-18",
+    "title": "NIX-E marked dead",
+    "description": "Public exchange-status sources marked NIX-E as dead by 2019-07-18.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2019-07-18 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4363,5 +4363,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and shows no live market data."
+  },
+  {
+    "id": "hei_src_000506",
+    "exchange_id": "hei_ex_000167",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former NIX-E site",
+    "url": "https://www.nix-e.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://www.nix-e.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000507",
+    "exchange_id": "hei_ex_000167",
+    "event_id": "hei_ev_000206",
+    "source_type": "news_article",
+    "title": "NIX-E review with 2019 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/nix-e/",
+    "publisher": "Cryptowisser",
+    "published_at": "2019-07-18",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/nix-e/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that NIX-E seemed dead on 2019-07-18 and cites stale activity plus invalid certificate."
+  },
+  {
+    "id": "hei_src_000508",
+    "exchange_id": "hei_ex_000167",
+    "event_id": "hei_ev_000206",
+    "source_type": "status_page",
+    "title": "NIX-E exchange page untracked and inactive",
+    "url": "https://coinmarketcap.com/exchanges/nix-e/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/nix-e/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page is untracked and inactive, with no live market data."
   }
 ]


### PR DESCRIPTION
## Summary
- add NIX-E canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2019-07-18 as the conservative terminal marker
- wording stays conservative and treats the business-reasons mention as context only, not as a proven cause classification