### PR TITLE
Add eXch dead-side swap-service canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3650,5 +3650,29 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-16",
     "notes": "Cause stays conservative as unknown. Public handling relies on the dead-side status update tied to site inaccessibility on 2021-07-15."
+  },
+  {
+    "id": "hei_ex_000176",
+    "slug": "exch",
+    "canonical_name": "eXch",
+    "aliases": [
+      "eXch.cx"
+    ],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "regulation",
+    "launch_date": "2014-01-01",
+    "death_date": "2025-04-30",
+    "country_or_origin": "Global",
+    "summary": "Exchange-like cryptocurrency swap service reachable via eXch.cx that was seized and shut down by German authorities on 2025-04-30 after investigators alleged money laundering and operation of a criminal online trading platform.",
+    "official_url_original": "https://eXch.cx/",
+    "official_domain_original": "eXch.cx",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://eXch.cx/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-04-18",
+    "notes": "Current HEI scope treats exchange-like swap services as in-scope. The terminal marker uses the 2025-04-30 infrastructure seizure and shutdown by German authorities, which preempted the operators' own planned 2025-05-01 closure."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1678,5 +1678,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2025-09-18 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000232",
+    "exchange_id": "hei_ex_000176",
+    "event_type": "regulatory_action",
+    "event_date": "2025-04-30",
+    "title": "German authorities seized eXch infrastructure",
+    "description": "The Frankfurt public prosecutor's cybercrime unit and the BKA seized the Germany-based server infrastructure of eXch and confiscated cryptocurrency assets, with support from the Dutch FIOD.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Primary enforcement action."
+  },
+  {
+    "id": "hei_ev_000233",
+    "exchange_id": "hei_ex_000176",
+    "event_type": "shutdown_effective",
+    "event_date": "2025-04-30",
+    "title": "eXch was shut down as a swap service",
+    "description": "Authorities stated that the seizure action shut down the eXch platform before the operators' announced 2025-05-01 closure date.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2025-04-30 as the terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4918,5 +4918,50 @@
     "reliability": "high",
     "claim_scope": "status",
     "notes": "Canadian Press reporting that the action shut down the website and marked the first dismantling of a cryptocurrency exchange by Canadian police."
+  },
+  {
+    "id": "hei_src_000548",
+    "exchange_id": "hei_ex_000176",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former eXch site",
+    "url": "https://eXch.cx/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-18",
+    "archived_url": "https://web.archive.org/web/*/https://eXch.cx/",
+    "accessed_at": "2026-04-18",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000549",
+    "exchange_id": "hei_ex_000176",
+    "event_id": "hei_ev_000232",
+    "source_type": "official_statement",
+    "title": "Krypto-Swapping-Dienst „eXch“ abgeschaltet",
+    "url": "https://www.bka.de/DE/Presse/Listenseite_Pressemitteilungen/2025/Presse2025/250509_exch_abgeschaltet.html",
+    "publisher": "Bundeskriminalamt",
+    "published_at": "2025-05-07",
+    "archived_url": "https://web.archive.org/web/*/https://www.bka.de/DE/Presse/Listenseite_Pressemitteilungen/2025/Presse2025/250509_exch_abgeschaltet.html",
+    "accessed_at": "2026-04-18",
+    "reliability": "high",
+    "claim_scope": "entity_event",
+    "notes": "Primary authority statement describing eXch as a crypto-swapping service existing since 2014 and shut down on 2025-04-30."
+  },
+  {
+    "id": "hei_src_000550",
+    "exchange_id": "hei_ex_000176",
+    "event_id": "hei_ev_000233",
+    "source_type": "official_statement",
+    "title": "BKA and FIOD shut down cryptocurrency swap service eXch",
+    "url": "https://www.fiod.nl/bka-and-fiod-shut-down-cryptocurrency-swap-service-exch-e-34-million-in-cryptocurrency-has-been-seized-during-the-operation/",
+    "publisher": "FIOD",
+    "published_at": "2025-05-09",
+    "archived_url": "https://web.archive.org/web/*/https://www.fiod.nl/bka-and-fiod-shut-down-cryptocurrency-swap-service-exch-e-34-million-in-cryptocurrency-has-been-seized-during-the-operation/",
+    "accessed_at": "2026-04-18",
+    "reliability": "high",
+    "claim_scope": "status",
+    "notes": "English-language authority summary confirming seizure and shutdown of the cryptocurrency swap service."
   }
 ]


### PR DESCRIPTION
## Summary
- add eXch as a dead-side exchange-like swap-service canonical record
- capture the 2025-04-30 seizure-and-shutdown terminal marker
- keep the scope note explicit because this is an exchange-like swap service rather than a normal retail exchange

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- status is dead
- death_reason is regulation
- death_date uses 2025-04-30 as the terminal marker
- current HEI scope treats exchange-like swap services as in-scope
- this is not a general decision to include mixers by default