### PR TITLE
Add Rippex public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3606,5 +3606,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-16",
     "notes": "Cause stays conservative as unknown. Public closure text references Dutch registration requirements and economic infeasibility, but HEI does not hard-classify this beyond the terminal closure marker."
+  },
+  {
+    "id": "hei_ex_000174",
+    "slug": "rippex",
+    "canonical_name": "Rippex",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Brazil",
+    "summary": "Brazil-linked cryptocurrency exchange associated with XRP trading that is now permanently closed according to public exchange-status sources.",
+    "official_url_original": "https://rippex.net/",
+    "official_domain_original": "rippex.net",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://rippex.net/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-16",
+    "notes": "Cause stays conservative as unknown. Public handling relies on exchange-status coverage stating the platform is permanently closed and that a closure notice was shown on the website."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1594,5 +1594,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2020-09-01 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000226",
+    "exchange_id": "hei_ex_000174",
+    "event_type": "shutdown_announced",
+    "event_date": null,
+    "title": "Rippex closure notice was displayed",
+    "description": "Public exchange-status coverage states that Rippex displayed a closure notice on its website in Portuguese.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Announcement timing remains uncertain in this pass."
+  },
+  {
+    "id": "hei_ev_000227",
+    "exchange_id": "hei_ex_000174",
+    "event_type": "shutdown_effective",
+    "event_date": null,
+    "title": "Rippex marked permanently closed",
+    "description": "Public exchange-status sources describe Rippex as permanently closed.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 1,
+    "sort_order": 2,
+    "notes": "Terminal timing remains conservative because a precise effective date is not fixed in this pass."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4798,5 +4798,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current graveyard page lists dead exchanges and supports NLExch dead-side handling."
+  },
+  {
+    "id": "hei_src_000539",
+    "exchange_id": "hei_ex_000174",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Rippex site",
+    "url": "https://rippex.net/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-16",
+    "archived_url": "https://web.archive.org/web/*/https://rippex.net/",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000540",
+    "exchange_id": "hei_ex_000174",
+    "event_id": "hei_ev_000227",
+    "source_type": "news_article",
+    "title": "Rippex review marked permanently closed",
+    "url": "https://www.cryptowisser.com/exchange/rippex",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/rippex",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Cryptowisser states that Rippex is permanently closed and references a closure message shown on the website."
+  },
+  {
+    "id": "hei_src_000541",
+    "exchange_id": "hei_ex_000174",
+    "event_id": "hei_ev_000226",
+    "source_type": "database_reference",
+    "title": "Cryptowisser Exchange Graveyard entry",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page supports dead-side handling for exchanges marked closed by Cryptowisser."
   }
 ]


### PR DESCRIPTION
## Summary
- add Rippex canonical entity/event/evidence records
- capture the permanently-closed dead-side handling with conservative timing
- keep cause handling conservative

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date remains null intentionally in this pass because a precise terminal date is not fixed
- closure-message handling is treated as supporting status evidence, not as a hard cause classification