### PR TITLE
Add HEI monitoring skeleton

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -1,0 +1,71 @@
+name: HEI Monitoring
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  monitoring:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run monitoring
+        run: npm run monitor
+
+      - name: Guard canonical data files
+        run: |
+          if git status --porcelain -- data/entities.json data/events.json data/evidence.json | grep .; then
+            echo "Monitoring must not modify canonical data files."
+            exit 1
+          fi
+
+      - name: Check monitoring changes
+        id: changes
+        run: |
+          if git status --porcelain -- data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution | grep .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create monitoring pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="auto/monitoring/$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution
+          git commit -m "Add HEI auto monitoring report"
+          git push origin "$BRANCH"
+          SUMMARY_FILE="$(find data-staging/monitoring -name summary.md | sort | tail -n 1)"
+          if [ -f "$SUMMARY_FILE" ]; then
+            BODY_FILE="$SUMMARY_FILE"
+          else
+            BODY_FILE="/tmp/hei-monitoring-pr-body.md"
+            echo "HEI auto monitoring report." > "$BODY_FILE"
+          fi
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Auto monitoring report: $(date -u +%Y-%m-%d)" \
+            --body-file "$BODY_FILE"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "monitor": "node scripts/monitoring/run.mjs",
+    "monitor:dry": "HEI_MONITORING_MODE=manual node scripts/monitoring/run.mjs"
   },
   "dependencies": {
     "next": "15.2.4",

--- a/scripts/monitoring/config.mjs
+++ b/scripts/monitoring/config.mjs
@@ -1,0 +1,4 @@
+export const monitoringConfig = {
+  mode: process.env.HEI_MONITORING_MODE || 'scheduled',
+  shouldFailOnCanonicalChange: true,
+};

--- a/scripts/monitoring/core/constants.mjs
+++ b/scripts/monitoring/core/constants.mjs
@@ -1,0 +1,105 @@
+export const CANONICAL_PATHS = [
+  'data/entities.json',
+  'data/events.json',
+  'data/evidence.json',
+];
+
+export const OUTPUT_ROOT = 'data-staging/monitoring';
+export const WATCHLIST_AUTO_ROOT = 'data-staging/watchlists/auto';
+export const WATCHLIST_RESOLUTION_ROOT = 'data-staging/watchlists/resolution';
+
+export const MONITOR_NAMES = [
+  'candidate-discovery',
+  'news-and-event-watch',
+  'active-status-watch',
+  'evidence-and-record-quality-watch',
+  'site-and-seo-watch',
+  'monitoring-health-watch',
+];
+
+export const SEVERITIES = ['critical', 'high', 'medium', 'low'];
+export const CANDIDATE_CLASSES = ['A', 'B', 'C'];
+
+export const TYPE_VALUES = ['cex', 'dex', 'hybrid'];
+export const STATUS_VALUES = [
+  'active',
+  'limited',
+  'inactive',
+  'dead',
+  'merged',
+  'acquired',
+  'rebranded',
+  'unknown',
+];
+export const DEAD_SIDE_STATUSES = ['dead', 'merged', 'acquired', 'rebranded'];
+export const ACTIVE_SIDE_STATUSES = ['active', 'limited', 'inactive'];
+export const DEATH_REASON_VALUES = [
+  'hack',
+  'insolvency',
+  'regulation',
+  'scam_rug',
+  'merger',
+  'acquisition',
+  'rebrand',
+  'voluntary_shutdown',
+  'chain_failure',
+  'unknown',
+];
+export const OFFICIAL_URL_STATUS_VALUES = [
+  'live_verified',
+  'live_unverified',
+  'dead_domain',
+  'redirected',
+  'repurposed',
+  'unsafe',
+  'unknown',
+];
+
+export const EVENT_TYPE_VALUES = [
+  'launched',
+  'rebranded',
+  'acquired',
+  'merged',
+  'hack',
+  'exploit',
+  'withdrawal_suspended',
+  'deposit_suspended',
+  'trading_halted',
+  'service_outage',
+  'regulatory_action',
+  'lawsuit',
+  'bankruptcy_filed',
+  'insolvency_declared',
+  'shutdown_announced',
+  'shutdown_effective',
+  'reopened',
+  'token_migration',
+  'chain_shutdown_impact',
+  'other',
+];
+export const IMPACT_LEVEL_VALUES = ['low', 'medium', 'high', 'critical'];
+export const EVENT_STATUS_EFFECT_VALUES = ['none', 'active', 'limited', 'inactive', 'dead'];
+
+export const SOURCE_TYPE_VALUES = [
+  'official_statement',
+  'official_blog',
+  'official_social',
+  'archive_capture',
+  'news_article',
+  'court_document',
+  'regulatory_notice',
+  'database_reference',
+  'community_reference',
+  'other',
+];
+export const RELIABILITY_VALUES = ['high', 'medium', 'low'];
+export const CLAIM_SCOPE_VALUES = [
+  'entity',
+  'event',
+  'status',
+  'death_reason',
+  'launch_date',
+  'death_date',
+  'url_history',
+  'ownership',
+];

--- a/scripts/monitoring/core/finding-utils.mjs
+++ b/scripts/monitoring/core/finding-utils.mjs
@@ -1,0 +1,105 @@
+import { SEVERITIES } from './constants.mjs';
+
+function safeText(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+export function countBySeverity(findings = []) {
+  const counts = Object.fromEntries(SEVERITIES.map((severity) => [severity, 0]));
+  for (const finding of findings) {
+    if (counts[finding?.severity] !== undefined) {
+      counts[finding.severity] += 1;
+    }
+  }
+  return counts;
+}
+
+export function createFinding({
+  monitor,
+  severity = 'low',
+  category = 'info',
+  title,
+  summary = '',
+  affected_entity = null,
+  recommended_action = 'review',
+  source_urls = [],
+  confidence = 'medium',
+  dedupe_key = null,
+}) {
+  const normalizedSeverity = SEVERITIES.includes(severity) ? severity : 'low';
+  const normalizedCategory = safeText(category, 'info');
+  const normalizedTitle = safeText(title, `${monitor}: ${normalizedCategory}`);
+  const key = dedupe_key || [monitor, normalizedCategory, normalizedTitle]
+    .filter(Boolean)
+    .join(':')
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+
+  return {
+    finding_id: `finding_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    monitor,
+    severity: normalizedSeverity,
+    category: normalizedCategory,
+    title: normalizedTitle,
+    summary: safeText(summary),
+    affected_entity,
+    recommended_action,
+    source_urls: Array.isArray(source_urls) ? source_urls : [],
+    confidence,
+    dedupe_key: key,
+  };
+}
+
+export function createMonitorResult({ monitor, started_at, finished_at, findings = [], candidates = [], errors = [], extra = {} }) {
+  const severityCounts = countBySeverity(findings);
+  return {
+    monitor,
+    status: errors.length > 0 ? 'degraded' : 'ok',
+    started_at,
+    finished_at,
+    findings,
+    candidates,
+    errors,
+    summary: {
+      findings_count: findings.length,
+      candidate_count: candidates.length,
+      errors_count: errors.length,
+      ...severityCounts,
+    },
+    ...extra,
+  };
+}
+
+export async function runMonitorSafely(monitorName, monitorFn, context) {
+  const startedAt = new Date().toISOString();
+  try {
+    return await monitorFn(context, { startedAt });
+  } catch (error) {
+    const finishedAt = new Date().toISOString();
+    return createMonitorResult({
+      monitor: monitorName,
+      started_at: startedAt,
+      finished_at: finishedAt,
+      findings: [
+        createFinding({
+          monitor: monitorName,
+          severity: 'critical',
+          category: 'monitor_failed',
+          title: `${monitorName} failed`,
+          summary: error?.stack || error?.message || String(error),
+          recommended_action: 'fix_monitoring_workflow',
+          confidence: 'high',
+        }),
+      ],
+      errors: [error?.message || String(error)],
+    });
+  }
+}
+
+export function hasMeaningfulFindings(results = []) {
+  return results.some((result) => {
+    const findings = result?.findings || [];
+    const candidates = result?.candidates || [];
+    return candidates.length > 0 || findings.some((finding) => ['critical', 'high'].includes(finding.severity));
+  });
+}

--- a/scripts/monitoring/core/fs-utils.mjs
+++ b/scripts/monitoring/core/fs-utils.mjs
@@ -1,0 +1,72 @@
+import { mkdir, readFile, writeFile, access, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+export async function ensureDir(dirPath) {
+  await mkdir(dirPath, { recursive: true });
+}
+
+export async function pathExists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readJsonFile(filePath, fallback = null) {
+  if (!(await pathExists(filePath))) {
+    return fallback;
+  }
+
+  const raw = await readFile(filePath, 'utf8');
+  if (!raw.trim()) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const wrapped = new Error(`Failed to parse JSON file: ${filePath}: ${error.message}`);
+    wrapped.cause = error;
+    throw wrapped;
+  }
+}
+
+export async function writeJsonFile(filePath, value) {
+  await ensureDir(path.dirname(filePath));
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export async function writeTextFile(filePath, value) {
+  await ensureDir(path.dirname(filePath));
+  await writeFile(filePath, value.endsWith('\n') ? value : `${value}\n`, 'utf8');
+}
+
+export async function listJsonFiles(dirPath) {
+  if (!(await pathExists(dirPath))) {
+    return [];
+  }
+
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listJsonFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
+}
+
+export async function safeStat(filePath) {
+  try {
+    return await stat(filePath);
+  } catch {
+    return null;
+  }
+}

--- a/scripts/monitoring/core/guard-canonical.mjs
+++ b/scripts/monitoring/core/guard-canonical.mjs
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { CANONICAL_PATHS } from './constants.mjs';
+
+const execFileAsync = promisify(execFile);
+
+export async function getModifiedPaths() {
+  const { stdout } = await execFileAsync('git', ['status', '--porcelain']);
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+    .map((line) => line.replace(/^"|"$/g, ''));
+}
+
+export async function checkCanonicalGuard() {
+  const modifiedPaths = await getModifiedPaths();
+  const canonicalModified = modifiedPaths.filter((filePath) => CANONICAL_PATHS.includes(filePath));
+
+  return {
+    canonical_files_modified: canonicalModified.length > 0,
+    modified_paths: canonicalModified,
+  };
+}
+
+export async function assertCanonicalUnchanged() {
+  const result = await checkCanonicalGuard();
+  if (result.canonical_files_modified) {
+    throw new Error(`Monitoring run modified canonical data files: ${result.modified_paths.join(', ')}`);
+  }
+  return result;
+}

--- a/scripts/monitoring/core/load-canonical-data.mjs
+++ b/scripts/monitoring/core/load-canonical-data.mjs
@@ -1,0 +1,44 @@
+import { readJsonFile } from './fs-utils.mjs';
+
+const ENTITIES_PATH = 'data/entities.json';
+const EVENTS_PATH = 'data/events.json';
+const EVIDENCE_PATH = 'data/evidence.json';
+
+function normalizeArray(value, path) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  throw new Error(`${path} must contain a JSON array`);
+}
+
+export async function loadEntities() {
+  return normalizeArray(await readJsonFile(ENTITIES_PATH, []), ENTITIES_PATH);
+}
+
+export async function loadEvents() {
+  return normalizeArray(await readJsonFile(EVENTS_PATH, []), EVENTS_PATH);
+}
+
+export async function loadEvidence() {
+  return normalizeArray(await readJsonFile(EVIDENCE_PATH, []), EVIDENCE_PATH);
+}
+
+export async function loadCanonicalData() {
+  const [entities, events, evidence] = await Promise.all([
+    loadEntities(),
+    loadEvents(),
+    loadEvidence(),
+  ]);
+
+  return {
+    entities,
+    events,
+    evidence,
+    paths: {
+      entities: ENTITIES_PATH,
+      events: EVENTS_PATH,
+      evidence: EVIDENCE_PATH,
+    },
+  };
+}

--- a/scripts/monitoring/core/report-writer.mjs
+++ b/scripts/monitoring/core/report-writer.mjs
@@ -1,0 +1,86 @@
+import path from 'node:path';
+import { OUTPUT_ROOT, MONITOR_NAMES } from './constants.mjs';
+import { ensureDir, writeJsonFile, writeTextFile } from './fs-utils.mjs';
+
+function pad(value) {
+  return String(value).padStart(2, '0');
+}
+
+export function createRunId(date = new Date()) {
+  const yyyy = date.getUTCFullYear();
+  const mm = pad(date.getUTCMonth() + 1);
+  const dd = pad(date.getUTCDate());
+  const hh = pad(date.getUTCHours());
+  const min = pad(date.getUTCMinutes());
+  const ss = pad(date.getUTCSeconds());
+  return `${yyyy}${mm}${dd}-${hh}${min}${ss}`;
+}
+
+export function getRunDate(runId) {
+  return runId.slice(0, 8);
+}
+
+export function getRunDir(runId) {
+  return path.join(OUTPUT_ROOT, getRunDate(runId));
+}
+
+export async function createRunDir(runId) {
+  const runDir = getRunDir(runId);
+  await ensureDir(runDir);
+  return runDir;
+}
+
+export async function writeJsonReport(runDir, name, data) {
+  const filePath = path.join(runDir, `${name}.json`);
+  await writeJsonFile(filePath, data);
+  return filePath;
+}
+
+export async function writeSummary(runDir, markdown) {
+  const filePath = path.join(runDir, 'summary.md');
+  await writeTextFile(filePath, markdown);
+  return filePath;
+}
+
+export function buildManifest({ runId, mode, startedAt, finishedAt, results, canonicalGuard }) {
+  const monitorEntries = MONITOR_NAMES.map((name) => {
+    const result = results.find((item) => item.monitor === name);
+    return {
+      name,
+      status: result?.status || 'not_run',
+      findings_count: result?.summary?.findings_count || 0,
+      candidate_count: result?.summary?.candidate_count || 0,
+      errors_count: result?.summary?.errors_count || 0,
+    };
+  });
+
+  return {
+    run_id: runId,
+    created_at: finishedAt,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    mode,
+    monitors: monitorEntries,
+    canonical_guard: canonicalGuard || {
+      canonical_files_modified: false,
+      modified_paths: [],
+    },
+  };
+}
+
+export async function writeAllReports({ runId, mode, startedAt, finishedAt, results, summaryMarkdown, canonicalGuard }) {
+  const runDir = await createRunDir(runId);
+
+  for (const result of results) {
+    await writeJsonReport(runDir, result.monitor, result);
+  }
+
+  const manifest = buildManifest({ runId, mode, startedAt, finishedAt, results, canonicalGuard });
+  await writeJsonReport(runDir, 'manifest', manifest);
+  await writeSummary(runDir, summaryMarkdown);
+
+  return {
+    runDir,
+    manifest,
+  };
+}

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -1,0 +1,92 @@
+import { SEVERITIES } from './constants.mjs';
+
+function flattenFindings(results) {
+  return results.flatMap((result) => (result.findings || []).map((finding) => ({ ...finding, monitor: finding.monitor || result.monitor })));
+}
+
+function flattenCandidates(results) {
+  return results.flatMap((result) => (result.candidates || []).map((candidate) => ({ ...candidate, monitor: candidate.monitor || result.monitor })));
+}
+
+function sectionList(items, render, emptyText = 'None.') {
+  if (!items.length) {
+    return `- ${emptyText}`;
+  }
+  return items.map(render).join('\n');
+}
+
+export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, results, hasMeaningfulFindings }) {
+  const findings = flattenFindings(results);
+  const candidates = flattenCandidates(results);
+  const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
+  const bCandidates = candidates.filter((candidate) => candidate.candidate_class === 'B');
+  const criticalHigh = findings.filter((finding) => ['critical', 'high'].includes(finding.severity));
+  const dataQuality = findings.filter((finding) => finding.monitor === 'evidence-and-record-quality-watch');
+  const siteSeo = findings.filter((finding) => finding.monitor === 'site-and-seo-watch');
+
+  const severityCounts = Object.fromEntries(SEVERITIES.map((severity) => [severity, 0]));
+  for (const finding of findings) {
+    if (severityCounts[finding.severity] !== undefined) {
+      severityCounts[finding.severity] += 1;
+    }
+  }
+
+  const suggestedActions = [];
+  if (criticalHigh.length) {
+    suggestedActions.push('Review critical/high alerts before accepting new staging work.');
+  }
+  if (aCandidates.length) {
+    suggestedActions.push('Review A candidates and decide whether to promote them to manual staging packages.');
+  }
+  if (bCandidates.length) {
+    suggestedActions.push('Keep B candidates in watchlist or downgrade/resolve them after review.');
+  }
+  if (!suggestedActions.length) {
+    suggestedActions.push('No operator action required.');
+  }
+
+  return `# HEI Auto Monitoring Report - ${runId.slice(0, 8)}
+
+## Run
+
+- run_id: ${runId}
+- mode: ${mode}
+- started_at: ${startedAt}
+- finished_at: ${finishedAt}
+- meaningful_findings: ${hasMeaningfulFindings ? 'yes' : 'no'}
+
+## Counts
+
+- monitors: ${results.length}
+- findings: ${findings.length}
+- candidates: ${candidates.length}
+- critical: ${severityCounts.critical}
+- high: ${severityCounts.high}
+- medium: ${severityCounts.medium}
+- low: ${severityCounts.low}
+
+## A candidates
+
+${sectionList(aCandidates, (candidate) => `- ${candidate.canonical_name || candidate.headline || candidate.candidate_id} — ${candidate.next_action || 'review'}`)}
+
+## B candidates
+
+${sectionList(bCandidates, (candidate) => `- ${candidate.canonical_name || candidate.headline || candidate.candidate_id} — ${candidate.next_action || 'watchlist'}`)}
+
+## Critical / high alerts
+
+${sectionList(criticalHigh, (finding) => `- [${finding.severity}] ${finding.title} (${finding.monitor}) — ${finding.recommended_action || 'review'}`)}
+
+## Data quality
+
+${sectionList(dataQuality, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
+
+## Site / SEO
+
+${sectionList(siteSeo, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
+
+## Suggested operator actions
+
+${suggestedActions.map((action, index) => `${index + 1}. ${action}`).join('\n')}
+`;
+}

--- a/scripts/monitoring/monitors/active-status-watch.mjs
+++ b/scripts/monitoring/monitors/active-status-watch.mjs
@@ -1,0 +1,16 @@
+import { createMonitorResult } from '../core/finding-utils.mjs';
+
+export async function runActiveStatusWatch(context, { startedAt } = {}) {
+  const started_at = startedAt || new Date().toISOString();
+  return createMonitorResult({
+    monitor: 'active-status-watch',
+    started_at,
+    finished_at: new Date().toISOString(),
+    findings: [],
+    candidates: [],
+    errors: [],
+    extra: {
+      note: 'Skeleton monitor. Official site/domain checks and active status-change candidates are implemented in later phases.',
+    },
+  });
+}

--- a/scripts/monitoring/monitors/candidate-discovery.mjs
+++ b/scripts/monitoring/monitors/candidate-discovery.mjs
@@ -1,0 +1,16 @@
+import { createMonitorResult } from '../core/finding-utils.mjs';
+
+export async function runCandidateDiscovery(context, { startedAt } = {}) {
+  const started_at = startedAt || new Date().toISOString();
+  return createMonitorResult({
+    monitor: 'candidate-discovery',
+    started_at,
+    finished_at: new Date().toISOString(),
+    findings: [],
+    candidates: [],
+    errors: [],
+    extra: {
+      note: 'Skeleton monitor. External list diff and candidate discovery are implemented in later phases.',
+    },
+  });
+}

--- a/scripts/monitoring/monitors/evidence-and-record-quality-watch.mjs
+++ b/scripts/monitoring/monitors/evidence-and-record-quality-watch.mjs
@@ -1,0 +1,152 @@
+import {
+  STATUS_VALUES,
+  TYPE_VALUES,
+  DEATH_REASON_VALUES,
+  EVENT_TYPE_VALUES,
+  IMPACT_LEVEL_VALUES,
+  EVENT_STATUS_EFFECT_VALUES,
+  SOURCE_TYPE_VALUES,
+  RELIABILITY_VALUES,
+  CLAIM_SCOPE_VALUES,
+  DEAD_SIDE_STATUSES,
+} from '../core/constants.mjs';
+import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+
+function findDuplicates(items, getValue) {
+  const seen = new Map();
+  const duplicates = [];
+  for (const item of items) {
+    const value = getValue(item);
+    if (!value) continue;
+    if (seen.has(value)) {
+      duplicates.push(value);
+    } else {
+      seen.set(value, item);
+    }
+  }
+  return [...new Set(duplicates)];
+}
+
+function isDateLike(value) {
+  return value === null || value === undefined || /^\d{4}(-\d{2}){0,2}$/.test(String(value));
+}
+
+function isUrlLike(value) {
+  if (value === null || value === undefined || value === '') return true;
+  try {
+    new URL(String(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function addDuplicateFindings(findings, monitor, label, values) {
+  for (const value of values) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'critical',
+      category: `duplicate_${label}`,
+      title: `Duplicate ${label}: ${value}`,
+      summary: `Canonical data contains duplicate ${label} value ${value}.`,
+      recommended_action: 'fix_canonical_data_before_more_batches',
+      confidence: 'high',
+      dedupe_key: `${monitor}:duplicate_${label}:${value}`,
+    }));
+  }
+}
+
+export async function runEvidenceAndRecordQualityWatch(context, { startedAt } = {}) {
+  const monitor = 'evidence-and-record-quality-watch';
+  const started_at = startedAt || new Date().toISOString();
+  const findings = [];
+  const { entities = [], events = [], evidence = [] } = context.canonicalData || {};
+
+  const entityIds = new Set(entities.map((entity) => entity.id));
+  const eventIds = new Set(events.map((event) => event.id));
+
+  addDuplicateFindings(findings, monitor, 'entity_id', findDuplicates(entities, (entity) => entity.id));
+  addDuplicateFindings(findings, monitor, 'entity_slug', findDuplicates(entities, (entity) => entity.slug));
+  addDuplicateFindings(findings, monitor, 'event_id', findDuplicates(events, (event) => event.id));
+  addDuplicateFindings(findings, monitor, 'evidence_id', findDuplicates(evidence, (source) => source.id));
+
+  for (const entity of entities) {
+    if (!TYPE_VALUES.includes(entity.type)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_type', title: `Invalid type on ${entity.id}`, summary: `type=${entity.type}`, recommended_action: 'fix_entity_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_type:${entity.id}` }));
+    }
+    if (!STATUS_VALUES.includes(entity.status)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_status', title: `Invalid status on ${entity.id}`, summary: `status=${entity.status}`, recommended_action: 'fix_entity_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_status:${entity.id}` }));
+    }
+    if (DEAD_SIDE_STATUSES.includes(entity.status) && !entity.death_reason) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'dead_side_missing_death_reason', title: `Dead-side entity missing death_reason: ${entity.canonical_name}`, summary: entity.id, recommended_action: 'review_death_reason', confidence: 'high', dedupe_key: `${monitor}:missing_death_reason:${entity.id}` }));
+    }
+    if (entity.death_reason && !DEATH_REASON_VALUES.includes(entity.death_reason)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_death_reason', title: `Invalid death_reason on ${entity.id}`, summary: `death_reason=${entity.death_reason}`, recommended_action: 'fix_entity_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_death_reason:${entity.id}` }));
+    }
+    if (!isDateLike(entity.launch_date) || !isDateLike(entity.death_date) || !isDateLike(entity.last_verified_at)) {
+      findings.push(createFinding({ monitor, severity: 'medium', category: 'bad_entity_date_format', title: `Bad date format on ${entity.id}`, summary: 'Expected YYYY, YYYY-MM, YYYY-MM-DD, null, or empty.', recommended_action: 'fix_date_format', confidence: 'medium', dedupe_key: `${monitor}:bad_date:${entity.id}` }));
+    }
+    for (const key of ['official_url_original', 'archived_url']) {
+      if (!isUrlLike(entity[key])) {
+        findings.push(createFinding({ monitor, severity: 'medium', category: 'bad_entity_url_format', title: `Bad URL format on ${entity.id}`, summary: `${key}=${entity[key]}`, recommended_action: 'fix_url_format', confidence: 'medium', dedupe_key: `${monitor}:bad_url:${entity.id}:${key}` }));
+      }
+    }
+  }
+
+  for (const event of events) {
+    if (!entityIds.has(event.exchange_id)) {
+      findings.push(createFinding({ monitor, severity: 'critical', category: 'event_missing_entity_reference', title: `Event references missing entity: ${event.id}`, summary: `exchange_id=${event.exchange_id}`, recommended_action: 'fix_canonical_data_before_more_batches', confidence: 'high', dedupe_key: `${monitor}:event_missing_entity:${event.id}` }));
+    }
+    if (!EVENT_TYPE_VALUES.includes(event.event_type)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_event_type', title: `Invalid event_type on ${event.id}`, summary: `event_type=${event.event_type}`, recommended_action: 'fix_event_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_event_type:${event.id}` }));
+    }
+    if (event.impact_level && !IMPACT_LEVEL_VALUES.includes(event.impact_level)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_impact_level', title: `Invalid impact_level on ${event.id}`, summary: `impact_level=${event.impact_level}`, recommended_action: 'fix_event_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_impact:${event.id}` }));
+    }
+    if (event.event_status_effect && !EVENT_STATUS_EFFECT_VALUES.includes(event.event_status_effect)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_event_status_effect', title: `Invalid event_status_effect on ${event.id}`, summary: `event_status_effect=${event.event_status_effect}`, recommended_action: 'fix_event_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_event_status_effect:${event.id}` }));
+    }
+    if (!isDateLike(event.event_date) || !isDateLike(event.start_date) || !isDateLike(event.end_date)) {
+      findings.push(createFinding({ monitor, severity: 'medium', category: 'bad_event_date_format', title: `Bad date format on ${event.id}`, summary: 'Expected YYYY, YYYY-MM, YYYY-MM-DD, null, or empty.', recommended_action: 'fix_date_format', confidence: 'medium', dedupe_key: `${monitor}:bad_event_date:${event.id}` }));
+    }
+  }
+
+  const evidenceByEntity = new Map();
+  for (const source of evidence) {
+    if (!entityIds.has(source.exchange_id)) {
+      findings.push(createFinding({ monitor, severity: 'critical', category: 'evidence_missing_entity_reference', title: `Evidence references missing entity: ${source.id}`, summary: `exchange_id=${source.exchange_id}`, recommended_action: 'fix_canonical_data_before_more_batches', confidence: 'high', dedupe_key: `${monitor}:evidence_missing_entity:${source.id}` }));
+    }
+    if (source.event_id && !eventIds.has(source.event_id)) {
+      findings.push(createFinding({ monitor, severity: 'critical', category: 'evidence_missing_event_reference', title: `Evidence references missing event: ${source.id}`, summary: `event_id=${source.event_id}`, recommended_action: 'fix_canonical_data_before_more_batches', confidence: 'high', dedupe_key: `${monitor}:evidence_missing_event:${source.id}` }));
+    }
+    if (source.source_type && !SOURCE_TYPE_VALUES.includes(source.source_type)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_source_type', title: `Invalid source_type on ${source.id}`, summary: `source_type=${source.source_type}`, recommended_action: 'fix_evidence_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_source_type:${source.id}` }));
+    }
+    if (source.reliability && !RELIABILITY_VALUES.includes(source.reliability)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_reliability', title: `Invalid reliability on ${source.id}`, summary: `reliability=${source.reliability}`, recommended_action: 'fix_evidence_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_reliability:${source.id}` }));
+    }
+    if (source.claim_scope && !CLAIM_SCOPE_VALUES.includes(source.claim_scope)) {
+      findings.push(createFinding({ monitor, severity: 'high', category: 'invalid_claim_scope', title: `Invalid claim_scope on ${source.id}`, summary: `claim_scope=${source.claim_scope}`, recommended_action: 'fix_evidence_enum', confidence: 'high', dedupe_key: `${monitor}:invalid_claim_scope:${source.id}` }));
+    }
+    if (!isUrlLike(source.url) || !isUrlLike(source.archived_url)) {
+      findings.push(createFinding({ monitor, severity: 'medium', category: 'bad_evidence_url_format', title: `Bad URL format on ${source.id}`, summary: 'Evidence url or archived_url is not URL-like.', recommended_action: 'fix_url_format', confidence: 'medium', dedupe_key: `${monitor}:bad_evidence_url:${source.id}` }));
+    }
+    evidenceByEntity.set(source.exchange_id, (evidenceByEntity.get(source.exchange_id) || 0) + 1);
+  }
+
+  for (const entity of entities) {
+    const count = evidenceByEntity.get(entity.id) || 0;
+    if (DEAD_SIDE_STATUSES.includes(entity.status) && count < 2) {
+      findings.push(createFinding({ monitor, severity: 'medium', category: 'dead_side_thin_evidence', title: `Dead-side entity has fewer than 2 evidence records: ${entity.canonical_name}`, summary: `${entity.id} has ${count} evidence records.`, recommended_action: 'add_second_source_or_archive', confidence: 'medium', dedupe_key: `${monitor}:thin_evidence:${entity.id}` }));
+    }
+  }
+
+  return createMonitorResult({
+    monitor,
+    started_at,
+    finished_at: new Date().toISOString(),
+    findings,
+    candidates: [],
+    errors: [],
+  });
+}

--- a/scripts/monitoring/monitors/monitoring-health-watch.mjs
+++ b/scripts/monitoring/monitors/monitoring-health-watch.mjs
@@ -1,0 +1,66 @@
+import { MONITOR_NAMES } from '../core/constants.mjs';
+import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+
+export async function runMonitoringHealthWatch(context, { startedAt } = {}) {
+  const started_at = startedAt || new Date().toISOString();
+  const findings = [];
+
+  const canonical = context?.canonicalData;
+  if (!canonical) {
+    findings.push(createFinding({
+      monitor: 'monitoring-health-watch',
+      severity: 'critical',
+      category: 'canonical_load_missing',
+      title: 'Canonical data was not loaded',
+      summary: 'The monitoring runner did not provide canonical data to the health monitor.',
+      recommended_action: 'fix_monitoring_workflow',
+      confidence: 'high',
+    }));
+  } else {
+    const counts = {
+      entities: canonical.entities?.length || 0,
+      events: canonical.events?.length || 0,
+      evidence: canonical.evidence?.length || 0,
+    };
+
+    if (counts.entities === 0 || counts.events === 0 || counts.evidence === 0) {
+      findings.push(createFinding({
+        monitor: 'monitoring-health-watch',
+        severity: 'high',
+        category: 'canonical_data_empty_or_missing',
+        title: 'Canonical data appears empty or incomplete',
+        summary: `entities=${counts.entities}, events=${counts.events}, evidence=${counts.evidence}`,
+        recommended_action: 'inspect_canonical_data_paths',
+        confidence: 'high',
+      }));
+    }
+  }
+
+  const expectedReports = MONITOR_NAMES.length;
+  if (expectedReports < 6) {
+    findings.push(createFinding({
+      monitor: 'monitoring-health-watch',
+      severity: 'medium',
+      category: 'monitor_registry_incomplete',
+      title: 'Monitor registry has fewer monitors than expected',
+      summary: `Registered monitors: ${expectedReports}`,
+      recommended_action: 'inspect_monitoring_constants',
+      confidence: 'medium',
+    }));
+  }
+
+  return createMonitorResult({
+    monitor: 'monitoring-health-watch',
+    started_at,
+    finished_at: new Date().toISOString(),
+    findings,
+    candidates: [],
+    errors: [],
+    extra: {
+      checked: {
+        canonical_data_loaded: Boolean(canonical),
+        registered_monitors: MONITOR_NAMES,
+      },
+    },
+  });
+}

--- a/scripts/monitoring/monitors/news-and-event-watch.mjs
+++ b/scripts/monitoring/monitors/news-and-event-watch.mjs
@@ -1,0 +1,16 @@
+import { createMonitorResult } from '../core/finding-utils.mjs';
+
+export async function runNewsAndEventWatch(context, { startedAt } = {}) {
+  const started_at = startedAt || new Date().toISOString();
+  return createMonitorResult({
+    monitor: 'news-and-event-watch',
+    started_at,
+    finished_at: new Date().toISOString(),
+    findings: [],
+    candidates: [],
+    errors: [],
+    extra: {
+      note: 'Skeleton monitor. News/RSS, regulatory, incident, suspension, and continuity detection are implemented in later phases.',
+    },
+  });
+}

--- a/scripts/monitoring/monitors/site-and-seo-watch.mjs
+++ b/scripts/monitoring/monitors/site-and-seo-watch.mjs
@@ -1,0 +1,16 @@
+import { createMonitorResult } from '../core/finding-utils.mjs';
+
+export async function runSiteAndSeoWatch(context, { startedAt } = {}) {
+  const started_at = startedAt || new Date().toISOString();
+  return createMonitorResult({
+    monitor: 'site-and-seo-watch',
+    started_at,
+    finished_at: new Date().toISOString(),
+    findings: [],
+    candidates: [],
+    errors: [],
+    extra: {
+      note: 'Skeleton monitor. Site route, sitemap, robots, and metadata checks are implemented in later phases.',
+    },
+  });
+}

--- a/scripts/monitoring/run.mjs
+++ b/scripts/monitoring/run.mjs
@@ -1,0 +1,73 @@
+import { monitoringConfig } from './config.mjs';
+import { loadCanonicalData } from './core/load-canonical-data.mjs';
+import { assertCanonicalUnchanged, checkCanonicalGuard } from './core/guard-canonical.mjs';
+import { createRunId, writeAllReports } from './core/report-writer.mjs';
+import { buildSummaryMarkdown } from './core/summary-writer.mjs';
+import { hasMeaningfulFindings, runMonitorSafely } from './core/finding-utils.mjs';
+import { runCandidateDiscovery } from './monitors/candidate-discovery.mjs';
+import { runNewsAndEventWatch } from './monitors/news-and-event-watch.mjs';
+import { runActiveStatusWatch } from './monitors/active-status-watch.mjs';
+import { runEvidenceAndRecordQualityWatch } from './monitors/evidence-and-record-quality-watch.mjs';
+import { runSiteAndSeoWatch } from './monitors/site-and-seo-watch.mjs';
+import { runMonitoringHealthWatch } from './monitors/monitoring-health-watch.mjs';
+
+const monitorFns = [
+  ['candidate-discovery', runCandidateDiscovery],
+  ['news-and-event-watch', runNewsAndEventWatch],
+  ['active-status-watch', runActiveStatusWatch],
+  ['evidence-and-record-quality-watch', runEvidenceAndRecordQualityWatch],
+  ['site-and-seo-watch', runSiteAndSeoWatch],
+  ['monitoring-health-watch', runMonitoringHealthWatch],
+];
+
+async function main() {
+  const runId = process.env.HEI_MONITORING_RUN_ID || createRunId();
+  const startedAt = new Date().toISOString();
+  const canonicalData = await loadCanonicalData();
+  const context = {
+    runId,
+    mode: monitoringConfig.mode,
+    canonicalData,
+  };
+
+  const results = [];
+  for (const [name, fn] of monitorFns) {
+    results.push(await runMonitorSafely(name, fn, context));
+  }
+
+  const meaningfulFindings = hasMeaningfulFindings(results);
+  const finishedAt = new Date().toISOString();
+  const preWriteGuard = await checkCanonicalGuard();
+
+  const summaryMarkdown = buildSummaryMarkdown({
+    runId,
+    mode: monitoringConfig.mode,
+    startedAt,
+    finishedAt,
+    results,
+    hasMeaningfulFindings: meaningfulFindings,
+  });
+
+  const { runDir } = await writeAllReports({
+    runId,
+    mode: monitoringConfig.mode,
+    startedAt,
+    finishedAt,
+    results,
+    summaryMarkdown,
+    canonicalGuard: preWriteGuard,
+  });
+
+  if (monitoringConfig.shouldFailOnCanonicalChange) {
+    await assertCanonicalUnchanged();
+  }
+
+  console.log(`HEI monitoring run complete: ${runId}`);
+  console.log(`Reports written to: ${runDir}`);
+  console.log(`Meaningful findings: ${meaningfulFindings ? 'yes' : 'no'}`);
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Phase 1 HEI monitoring skeleton based on the uploaded monitoring specification and implementation plan
- add `npm run monitor` / `npm run monitor:dry`
- add six monitor-group entry points with placeholders for later phases
- implement canonical data loading, report writing, summary writing, monitor result helpers, and canonical-change guard
- implement first data-quality checks in `evidence-and-record-quality-watch`
- add scheduled/manual GitHub Actions workflow that writes monitoring reports and opens report-only PRs

## Scope
- does not modify canonical data
- monitoring outputs are limited to `data-staging/monitoring/**` and watchlist staging paths
- external discovery/news/domain/site checks are intentionally placeholders for later PRs

## Safety
- `data/entities.json`, `data/events.json`, and `data/evidence.json` are guarded from monitoring modifications
- workflow fails if canonical data files are changed by a monitoring run

## Notes
- this is the safe skeleton / Phase 1 implementation, not the full 18-item monitor completion in one PR
- later PRs should add candidate discovery, news/event watch, URL/evidence health checks, active status checks, regulatory sources, site/SEO checks, and noise control