### PR TITLE
Add Eterbase public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3784,5 +3784,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-19",
     "notes": "Terminal handling uses the 2021-03-22 dead-side update. Death reason is mapped to voluntary_shutdown because public exchange-status coverage says no specific reason was given and assumes business reasons."
+  },
+  {
+    "id": "hei_ex_000182",
+    "slug": "eterbase",
+    "canonical_name": "Eterbase",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "hack",
+    "launch_date": "2019-01-01",
+    "death_date": "2021-04-22",
+    "country_or_origin": "Slovakia",
+    "summary": "Slovakia-based cryptocurrency exchange launched in 2019 that paused operations on 2021-04-22 after a 2020 hack crisis and was subsequently treated as dead.",
+    "official_url_original": "https://www.eterbase.com/",
+    "official_domain_original": "eterbase.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.eterbase.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2021-04-22 paused-operations marker. Death reason is mapped to hack because the shutdown followed the September 2020 hot-wallet compromise, although later bankruptcy context also exists."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1846,5 +1846,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2021-03-22 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000244",
+    "exchange_id": "hei_ex_000182",
+    "event_type": "hack",
+    "event_date": "2020-09-08",
+    "title": "Eterbase suffered a major hot-wallet hack",
+    "description": "Public reporting stated that Eterbase lost more than five million dollars from compromised hot wallets and entered maintenance mode.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Primary crisis event."
+  },
+  {
+    "id": "hei_ev_000245",
+    "exchange_id": "hei_ex_000182",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-04-22",
+    "title": "Eterbase paused operations and was treated as dead",
+    "description": "Public exchange-status coverage stated on 2021-04-22 that Eterbase had paused operations and was moved to dead-side handling.",
+    "confidence": "high",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-04-22 as the terminal marker."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5188,5 +5188,50 @@
     "reliability": "medium",
     "claim_scope": "entity",
     "notes": "Supports South Korea origin and March 2018 launch timing."
+  },
+  {
+    "id": "hei_src_000566",
+    "exchange_id": "hei_ex_000182",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Eterbase site",
+    "url": "https://www.eterbase.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://www.eterbase.com/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000567",
+    "exchange_id": "hei_ex_000182",
+    "event_id": "hei_ev_000245",
+    "source_type": "news_article",
+    "title": "Eterbase review with 2021 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/eterbase/",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-04-22",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/eterbase/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Eterbase paused operations on 2021-04-22, launched in 2019, and was treated as dead."
+  },
+  {
+    "id": "hei_src_000568",
+    "exchange_id": "hei_ex_000182",
+    "event_id": "hei_ev_000244",
+    "source_type": "news_article",
+    "title": "European crypto exchange ETERBASE hacked, lost more than $5 million from its hot wallets",
+    "url": "https://www.theblock.co/linked/77141/european-crypto-exchange-eterbase-hacked-lost-5-million",
+    "publisher": "The Block",
+    "published_at": "2020-09-08",
+    "archived_url": "https://web.archive.org/web/*/https://www.theblock.co/linked/77141/european-crypto-exchange-eterbase-hacked-lost-5-million",
+    "accessed_at": "2026-04-19",
+    "reliability": "high",
+    "claim_scope": "event",
+    "notes": "Used for the September 2020 hack event and scale of loss."
   }
 ]


### PR DESCRIPTION
## Summary
- add Eterbase canonical entity/event/evidence records
- capture the 2021-04-22 terminal marker after the 2020 hack crisis
- classify the dead-side outcome as hack-linked terminal handling

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is hack
- launch_date uses 2019-01-01 as a conservative launch marker
- death_date uses 2021-04-22 as the terminal marker
- the record models the September 2020 hack as the key crisis event and the 2021-04-22 paused-operations update as the terminal dead-side marker