### PR TITLE
Upgrade Gatecoin public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -2644,16 +2644,16 @@
     "launch_date": "2013-01-01",
     "death_date": "2019-03-13",
     "country_or_origin": "Hong Kong",
-    "summary": "Hong Kong centralized exchange that ceased operations in March 2019 after a court-ordered wind-up and liquidation process.",
+    "summary": "Hong Kong-based cryptocurrency exchange founded in 2013 that ceased operations after a court-ordered winding-up and compulsory liquidation process in March 2019.",
     "official_url_original": "https://www.gatecoin.com/",
     "official_domain_original": "gatecoin.com",
-    "official_url_status": "unknown",
+    "official_url_status": "dead_domain",
     "archived_url": "https://web.archive.org/web/*/https://www.gatecoin.com/",
     "predecessor_id": null,
     "successor_id": null,
     "confidence": "high",
-    "last_verified_at": "2026-04-11",
-    "notes": "Operational stop follows the 2019-03-13 winding-up order. Liquidators were appointed on 2019-03-20 and that later date remains documented in evidence."
+    "last_verified_at": "2026-04-24",
+    "notes": "Operational stop follows the 2019-03-13 winding-up order. Liquidators were formally appointed on 2019-03-20. This upgrade preserves the liquidation basis and adds archive/status corroboration while retaining the insolvency classification."
   },
   {
     "id": "hei_ex_000132",

--- a/data/events.json
+++ b/data/events.json
@@ -565,13 +565,13 @@
     "event_type": "shutdown_effective",
     "event_date": "2019-03-13",
     "title": "Gatecoin ordered to wind up and cease operations",
-    "description": "Gatecoin ceased operations after a Hong Kong court granted a winding-up order against the company.",
+    "description": "Gatecoin ceased operations after a Hong Kong court granted a winding-up order against the company, leading to compulsory liquidation.",
     "confidence": "high",
-    "impact_level": "high",
+    "impact_level": "critical",
     "event_status_effect": "dead",
-    "source_count": 2,
-    "sort_order": 1,
-    "notes": "Liquidators were formally appointed on 2019-03-20; the event date here follows the operational stop marker."
+    "source_count": 4,
+    "sort_order": 2,
+    "notes": "Liquidators were formally appointed on 2019-03-20; HEI keeps 2019-03-13 as the operational stop and terminal marker."
   },
   {
     "id": "hei_ev_000154",
@@ -2616,5 +2616,19 @@
     "source_count": 3,
     "sort_order": 2,
     "notes": "HEI uses the 2021-10-11 dead-side update as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000300",
+    "exchange_id": "hei_ex_000131",
+    "event_type": "shutdown_announced",
+    "event_date": "2019-03-13",
+    "title": "Gatecoin announced winding-up and immediate cessation of operations",
+    "description": "Public reporting reproduced Gatecoin's notice that a Hong Kong court had granted a winding-up order and that operations ceased immediately.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 1,
+    "notes": "Some secondary coverage appeared after the 2019-03-13 order date; HEI uses the order and immediate cessation date."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -6733,5 +6733,35 @@
     "reliability": "medium",
     "claim_scope": "url_history",
     "notes": "Used as supporting evidence that the exchange listing and market surface remained associated with the Coinzo identity and domain in Cryptowisser's archive."
+  },
+  {
+    "id": "hei_src_000671",
+    "exchange_id": "hei_ex_000131",
+    "event_id": null,
+    "source_type": "archive_capture",
+    "title": "Archive index for the former Gatecoin site",
+    "url": "https://www.gatecoin.com/",
+    "publisher": "Internet Archive",
+    "published_at": "2026-04-24",
+    "archived_url": "https://web.archive.org/web/*/https://www.gatecoin.com/",
+    "accessed_at": "2026-04-24",
+    "reliability": "medium",
+    "claim_scope": "url_history",
+    "notes": "Archive-first access for historical reference."
+  },
+  {
+    "id": "hei_src_000672",
+    "exchange_id": "hei_ex_000131",
+    "event_id": "hei_ev_000153",
+    "source_type": "news_article",
+    "title": "Gatecoin review with 2019 closed-down update",
+    "url": "https://www.cryptowisser.com/exchange/gatecoin/",
+    "publisher": "Cryptowisser",
+    "published_at": "2019-04-01",
+    "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/gatecoin/",
+    "accessed_at": "2026-04-24",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "States that Gatecoin had closed down operations as of 2019-03-13 and describes the exchange as registered in Hong Kong."
   }
 ]


### PR DESCRIPTION
## Summary
- upgrade existing Gatecoin canonical record hei_ex_000131
- add shutdown_announced event for the winding-up / immediate cessation marker
- add archive and Cryptowisser status evidence
- refresh entity metadata and effective shutdown event wording

## Scope
- entities: update 1
- events: +1, update 1
- evidence: +2

## Notes
- this is an upgrade existing flow, not a new entity
- death_reason remains insolvency
- death_date remains 2019-03-13
- evidence count increases from 2 to 4
- the record now separates announcement handling from shutdown_effective handling