### PR TITLE
Add Bitmaszyna public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3628,5 +3628,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-16",
     "notes": "Cause stays conservative as unknown. Public handling relies on exchange-status coverage stating the platform is permanently closed and that a closure notice was shown on the website."
+  },
+  {
+    "id": "hei_ex_000175",
+    "slug": "bitmaszyna",
+    "canonical_name": "Bitmaszyna",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2021-07-15",
+    "country_or_origin": "Poland",
+    "summary": "Polish cryptocurrency exchange that was publicly marked dead on 2021-07-15 after its website became inaccessible with no preceding maintenance or migration notice.",
+    "official_url_original": "https://bitmaszyna.pl/",
+    "official_domain_original": "bitmaszyna.pl",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://bitmaszyna.pl/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-16",
+    "notes": "Cause stays conservative as unknown. Public handling relies on the dead-side status update tied to site inaccessibility on 2021-07-15."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1622,5 +1622,33 @@
     "source_count": 1,
     "sort_order": 2,
     "notes": "Terminal timing remains conservative because a precise effective date is not fixed in this pass."
+  },
+  {
+    "id": "hei_ev_000228",
+    "exchange_id": "hei_ex_000175",
+    "event_type": "service_outage",
+    "event_date": "2021-07-15",
+    "title": "Bitmaszyna site became inaccessible",
+    "description": "Public exchange-status coverage stated that attempts to access bitmaszyna.pl on 2021-07-15 were unsuccessful and that there had been no prior maintenance or migration notice.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Start of conservative terminal handling."
+  },
+  {
+    "id": "hei_ev_000229",
+    "exchange_id": "hei_ex_000175",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-07-15",
+    "title": "Bitmaszyna marked dead",
+    "description": "Public exchange-status sources marked Bitmaszyna as dead on 2021-07-15.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 1,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-07-15 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4843,5 +4843,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current graveyard page supports dead-side handling for exchanges marked closed by Cryptowisser."
+  },
+  {
+    "id": "hei_src_000542",
+    "exchange_id": "hei_ex_000175",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Bitmaszyna site",
+    "url": "https://bitmaszyna.pl/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-16",
+    "archived_url": "https://web.archive.org/web/*/https://bitmaszyna.pl/",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000543",
+    "exchange_id": "hei_ex_000175",
+    "event_id": "hei_ev_000229",
+    "source_type": "news_article",
+    "title": "Bitmaszyna review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/bitmaszyna/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-07-15",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/bitmaszyna/",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that the site was inaccessible on 2021-07-15 and that the exchange was moved to the graveyard."
+  },
+  {
+    "id": "hei_src_000544",
+    "exchange_id": "hei_ex_000175",
+    "event_id": "hei_ev_000229",
+    "source_type": "database_reference",
+    "title": "Cryptowisser Exchange Graveyard entry",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-16",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page supports dead-side handling for exchanges marked closed by Cryptowisser."
   }
 ]


### PR DESCRIPTION
## Summary
- add Bitmaszyna canonical entity/event/evidence records
- capture the 2021 dead-side terminal marker and supporting status evidence
- keep cause handling conservative

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown intentionally
- launch_date remains null intentionally
- death_date uses 2021-07-15 as the conservative terminal marker
- site-inaccessibility handling is treated as supporting status evidence, not as a hard cause classification