### PR TITLE
Add Titanex public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3696,5 +3696,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-18",
     "notes": "Terminal handling uses the 2021-01-12 bankruptcy update. Death reason is set to insolvency based on the bankruptcy filing and dead-side treatment."
+  },
+  {
+    "id": "hei_ex_000178",
+    "slug": "titanex",
+    "canonical_name": "Titanex",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2023-01-03",
+    "country_or_origin": "Seychelles",
+    "summary": "Seychelles-linked cryptocurrency exchange that was publicly treated as dead on 2023-01-03 after disappearing from normal operation.",
+    "official_url_original": "https://titanex.io/",
+    "official_domain_original": "titanex.io",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://titanex.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2023-01-03 graveyard marker. Cause stays conservative as unknown even though public status coverage characterizes the exchange as having disappeared."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1734,5 +1734,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-01-12 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000236",
+    "exchange_id": "hei_ex_000178",
+    "event_type": "service_outage",
+    "event_date": "2023-01-03",
+    "title": "Titanex was treated as missing from operation",
+    "description": "Public exchange-status coverage classified Titanex as having disappeared from normal operation.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Conservative terminal lead-in based on graveyard-style handling."
+  },
+  {
+    "id": "hei_ev_000237",
+    "exchange_id": "hei_ex_000178",
+    "event_type": "shutdown_effective",
+    "event_date": "2023-01-03",
+    "title": "Titanex was treated as dead",
+    "description": "Public exchange-status sources treated Titanex as dead on 2023-01-03.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2023-01-03 as the conservative terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5008,5 +5008,50 @@
     "reliability": "medium",
     "claim_scope": "entity",
     "notes": "Supports 2014 launch timing, London headquarters, and current untracked status."
+  },
+  {
+    "id": "hei_src_000554",
+    "exchange_id": "hei_ex_000178",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Titanex site",
+    "url": "https://titanex.io/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://titanex.io/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000555",
+    "exchange_id": "hei_ex_000178",
+    "event_id": "hei_ev_000237",
+    "source_type": "news_article",
+    "title": "Titanex review with 2023 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/titanex/",
+    "publisher": "Cryptowisser",
+    "published_at": "2023-01-03",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/titanex/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Public exchange-status coverage marking Titanex dead on 2023-01-03."
+  },
+  {
+    "id": "hei_src_000556",
+    "exchange_id": "hei_ex_000178",
+    "event_id": "hei_ev_000237",
+    "source_type": "database_reference",
+    "title": "Cryptowisser Exchange Graveyard entry",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page lists Titanex with a 2023-01-03 terminal marker."
   }
 ]


### PR DESCRIPTION
## Summary
- add Titanex canonical entity/event/evidence records
- capture the 2023 dead-side terminal marker
- keep cause handling conservative as unknown

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason stays unknown
- launch_date remains null in this pass
- death_date uses 2023-01-03 as the terminal marker
- disappearance-style handling is treated as supporting status context, not as a hard cause classification