### PR TITLE
Add Coinsuper public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3808,5 +3808,27 @@
     "confidence": "high",
     "last_verified_at": "2026-04-19",
     "notes": "Terminal handling uses the 2021-04-22 paused-operations marker. Death reason is mapped to hack because the shutdown followed the September 2020 hot-wallet compromise, although later bankruptcy context also exists."
+  },
+  {
+    "id": "hei_ex_000183",
+    "slug": "coinsuper",
+    "canonical_name": "Coinsuper",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "voluntary_shutdown",
+    "launch_date": "2017-01-01",
+    "death_date": "2021-12-02",
+    "country_or_origin": "Hong Kong",
+    "summary": "Hong Kong-based cryptocurrency exchange active since 2017 that was publicly marked dead in late 2021 after prolonged financial troubles and business-driven closure handling.",
+    "official_url_original": "https://www.coinsuper.com/",
+    "official_domain_original": "coinsuper.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.coinsuper.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2021-12-02 public dead-side update. Death reason is mapped to voluntary_shutdown from business-reasons closure handling. Cryptowisser's graveyard also places Coinsuper in the 2021 business-reasons cohort."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1888,5 +1888,33 @@
     "source_count": 2,
     "sort_order": 2,
     "notes": "HEI uses 2019-10-15 as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000248",
+    "exchange_id": "hei_ex_000183",
+    "event_type": "shutdown_announced",
+    "event_date": "2021-12-02",
+    "title": "Coinsuper was marked dead after 2021 financial troubles",
+    "description": "Public exchange-status coverage stated that financial troubles persisted through 2021 and later resulted in the firm closing business, after which the platform was marked dead.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 1,
+    "sort_order": 1,
+    "notes": "Primary public terminal update."
+  },
+  {
+    "id": "hei_ev_000249",
+    "exchange_id": "hei_ex_000183",
+    "event_type": "shutdown_effective",
+    "event_date": "2021-12-02",
+    "title": "Coinsuper was treated as dead",
+    "description": "Public exchange-status sources treated Coinsuper as dead in late 2021 under business-reasons handling.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2021-12-02 as the public dead-side marker in this pass."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5248,5 +5248,50 @@
     "reliability": "medium",
     "claim_scope": "status",
     "notes": "Current graveyard page lists CoinExchange.io with a 2019-10-15 terminal marker and business reasons."
+  },
+  {
+    "id": "hei_src_000572",
+    "exchange_id": "hei_ex_000183",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Coinsuper site",
+    "url": "https://www.coinsuper.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://www.coinsuper.com/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000573",
+    "exchange_id": "hei_ex_000183",
+    "event_id": "hei_ev_000249",
+    "source_type": "news_article",
+    "title": "Coinsuper review with inactive and dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/coinsuper",
+    "publisher": "Cryptowisser",
+    "published_at": "2021-12-02",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/coinsuper",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Coinsuper encountered financial troubles during 2021, later closed business, and was marked dead; also supports Hong Kong origin and 2017 activity."
+  },
+  {
+    "id": "hei_src_000574",
+    "exchange_id": "hei_ex_000183",
+    "event_id": null,
+    "source_type": "database_reference",
+    "title": "Cryptowisser Exchange Graveyard entry",
+    "url": "https://www.cryptowisser.com/exchange-graveyard",
+    "publisher": "Cryptowisser",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Current graveyard page places Coinsuper in the 2021 business-reasons dead-side group."
   }
 ]


### PR DESCRIPTION
## Summary
- add Coinsuper canonical entity/event/evidence records
- capture the late-2021 dead-side terminal marker
- map the dead-side outcome conservatively to voluntary_shutdown

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is voluntary_shutdown
- launch_date uses 2017-01-01 as a conservative launch marker
- death_date uses 2021-12-02 as the terminal marker
- closure handling is modeled through a shutdown_announced event plus a shutdown_effective event