### PR TITLE
Add NLExch public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3584,5 +3584,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-16",
     "notes": "Entity-level umbrella record. Launch marker uses the documented production date. Bisq 1 and Bisq 2 are not yet split into separate protocol or product records."
+  },
+  {
+    "id": "hei_ex_000173",
+    "slug": "nlexch",
+    "canonical_name": "NLExch",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2020-09-01",
+    "country_or_origin": "Netherlands",
+    "summary": "Dutch cryptocurrency exchange that was publicly marked closed on 2020-09-01 after citing Dutch registration requirements and operating-cost pressure.",
+    "official_url_original": "https://nlexch.com/",
+    "official_domain_original": "nlexch.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://nlexch.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-16",
+    "notes": "Cause stays conservative as unknown. Public closure text references Dutch registration requirements and economic infeasibility, but HEI does not hard-classify this beyond the terminal closure marker."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1566,5 +1566,33 @@
     "source_count": 1,
     "sort_order": 2,
     "notes": "Year-level conservative marker for the current-generation platform."
+  },
+  {
+    "id": "hei_ev_000224",
+    "exchange_id": "hei_ex_000173",
+    "event_type": "shutdown_announced",
+    "event_date": "2020-09-01",
+    "title": "NLExch closure statement surfaced",
+    "description": "A public update stated that NLExch had closed down and cited Dutch registration requirements and related operating costs.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Conservative announcement marker from public exchange-status coverage."
+  },
+  {
+    "id": "hei_ev_000225",
+    "exchange_id": "hei_ex_000173",
+    "event_type": "shutdown_effective",
+    "event_date": "2020-09-01",
+    "title": "NLExch marked dead",
+    "description": "Public exchange-status sources marked NLExch as closed and moved it to the exchange graveyard on 2020-09-01.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2020-09-01 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4753,5 +4753,50 @@
     "reliability": "medium",
     "claim_scope": "event",
     "notes": "Current Bisq wiki states that Bisq 2 launched in 2024 and that Bisq 1 was originally launched in 2016 as BitSquare."
+  },
+  {
+    "id": "hei_src_000536",
+    "exchange_id": "hei_ex_000173",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former NLExch site",
+    "url": "https://nlexch.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-16",
+    "archived_url": "https://web.archive.org/web/*/https://nlexch.com/",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000537",
+    "exchange_id": "hei_ex_000173",
+    "event_id": "hei_ev_000225",
+    "source_type": "news_article",
+    "title": "NLExch review with 2020 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/nlexch/",
+    "publisher": "Cryptowisser",
+    "published_at": "2020-09-01",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/nlexch/",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that NLExch closed down on 2020-09-01 and reproduces the closure statement tied to Dutch registration requirements."
+  },
+  {
+    "id": "hei_src_000538",
+    "exchange_id": "hei_ex_000173",
+    "event_id": "hei_ev_000225",
+    "source_type": "database_reference",
+    "title": "Cryptowisser Exchange Graveyard entry",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page lists dead exchanges and supports NLExch dead-side handling."
   }
 ]


### PR DESCRIPTION
## Summary
- add NLExch canonical entity/event/evidence records
- capture the 2020 closure marker and supporting dead-side evidence
- keep cause handling conservative

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2020-09-01 as the conservative terminal marker
- closure text mentioning Dutch registration requirements is treated as supporting context, not as a hard cause classification