### PR TITLE
Add Bitlish public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -3852,5 +3852,27 @@
     "confidence": "medium",
     "last_verified_at": "2026-04-19",
     "notes": "Cryptowisser review preserves a 2020-11-18 closing-down update, while Cryptowisser graveyard places MercuriEx in the 2020-12-31 business-reasons dead-side cohort. Some SurfTheWeb materials say the exchange was developed or operational since late 2017, but HEI retains 2018-01-01 as the conservative public launch marker."
+  },
+  {
+    "id": "hei_ex_000185",
+    "slug": "bitlish",
+    "canonical_name": "Bitlish",
+    "aliases": [],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": "2015-01-01",
+    "death_date": "2020-03-30",
+    "country_or_origin": "United Kingdom",
+    "summary": "United Kingdom-based cryptocurrency exchange launched in 2015 that stopped providing services on 2020-03-30 and was subsequently treated as dead.",
+    "official_url_original": "https://bitlish.com/",
+    "official_domain_original": "bitlish.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://bitlish.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-04-19",
+    "notes": "Terminal handling uses the 2020-03-30 closure update. Public review coverage confirms United Kingdom domicile and 2015 launch, while the preserved closure message cites technical problems and a final withdrawal deadline but does not support a cleaner cause classification than unknown."
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -1944,5 +1944,33 @@
     "source_count": 1,
     "sort_order": 2,
     "notes": "HEI uses the graveyard terminal marker rather than the earlier announcement date."
+  },
+  {
+    "id": "hei_ev_000252",
+    "exchange_id": "hei_ex_000185",
+    "event_type": "shutdown_announced",
+    "event_date": "2020-03-30",
+    "title": "Bitlish published a final closure notice",
+    "description": "Publicly preserved closure text stated that Bitlish would stop providing services to all customers on 2020-03-30 and required users to withdraw remaining assets by the same date.",
+    "confidence": "medium",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "The same closure notice also said that technical problems affected parts of the service."
+  },
+  {
+    "id": "hei_ev_000253",
+    "exchange_id": "hei_ex_000185",
+    "event_type": "shutdown_effective",
+    "event_date": "2020-03-30",
+    "title": "Bitlish stopped providing services and was treated as dead",
+    "description": "Cryptowisser marked Bitlish as dead on 2020-03-30 after the exchange closed down.",
+    "confidence": "medium",
+    "impact_level": "critical",
+    "event_status_effect": "dead",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "HEI uses 2020-03-30 as the terminal marker in this pass."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -5353,5 +5353,50 @@
     "reliability": "medium",
     "claim_scope": "entity",
     "notes": "Press-release style coverage stating SurfTheWeb purchased MercuriEx at the end of 2019 and that the exchange had been operational since 2017."
+  },
+  {
+    "id": "hei_src_000579",
+    "exchange_id": "hei_ex_000185",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Bitlish site",
+    "url": "https://bitlish.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-19",
+    "archived_url": "https://web.archive.org/web/*/https://bitlish.com/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000580",
+    "exchange_id": "hei_ex_000185",
+    "event_id": "hei_ev_000253",
+    "source_type": "news_article",
+    "title": "Bitlish review with 2020 dead-side update",
+    "url": "https://www.cryptowisser.com/exchange/bitlish/",
+    "publisher": "Cryptowisser",
+    "published_at": "2020-03-30",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/bitlish/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Bitlish closed down on 2020-03-30, was moved to the Exchange Graveyard, and describes the exchange as domiciled in the United Kingdom and launched in 2015."
+  },
+  {
+    "id": "hei_src_000581",
+    "exchange_id": "hei_ex_000185",
+    "event_id": "hei_ev_000252",
+    "source_type": "news_article",
+    "title": "WalletScrutiny preserved Bitlish closure message",
+    "url": "https://walletscrutiny.com/android/com.bitlish.bitlish/",
+    "publisher": "WalletScrutiny",
+    "published_at": null,
+    "archived_url": "https://web.archive.org/web/*/https://walletscrutiny.com/android/com.bitlish.bitlish/",
+    "accessed_at": "2026-04-19",
+    "reliability": "medium",
+    "claim_scope": "event",
+    "notes": "Quotes the Bitlish website notice stating service would stop on 2020-03-30, with withdrawals allowed until 23:00 UTC the same day and technical problems affecting fiat functions."
   }
 ]


### PR DESCRIPTION
## Summary
- add Bitlish canonical entity/event/evidence records
- capture the 2020-03-30 terminal marker from the preserved closure notice and dead-side update
- keep the dead-side outcome conservatively classified as unknown

## Scope
- entities: +1
- events: +2
- evidence: +3

## Notes
- death_reason is unknown
- launch_date uses 2015-01-01 as a conservative launch marker
- death_date uses 2020-03-30 as the terminal marker
- the record models the preserved final closure notice as shutdown_announced and the same-day dead-side handling as shutdown_effective