### PR TITLE
Upgrade Cobinhood public-ready canonical record

### DIFF
--- a/data/entities.json
+++ b/data/entities.json
@@ -2274,21 +2274,23 @@
     "id": "hei_ex_000114",
     "slug": "cobinhood",
     "canonical_name": "Cobinhood",
-    "aliases": [],
+    "aliases": [
+      "COBINHOOD"
+    ],
     "type": "cex",
     "status": "dead",
-    "death_reason": "voluntary_shutdown",
+    "death_reason": "unknown",
     "launch_date": "2017-12-18",
     "death_date": "2020-01-10",
     "country_or_origin": "Taiwan",
-    "summary": "Taiwan-based centralized exchange that ceased operations in 2020 after a voluntary shutdown.",
+    "summary": "Taiwan-based cryptocurrency exchange launched in 2017 that entered a shutdown and account-balance audit period beginning on 2020-01-10 amid bankruptcy and exit-scam rumors.",
     "official_url_original": "https://cobinhood.com/",
     "official_domain_original": "cobinhood.com",
     "official_url_status": "dead_domain",
     "archived_url": "https://web.archive.org/web/*/https://cobinhood.com/",
     "confidence": "medium",
-    "notes": "Reuters announced the platform launch in September 2017, but the live platform launch reference used here is 2017-12-18. Shutdown marker uses the 2020-01-10 customer notice.",
-    "last_verified_at": "2026-04-07"
+    "notes": "Reuters announced the platform in September 2017, while the live platform launch reference used here is 2017-12-18. Terminal handling uses the 2020-01-10 shutdown/audit notice. Death reason is kept as unknown because public reporting described a shutdown and balance-audit period, with bankruptcy and exit-scam rumors not treated here as a confirmed terminal cause.",
+    "last_verified_at": "2026-04-24"
   },
   {
     "id": "hei_ex_000115",

--- a/data/events.json
+++ b/data/events.json
@@ -256,28 +256,28 @@
     "exchange_id": "hei_ex_000114",
     "event_type": "launched",
     "event_date": "2017-12-18",
-    "title": "Cobinhood launched",
-    "description": "Cobinhood began operating as a centralized exchange.",
+    "title": "Cobinhood platform went live",
+    "description": "Cobinhood began operating as a centralized cryptocurrency exchange platform.",
     "confidence": "medium",
     "impact_level": "medium",
     "event_status_effect": "active",
     "source_count": 1,
     "sort_order": 1,
-    "notes": ""
+    "notes": "HEI uses the 2017-12-18 live-platform report as the launch marker."
   },
   {
     "id": "hei_ev_000126",
     "exchange_id": "hei_ex_000114",
     "event_type": "shutdown_effective",
     "event_date": "2020-01-10",
-    "title": "Operations wound down",
-    "description": "Cobinhood reached its terminal operating state on the date used by HEI as the end marker.",
+    "title": "Cobinhood was moved to dead-side handling after shutdown notice",
+    "description": "Cobinhood reached its terminal HEI operating state after the 2020-01-10 shutdown and account-balance audit notice.",
     "confidence": "medium",
     "impact_level": "critical",
     "event_status_effect": "dead",
-    "source_count": 1,
-    "sort_order": 2,
-    "notes": "Reuters announced the platform launch in September 2017, but the live platform launch reference used here is 2017-12-18. Shutdown marker uses the 2020-01-10 customer notice."
+    "source_count": 3,
+    "sort_order": 3,
+    "notes": "The notice described an audit period and later reopening for users to retrieve funds; HEI uses the first shutdown notice as the terminal marker while keeping the cause unknown."
   },
   {
     "id": "hei_ev_000127",
@@ -2658,5 +2658,19 @@
     "source_count": 4,
     "sort_order": 2,
     "notes": "HEI uses the closure-notice date as the terminal marker."
+  },
+  {
+    "id": "hei_ev_000303",
+    "exchange_id": "hei_ex_000114",
+    "event_type": "shutdown_announced",
+    "event_date": "2020-01-10",
+    "title": "Cobinhood announced shutdown and account-balance audit",
+    "description": "Cobinhood announced that the exchange would shut down for an account-balance audit from 2020-01-10 to 2020-02-09 and warned users not to deposit assets during that period.",
+    "confidence": "high",
+    "impact_level": "high",
+    "event_status_effect": "limited",
+    "source_count": 2,
+    "sort_order": 2,
+    "notes": "The announcement said the exchange would reopen on 2020-02-10 for users to retrieve funds, but public reporting treated the situation as troubled and ambiguous."
   }
 ]

