### PR TITLE
Upgrade Uniswap active DEX canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -117,14 +117,14 @@
     "launch_date": "2018-11-02",
     "death_date": null,
     "country_or_origin": "Ethereum ecosystem",
-    "summary": "Ethereum ecosystem decentralized exchange protocol launched in 2018 and still operating under the Uniswap brand.",
+    "summary": "Ethereum-born decentralized exchange protocol family first deployed to mainnet in 2018 and still active through multiple major protocol versions under the Uniswap brand.",
     "official_url_original": "https://app.uniswap.org/",
     "official_domain_original": "uniswap.org",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://app.uniswap.org/",
-    "confidence": "medium",
-    "last_verified_at": "2026-04-05",
-    "notes": "Official Uniswap history states the protocol was publicly announced and deployed to Ethereum mainnet on 2018-11-02."
+    "confidence": "high",
+    "last_verified_at": "2026-04-15",
+    "notes": "Entity-level umbrella record. v0/v1, v2, and v3 milestones are recorded here. Deployment-level and chain-level modeling is still pending, so this is not yet split by deployment."
   },
   {
     "id": "hei_ex_000007",

--- a/data/events.json
+++ b/data/events.json
@@ -70,20 +70,6 @@
     "notes": ""
   },
   {
-    "id": "hei_ev_000010",
-    "exchange_id": "hei_ex_000006",
-    "event_type": "launched",
-    "event_date": "2018-11-02",
-    "title": "Uniswap protocol launched",
-    "description": "Uniswap began operating as a decentralized exchange protocol.",
-    "confidence": "medium",
-    "impact_level": "medium",
-    "event_status_effect": "active",
-    "source_count": 2,
-    "sort_order": 1,
-    "notes": ""
-  },
-  {
     "id": "hei_ev_000011",
     "exchange_id": "hei_ex_000007",
     "event_type": "launched",
@@ -1440,5 +1426,47 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2024-09-18 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000213",
+    "exchange_id": "hei_ex_000006",
+    "event_type": "launched",
+    "event_date": "2018-11-02",
+    "title": "Uniswap was publicly launched on Ethereum mainnet",
+    "description": "Uniswap was publicly announced and deployed to Ethereum mainnet on 2018-11-02.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "active",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Entity-level launch marker for the protocol family."
+  },
+  {
+    "id": "hei_ev_000214",
+    "exchange_id": "hei_ex_000006",
+    "event_type": "launched",
+    "event_date": "2020-05-18",
+    "title": "Uniswap v2 mainnet launch",
+    "description": "Uniswap v2, the second major protocol version, was deployed to Ethereum mainnet on 2020-05-18.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "active",
+    "source_count": 1,
+    "sort_order": 2,
+    "notes": "Major protocol-version milestone under the same umbrella entity."
+  },
+  {
+    "id": "hei_ev_000215",
+    "exchange_id": "hei_ex_000006",
+    "event_type": "launched",
+    "event_date": "2021-05-05",
+    "title": "Uniswap v3 mainnet launch",
+    "description": "Uniswap v3, the third major protocol version, was deployed to Ethereum mainnet on 2021-05-05.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "active",
+    "source_count": 2,
+    "sort_order": 3,
+    "notes": "Major protocol-version milestone under the same umbrella entity."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -105,21 +105,6 @@
     "notes": "Primary U.S. enforcement reference."
   },
   {
-    "id": "hei_src_000008",
-    "exchange_id": "hei_ex_000006",
-    "event_id": "hei_ev_000010",
-    "source_type": "official_blog",
-    "title": "A Short History of Uniswap",
-    "url": "https://blog.uniswap.org/uniswap-history",
-    "publisher": "Uniswap Labs",
-    "published_at": "2019-02-10",
-    "archived_url": "https://web.archive.org/web/*/https://blog.uniswap.org/uniswap-history",
-    "accessed_at": "2026-04-06",
-    "reliability": "high",
-    "claim_scope": "launch_date",
-    "notes": "Official Uniswap history gives 2018-11-02 as the public announcement and mainnet deployment date."
-  },
-  {
     "id": "hei_src_000009",
     "exchange_id": "hei_ex_000007",
     "event_id": "hei_ev_000011",
@@ -178,21 +163,6 @@
     "reliability": "high",
     "claim_scope": "entity",
     "notes": "About page states Binance was launched in July 2017. Snapshot date reflects an undated page observation captured on the access date."
-  },
-  {
-    "id": "hei_src_000013",
-    "exchange_id": "hei_ex_000006",
-    "event_id": "hei_ev_000010",
-    "source_type": "official_blog",
-    "title": "Introducing Uniswap v3",
-    "url": "https://blog.uniswap.org/uniswap-v3",
-    "publisher": "Uniswap Labs",
-    "published_at": "2021-03-23",
-    "archived_url": "https://web.archive.org/web/*/https://blog.uniswap.org/uniswap-v3",
-    "accessed_at": "2026-04-06",
-    "reliability": "high",
-    "claim_scope": "entity",
-    "notes": "States Uniswap v1 launched in November 2018."
   },
   {
     "id": "hei_src_000014",
@@ -4558,5 +4528,65 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current graveyard page lists InstaSwap among dead exchanges."
+  },
+  {
+    "id": "hei_src_000519",
+    "exchange_id": "hei_ex_000006",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for Uniswap app",
+    "url": "https://app.uniswap.org/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-15",
+    "archived_url": "https://web.archive.org/web/*/https://app.uniswap.org/",
+    "accessed_at": "2026-04-15",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000520",
+    "exchange_id": "hei_ex_000006",
+    "event_id": "hei_ev_000213",
+    "source_type": "official_blog",
+    "title": "A Short History of Uniswap",
+    "url": "https://blog.uniswap.org/uniswap-history",
+    "publisher": "Uniswap Labs",
+    "published_at": "2019-02-11",
+    "archived_url": "https://web.archive.org/web/*/https://blog.uniswap.org/uniswap-history",
+    "accessed_at": "2026-04-15",
+    "reliability": "high",
+    "claim_scope": "event",
+    "notes": "Official retrospective stating Uniswap was publicly announced and deployed to Ethereum mainnet on 2018-11-02."
+  },
+  {
+    "id": "hei_src_000521",
+    "exchange_id": "hei_ex_000006",
+    "event_id": "hei_ev_000214",
+    "source_type": "official_blog",
+    "title": "Uniswap v2 Mainnet Launch",
+    "url": "https://blog.uniswap.org/launch-uniswap-v2",
+    "publisher": "Uniswap Labs",
+    "published_at": "2020-05-18",
+    "archived_url": "https://web.archive.org/web/*/https://blog.uniswap.org/launch-uniswap-v2",
+    "accessed_at": "2026-04-15",
+    "reliability": "high",
+    "claim_scope": "event",
+    "notes": "Official launch post for Uniswap v2 on Ethereum mainnet."
+  },
+  {
+    "id": "hei_src_000522",
+    "exchange_id": "hei_ex_000006",
+    "event_id": "hei_ev_000215",
+    "source_type": "official_blog",
+    "title": "Uniswap v3 Mainnet Launch",
+    "url": "https://blog.uniswap.org/launch-uniswap-v3",
+    "publisher": "Uniswap Labs",
+    "published_at": "2021-05-05",
+    "archived_url": "https://web.archive.org/web/*/https://blog.uniswap.org/launch-uniswap-v3",
+    "accessed_at": "2026-04-15",
+    "reliability": "high",
+    "claim_scope": "event",
+    "notes": "Official launch post for Uniswap v3 on Ethereum mainnet."
   }
 ]


### PR DESCRIPTION
## Summary
- upgrade the Uniswap active DEX canonical record
- replace the old single-event placeholder with multi-version milestones
- strengthen entity summary, notes, and evidence

## Scope
- entities: update 1
- events: replace with 3
- evidence: replace with 4

## Notes
- keep Uniswap as one umbrella entity for now
- explicitly note that deployment-level and chain-level modeling is still pending
- use 2018-11-02 as the entity-level launch marker
- add major milestone events for Uniswap v2 and Uniswap v3