### PR TITLE
Add InstaSwap public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3516,5 +3516,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-15",
     "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2023-01-11 dead-side update. Source coverage shows a 2022-11-13 suspension first, then a later dead-side marker."
+  },
+  {
+    "id": "hei_ex_000170",
+    "slug": "instaswap",
+    "canonical_name": "InstaSwap",
+    "aliases": [],
+    "type": "dex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": "2019-01-01",
+    "death_date": "2024-09-18",
+    "country_or_origin": "Greece",
+    "summary": "Greece-linked non-custodial exchange or broker-style swap platform that was publicly described as inaccessible and dead by 2024-09-18.",
+    "official_url_original": "https://instaswap.io/",
+    "official_domain_original": "instaswap.io",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://instaswap.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-15",
+    "notes": "Treat cause conservatively as unknown. Terminal marker uses the 2024-09-18 dead-side update. Launch year is 2019, recorded conservatively as 2019-01-01."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1412,5 +1412,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2023-01-11 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000211",
+    "exchange_id": "hei_ex_000170",
+    "event_type": "service_outage",
+    "event_date": "2024-09-18",
+    "title": "InstaSwap site became inaccessible",
+    "description": "By 2024-09-18, public exchange-status sources reported that the InstaSwap website was unsuccessful to access and there had been no prior maintenance or migration notice.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000212",
+    "exchange_id": "hei_ex_000170",
+    "event_type": "shutdown_effective",
+    "event_date": "2024-09-18",
+    "title": "InstaSwap marked dead",
+    "description": "Public exchange-status sources marked InstaSwap as dead by 2024-09-18.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2024-09-18 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4513,5 +4513,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current page says AAX has halted all operations including trading and withdrawals and is untracked."
+  },
+  {
+    "id": "hei_src_000516",
+    "exchange_id": "hei_ex_000170",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former InstaSwap site",
+    "url": "https://instaswap.io/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://instaswap.io/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000517",
+    "exchange_id": "hei_ex_000170",
+    "event_id": "hei_ev_000212",
+    "source_type": "news_article",
+    "title": "InstaSwap review with 2024 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/instaswap/",
+    "publisher": "Cryptowisser",
+    "published_at": "2024-09-18",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/instaswap/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that InstaSwap was inaccessible on 2024-09-18 and marked dead."
+  },
+  {
+    "id": "hei_src_000518",
+    "exchange_id": "hei_ex_000170",
+    "event_id": "hei_ev_000212",
+    "source_type": "status_page",
+    "title": "Cryptowisser Exchange Graveyard entry for InstaSwap",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page lists InstaSwap among dead exchanges."
   }
 ]


### PR DESCRIPTION
## Summary
- add InstaSwap canonical entity/event/evidence records

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date uses 2019-01-01 conservatively
- death_date uses 2024-09-18 as the conservative terminal marker
- wording stays conservative and treats the graveyard listing as supporting status evidence, not as a separately proven cause classification