--- a/data/evidence.json
+++ b/data/evidence.json
@@ -647,17 +647,17 @@
   {
     "id": "hei_src_000164",
     "exchange_id": "hei_ex_000114",
-    "event_id": "hei_ev_000126",
+    "event_id": "hei_ev_000303",
     "source_type": "news_article",
-    "title": "COBINHOOD announces shutdown",
+    "title": "Cobinhood Announces Shutdown, Claims It Will Audit User Accounts",
     "url": "https://www.coindesk.com/markets/2020/01/10/cobinhood-announces-shutdown-claims-it-will-audit-user-accounts",
     "publisher": "CoinDesk",
     "published_at": "2020-01-10",
     "archived_url": "https://web.archive.org/web/*/https://www.coindesk.com/markets/2020/01/10/cobinhood-announces-shutdown-claims-it-will-audit-user-accounts",
     "accessed_at": "2026-04-10",
-    "reliability": "medium",
-    "claim_scope": "death_date",
-    "notes": "Reports the shutdown and balance-audit notice."
+    "reliability": "high",
+    "claim_scope": "event",
+    "notes": "Reports Cobinhood's shutdown notice, the 2020-01-10 to 2020-02-09 account audit window, and the claim that users could retrieve funds after reopening."
   },
   {
     "id": "hei_src_000165",
@@ -6823,5 +6823,35 @@
     "reliability": "medium",
     "claim_scope": "event",
     "notes": "Secondary corroboration of the 2019-07-08 liquidity-loss shutdown notice and cessation of operations."
+  },
+  {
+    "id": "hei_src_000677",
+    "exchange_id": "hei_ex_000114",
+    "event_id": "hei_ev_000303",
+    "source_type": "news_article",
+    "title": "Crypto exchange behind Jamie Foxx endorsed ICO is temporarily shutting down",
+    "url": "https://www.theblock.co/post/52637/crypto-exchange-behind-jamie-foxx-endorsed-ico-is-temporarily-shutting-down",
+    "publisher": "The Block",
+    "published_at": "2020-01-10",
+    "archived_url": "https://web.archive.org/web/*/https://www.theblock.co/post/52637/crypto-exchange-behind-jamie-foxx-endorsed-ico-is-temporarily-shutting-down",
+    "accessed_at": "2026-04-24",
+    "reliability": "high",
+    "claim_scope": "event",
+    "notes": "Reports the shutdown/audit notice, deposit warning, planned 2020-02-10 reopening for fund retrieval, and Cobinhood's 2017 launch context."
+  },
+  {
+    "id": "hei_src_000678",
+    "exchange_id": "hei_ex_000114",
+    "event_id": "hei_ev_000126",
+    "source_type": "news_article",
+    "title": "Cobinhood Shutting Down Months After Bankruptcy Rumors",
+    "url": "https://cryptobriefing.com/cobinhood-shut-down-bankruptcy-rumors/",
+    "publisher": "Crypto Briefing",
+    "published_at": "2020-01-11",
+    "archived_url": "https://web.archive.org/web/*/https://cryptobriefing.com/cobinhood-shut-down-bankruptcy-rumors/",
+    "accessed_at": "2026-04-24",
+    "reliability": "medium",
+    "claim_scope": "status",
+    "notes": "Used as secondary context for bankruptcy-rumor framing and the shutdown announcement; HEI does not treat the rumors as a confirmed death reason."
   }
 ]


### PR DESCRIPTION
## Summary
- upgrade existing Cobinhood canonical record hei_ex_000114
- add shutdown_announced event for the 2020-01-10 shutdown / account-balance audit notice
- add The Block and Crypto Briefing evidence
- refresh entity metadata and shutdown_effective wording

## Scope
- entities: update 1
- events: +1, update 2
- evidence: +2, update 1

## Notes
- this is an upgrade existing flow, not a new entity
- death_reason changes from voluntary_shutdown to unknown
- death_date remains 2020-01-10
- evidence count increases from 3 to 5
- the record now separates shutdown announcement handling from shutdown_effective handling