### PR TITLE
Add DSX public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3674,5 +3674,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-18",
     "notes": "Current HEI scope treats exchange-like swap services as in-scope. The terminal marker uses the 2025-04-30 infrastructure seizure and shutdown by German authorities, which preempted the operators' own planned 2025-05-01 closure."
+  },
+  {
+    "id": "hei_ex_000177",
+    "slug": "dsx",
+    "canonical_name": "DSX",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "insolvency",
+    "launch_date": "2014-01-01",
+    "death_date": "2021-01-12",
+    "country_or_origin": "United Kingdom",
+    "summary": "United Kingdom-based cryptocurrency exchange launched in 2014 that was publicly reported bankrupt on 2021-01-12 and is no longer operating.",
+    "official_url_original": "https://dsx.uk/",
+    "official_domain_original": "dsx.uk",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://dsx.uk/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-04-18",
+    "notes": "Terminal handling uses the 2021-01-12 bankruptcy update. Death reason is set to insolvency based on the bankruptcy filing and dead-side treatment."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1706,5 +1706,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2025-04-30 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000234",
+    "exchange_id": "hei_ex_000177",
+    "event_type": "bankruptcy_filed",
+    "event_date": "2021-01-12",
+    "title": "DSX bankruptcy filing was reported",
+    "description": "Public exchange-status coverage stated on 2021-01-12 that DSX had filed for bankruptcy and displayed an administrator notice from DSX Global (UK) Limited.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Primary public bankruptcy marker."
+  },
+  {
+    "id": "hei_ev_000235",
+    "exchange_id": "hei_ex_000177",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-01-12",
+    "title": "DSX was treated as dead after the bankruptcy filing",
+    "description": "Public exchange-status sources treated DSX as effectively dead after the 2021-01-12 bankruptcy update.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-01-12 as the terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -4963,5 +4963,50 @@
     "reliability": "high",
     "claim_scope": "status",
     "notes": "English-language authority summary confirming seizure and shutdown of the cryptocurrency swap service."
+  },
+  {
+    "id": "hei_src_000551",
+    "exchange_id": "hei_ex_000177",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former DSX site",
+    "url": "https://dsx.uk/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-18",
+    "archived_url": "https://web.archive.org/web/*/https://dsx.uk/",
+    "accessed_at": "2026-04-18",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000552",
+    "exchange_id": "hei_ex_000177",
+    "event_id": "hei_ev_000235",
+    "source_type": "news_article",
+    "title": "DSX review with 2021 bankruptcy update",
+    "url": "https://www.cryptowisser.com/exchange/dsx/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-01-12",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/dsx/",
+    "accessed_at": "2026-04-18",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that DSX filed for bankruptcy on 2021-01-12 and reproduces the administrator notice."
+  },
+  {
+    "id": "hei_src_000553",
+    "exchange_id": "hei_ex_000177",
+    "event_id": null,
+    "source_type": "database_reference",
+    "title": "DSX exchange profile with launch and location details",
+    "url": "https://coinmarketcap.com/exchanges/dsx/",
+    "publisher": "CoinMarketCap",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/dsx/",
+    "accessed_at": "2026-04-18",
+    "reliability": "medium",
+    "claim_scope": "entity",
+    "notes": "Supports 2014 launch timing, London headquarters, and current untracked status."
   }
 ]


### PR DESCRIPTION
## Summary
- add DSX canonical entity/event/evidence records
- capture the 2021 bankruptcy-based terminal marker
- classify the dead-side outcome as insolvency

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is insolvency
- launch_date uses 2014-01-01 as a conservative launch marker
- death_date uses 2021-01-12 as the terminal marker
- bankruptcy handling is modeled through a bankruptcy_filed event plus a shutdown_effective event