### PR TITLE
Add Allbit public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3762,5 +3762,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-19",
     "notes": "Terminal handling uses the 2021-01-01 graveyard marker. Death reason is mapped to voluntary_shutdown from business-reasons style closure handling."
+  },
+  {
+    "id": "hei_ex_000181",
+    "slug": "allbit",
+    "canonical_name": "Allbit",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "voluntary_shutdown",
+    "launch_date": "2018-03-01",
+    "death_date": "2021-03-22",
+    "country_or_origin": "South Korea",
+    "summary": "South Korean cryptocurrency exchange launched in March 2018 that closed all exchange services on 2021-03-22 and was publicly treated as a business-reasons shutdown.",
+    "official_url_original": "https://allbit.com/",
+    "official_domain_original": "allbit.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://allbit.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2021-03-22 dead-side update. Death reason is mapped to voluntary_shutdown because public exchange-status coverage says no specific reason was given and assumes business reasons."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1818,5 +1818,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-01-01 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000242",
+    "exchange_id": "hei_ex_000181",
+    "event_type": "shutdown_announced",
+    "event_date": "2021-03-22",
+    "title": "Allbit closed all exchange services",
+    "description": "Public exchange-status coverage stated that Allbit closed down all exchange services with effect as of 2021-03-22.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Primary public terminal update."
+  },
+  {
+    "id": "hei_ev_000243",
+    "exchange_id": "hei_ex_000181",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-03-22",
+    "title": "Allbit was treated as dead",
+    "description": "Public exchange-status sources treated Allbit as dead on 2021-03-22.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-03-22 as the terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5143,5 +5143,50 @@
     "reliability": "medium",
     "claim_scope": "entity",
     "notes": "Used for exchange-specific profile context when available."
+  },
+  {
+    "id": "hei_src_000563",
+    "exchange_id": "hei_ex_000181",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Allbit site",
+    "url": "https://allbit.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://allbit.com/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000564",
+    "exchange_id": "hei_ex_000181",
+    "event_id": "hei_ev_000243",
+    "source_type": "news_article",
+    "title": "Allbit review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/allbit/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-03-22",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/allbit/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Allbit closed all exchange services on 2021-03-22 and that no specific reason was given."
+  },
+  {
+    "id": "hei_src_000565",
+    "exchange_id": "hei_ex_000181",
+    "event_id": null,
+    "source_type": "database_reference",
+    "title": "Allbit exchange profile with launch and origin details",
+    "url": "https://www.cryptowisser.com/exchange/allbit/",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/allbit/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "entity",
+    "notes": "Supports South Korea origin and March 2018 launch timing."
   }
 ]


### PR DESCRIPTION
## Summary
- add Allbit canonical entity/event/evidence records
- capture the 2021-03-22 terminal shutdown marker
- map the dead-side outcome conservatively to voluntary_shutdown

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is voluntary_shutdown
- launch_date uses 2018-03-01 as a conservative launch marker
- death_date uses 2021-03-22 as the terminal marker
- closure handling is modeled through a shutdown_announced event plus a shutdown_effective event