### PR TITLE
Add KKCoin public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3718,5 +3718,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-19",
     "notes": "Terminal handling uses the 2023-01-03 graveyard marker. Cause stays conservative as unknown even though public status coverage characterizes the exchange as having disappeared."
+  },
+  {
+    "id": "hei_ex_000179",
+    "slug": "kkcoin",
+    "canonical_name": "KKCoin",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "regulation",
+    "launch_date": "2017-01-01",
+    "death_date": "2021-01-01",
+    "country_or_origin": "Singapore",
+    "summary": "Singapore-based cryptocurrency exchange launched in 2017 that was publicly treated as closed on 2021-01-01 amid regulation-linked shutdown handling.",
+    "official_url_original": "https://www.kkcoin.com/",
+    "official_domain_original": "kkcoin.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.kkcoin.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2021-01-01 dead-side update. Death reason is set to regulation in line with public exchange-status coverage."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1762,5 +1762,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2023-01-03 as the conservative terminal marker."
+  },
+  {
+    "id": "hei_ev_000238",
+    "exchange_id": "hei_ex_000179",
+    "event_type": "regulatory_action",
+    "event_date": "2021-01-01",
+    "title": "KKCoin was treated as shut down under regulation-linked handling",
+    "description": "Public exchange-status coverage stated on 2021-01-01 that KKCoin had closed down and linked the terminal handling to regulation-related restrictions.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Primary public terminal update."
+  },
+  {
+    "id": "hei_ev_000239",
+    "exchange_id": "hei_ex_000179",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-01-01",
+    "title": "KKCoin was treated as dead",
+    "description": "Public exchange-status sources treated KKCoin as dead on 2021-01-01.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-01-01 as the terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5053,5 +5053,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current graveyard page lists Titanex with a 2023-01-03 terminal marker."
+  },
+  {
+    "id": "hei_src_000557",
+    "exchange_id": "hei_ex_000179",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former KKCoin site",
+    "url": "https://www.kkcoin.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://www.kkcoin.com/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000558",
+    "exchange_id": "hei_ex_000179",
+    "event_id": "hei_ev_000239",
+    "source_type": "news_article",
+    "title": "KKCoin review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/kkcoin",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-01-01",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/kkcoin",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that KKCoin closed down on 2021-01-01 and includes regulation-linked shutdown context."
+  },
+  {
+    "id": "hei_src_000559",
+    "exchange_id": "hei_ex_000179",
+    "event_id": null,
+    "source_type": "database_reference",
+    "title": "KKCoin exchange profile with launch and origin details",
+    "url": "https://www.cryptowisser.com/exchange/kkcoin",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/kkcoin",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "entity",
+    "notes": "Supports Singapore origin and 2017 launch timing."
   }
 ]


### PR DESCRIPTION
## Summary
- add KKCoin canonical entity/event/evidence records
- capture the 2021 regulation-linked terminal marker
- classify the dead-side outcome as regulation

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is regulation
- launch_date uses 2017-01-01 as a conservative launch marker
- death_date uses 2021-01-01 as the terminal marker
- regulation-linked closure handling is modeled through a regulatory_action event plus a shutdown_effective event