### PR TITLE
Add ZT.com Exchange public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3468,5 +3468,29 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Cryptowisser review update uses 2019-07-18 as the dead-side marker, while Cryptowisser graveyard shows 2019-07-17 with business reasons."
+  },
+  {
+    "id": "hei_ex_000168",
+    "slug": "zt-com-exchange",
+    "canonical_name": "ZT.com Exchange",
+    "aliases": [
+      "ZT"
+    ],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2024-09-18",
+    "country_or_origin": "China",
+    "summary": "Crypto exchange branded as ZT that was publicly described as inaccessible and dead by 2024-09-18, with CoinMarketCap later showing that withdrawals and trading were suspended.",
+    "official_url_original": "https://www.zt.com/",
+    "official_domain_original": "zt.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.zt.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2024-09-18 dead-side update. CoinMarketCap currently surfaces the exchange as ZT with ztb.im and suspended withdrawals/trading."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1356,5 +1356,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2019-07-18 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000207",
+    "exchange_id": "hei_ex_000168",
+    "event_type": "service_outage",
+    "event_date": "2024-09-18",
+    "title": "ZT.com site became inaccessible",
+    "description": "By 2024-09-18, public exchange-status sources reported that the zt.com website was unsuccessful to access and there had been no prior maintenance or migration notice.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000208",
+    "exchange_id": "hei_ex_000168",
+    "event_type": "shutdown_effective",
+    "event_date": "2024-09-18",
+    "title": "ZT.com Exchange marked dead",
+    "description": "Public exchange-status sources marked ZT.com Exchange as dead by 2024-09-18, and CoinMarketCap later showed withdrawals and trading suspended.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2024-09-18 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4408,5 +4408,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page is untracked and inactive, with no live market data."
+  },
+  {
+    "id": "hei_src_000509",
+    "exchange_id": "hei_ex_000168",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former ZT.com site",
+    "url": "https://www.zt.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://www.zt.com/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000510",
+    "exchange_id": "hei_ex_000168",
+    "event_id": "hei_ev_000208",
+    "source_type": "news_article",
+    "title": "ZT.com Exchange review with 2024 dead-side update",
+    "url": "https://www.cryptowisser.com/index.php/exchange/zt-com-exchange/",
+    "publisher": "Cryptowisser",
+    "published_at": "2024-09-18",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/index.php/exchange/zt-com-exchange/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that zt.com was inaccessible on 2024-09-18 and the exchange was marked dead."
+  },
+  {
+    "id": "hei_src_000511",
+    "exchange_id": "hei_ex_000168",
+    "event_id": "hei_ev_000208",
+    "source_type": "status_page",
+    "title": "ZT exchange page suspended and untracked",
+    "url": "https://coinmarketcap.com/exchanges/zt/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/zt/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current page says ZT has suspended all withdrawals and trading and shows the listing as untracked."
   }
 ]


### PR DESCRIPTION
## Summary
- add ZT.com Exchange canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2024-09-18 as the conservative terminal marker
- wording stays conservative and treats the suspended withdrawals/trading state as supporting status evidence, not as a separately proven cause classification