### PR TITLE
Add Ternion public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3740,5 +3740,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-19",
     "notes": "Terminal handling uses the 2021-01-01 dead-side update. Death reason is set to regulation in line with public exchange-status coverage."
+  },
+  {
+    "id": "hei_ex_000180",
+    "slug": "ternion",
+    "canonical_name": "Ternion",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "voluntary_shutdown",
+    "launch_date": null,
+    "death_date": "2021-01-01",
+    "country_or_origin": "Estonia",
+    "summary": "Estonia-linked cryptocurrency exchange that was publicly treated as dead on 2021-01-01 for business-related shutdown reasons.",
+    "official_url_original": "https://ternion.exchange/",
+    "official_domain_original": "ternion.exchange",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://ternion.exchange/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2021-01-01 graveyard marker. Death reason is mapped to voluntary_shutdown from business-reasons style closure handling."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1790,5 +1790,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-01-01 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000240",
+    "exchange_id": "hei_ex_000180",
+    "event_type": "shutdown_announced",
+    "event_date": "2021-01-01",
+    "title": "Ternion was treated as closed for business reasons",
+    "description": "Public exchange-status coverage treated Ternion as closed on 2021-01-01 and classified the terminal handling under business reasons.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Primary public terminal update."
+  },
+  {
+    "id": "hei_ev_000241",
+    "exchange_id": "hei_ex_000180",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-01-01",
+    "title": "Ternion was treated as dead",
+    "description": "Public exchange-status sources treated Ternion as dead on 2021-01-01.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-01-01 as the terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5098,5 +5098,50 @@
     "reliability": "medium",
     "claim_scope": "entity",
     "notes": "Supports Singapore origin and 2017 launch timing."
+  },
+  {
+    "id": "hei_src_000560",
+    "exchange_id": "hei_ex_000180",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Ternion site",
+    "url": "https://ternion.exchange/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://ternion.exchange/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000561",
+    "exchange_id": "hei_ex_000180",
+    "event_id": "hei_ev_000241",
+    "source_type": "database_reference",
+    "title": "Cryptowisser Exchange Graveyard entry",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page lists Ternion with a 2021-01-01 terminal marker and business reasons."
+  },
+  {
+    "id": "hei_src_000562",
+    "exchange_id": "hei_ex_000180",
+    "event_id": "hei_ev_000241",
+    "source_type": "database_reference",
+    "title": "Cryptowisser Ternion exchange profile",
+    "url": "https://www.cryptowisser.com/exchange/ternion/",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/ternion/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "entity",
+    "notes": "Used for exchange-specific profile context when available."
   }
 ]


### PR DESCRIPTION
## Summary
- add Ternion canonical entity/event/evidence records
- capture the 2021 business-reasons terminal marker
- map the dead-side outcome conservatively to voluntary_shutdown

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is voluntary_shutdown
- launch_date remains null in this pass
- death_date uses 2021-01-01 as the terminal marker
- business-reasons closure handling is modeled through a shutdown_announced event plus a shutdown_effective event