### PR TITLE
Add HEI monitoring watchlist state checks

### DIFF
--- a/scripts/monitoring/core/load-watchlists.mjs
+++ b/scripts/monitoring/core/load-watchlists.mjs
@@ -1,0 +1,156 @@
+import { readFile } from 'node:fs/promises';
+import { listJsonFiles, pathExists } from './fs-utils.mjs';
+import { WATCHLIST_AUTO_ROOT, WATCHLIST_RESOLUTION_ROOT } from './constants.mjs';
+
+const WATCHLIST_ROOT = 'data-staging/watchlists';
+const MANUAL_STAGING_ROOT = 'data-staging/manual';
+
+async function readJsonLoose(filePath) {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    return {
+      path: filePath,
+      json: JSON.parse(raw),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      path: filePath,
+      json: null,
+      error: error?.message || String(error),
+    };
+  }
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function getCandidatesFromWatchlist(json) {
+  if (!json || typeof json !== 'object') return [];
+
+  const candidates = [
+    ...asArray(json.candidates),
+    ...asArray(json.records?.candidates),
+    ...asArray(json.items),
+  ];
+
+  for (const key of ['A', 'B', 'C', 'promoted_to_canonical', 'still_watch', 'hold_or_out_of_scope']) {
+    if (Array.isArray(json[key])) {
+      candidates.push(...json[key].map((item) => (typeof item === 'string' ? { canonical_name: item, bucket: key } : { ...item, bucket: key })));
+    }
+  }
+
+  return candidates;
+}
+
+function getCandidateName(candidate) {
+  if (typeof candidate === 'string') return candidate;
+  return candidate?.canonical_name || candidate?.name || candidate?.exchange || candidate?.title || candidate?.slug || null;
+}
+
+function getCandidateClass(candidate) {
+  if (typeof candidate === 'string') return null;
+  return candidate?.candidate_class || candidate?.class || candidate?.bucket || null;
+}
+
+function getCandidateCreatedAt(candidate, fallback = null) {
+  if (typeof candidate === 'string') return fallback;
+  return candidate?.created_at || candidate?.discovered_at || candidate?.first_seen_at || fallback;
+}
+
+function normalizeName(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+export async function loadWatchlists() {
+  if (!(await pathExists(WATCHLIST_ROOT))) {
+    return { files: [], candidates: [], parseErrors: [] };
+  }
+
+  const files = await listJsonFiles(WATCHLIST_ROOT);
+  const entries = await Promise.all(files.map(readJsonLoose));
+  const parseErrors = entries.filter((entry) => entry.error);
+  const candidates = [];
+
+  for (const entry of entries.filter((item) => !item.error)) {
+    const json = entry.json;
+    const fallbackCreatedAt = json?.created_at || json?.generated_at || null;
+    for (const candidate of getCandidatesFromWatchlist(json)) {
+      const name = getCandidateName(candidate);
+      if (!name) continue;
+      candidates.push({
+        name,
+        normalized_name: normalizeName(name),
+        candidate_class: getCandidateClass(candidate),
+        created_at: getCandidateCreatedAt(candidate, fallbackCreatedAt),
+        source_file: entry.path,
+        raw: candidate,
+      });
+    }
+  }
+
+  return { files: entries, candidates, parseErrors };
+}
+
+export async function loadManualStagingPackages() {
+  if (!(await pathExists(MANUAL_STAGING_ROOT))) {
+    return { files: [], packages: [], parseErrors: [] };
+  }
+
+  const files = await listJsonFiles(MANUAL_STAGING_ROOT);
+  const entries = await Promise.all(files.map(readJsonLoose));
+  const parseErrors = entries.filter((entry) => entry.error);
+  const packages = [];
+
+  for (const entry of entries.filter((item) => !item.error)) {
+    const entities = asArray(entry.json?.records?.entities);
+    if (!entities.length) continue;
+    packages.push({
+      path: entry.path,
+      created_at: entry.json?.created_at || null,
+      package_type: entry.json?.package_type || null,
+      entities: entities.map((entity) => ({
+        id: entity.id || null,
+        slug: entity.slug || null,
+        canonical_name: entity.canonical_name || entity.name || null,
+        normalized_name: normalizeName(entity.canonical_name || entity.name || entity.slug || ''),
+      })),
+    });
+  }
+
+  return { files: entries, packages, parseErrors };
+}
+
+export async function loadResolutionFiles() {
+  if (!(await pathExists(WATCHLIST_RESOLUTION_ROOT))) {
+    return { files: [], resolvedNames: new Set(), parseErrors: [] };
+  }
+
+  const files = await listJsonFiles(WATCHLIST_RESOLUTION_ROOT);
+  const entries = await Promise.all(files.map(readJsonLoose));
+  const parseErrors = entries.filter((entry) => entry.error);
+  const resolvedNames = new Set();
+
+  for (const entry of entries.filter((item) => !item.error)) {
+    const json = entry.json;
+    const buckets = [
+      ...asArray(json.promoted_to_canonical),
+      ...asArray(json.hold_or_out_of_scope),
+      ...asArray(json.out_of_scope),
+      ...asArray(json.resolved),
+    ];
+    for (const item of buckets) {
+      const name = getCandidateName(item);
+      if (name) resolvedNames.add(normalizeName(name));
+    }
+  }
+
+  return { files: entries, resolvedNames, parseErrors };
+}
+
+export { WATCHLIST_AUTO_ROOT, WATCHLIST_RESOLUTION_ROOT, normalizeName };

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -15,6 +15,10 @@ function sectionList(items, render, emptyText = 'None.') {
   return items.map(render).join('\n');
 }
 
+function findResult(results, monitor) {
+  return results.find((result) => result.monitor === monitor) || null;
+}
+
 export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, results, hasMeaningfulFindings }) {
   const findings = flattenFindings(results);
   const candidates = flattenCandidates(results);
@@ -23,6 +27,9 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   const criticalHigh = findings.filter((finding) => ['critical', 'high'].includes(finding.severity));
   const dataQuality = findings.filter((finding) => finding.monitor === 'evidence-and-record-quality-watch');
   const siteSeo = findings.filter((finding) => finding.monitor === 'site-and-seo-watch');
+  const watchlistFindings = findings.filter((finding) => finding.monitor === 'monitoring-health-watch' && finding.category?.includes('watchlist'));
+  const monitoringHealth = findResult(results, 'monitoring-health-watch');
+  const watchlistState = monitoringHealth?.watchlist_state || null;
 
   const severityCounts = Object.fromEntries(SEVERITIES.map((severity) => [severity, 0]));
   for (const finding of findings) {
@@ -40,6 +47,9 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   }
   if (bCandidates.length) {
     suggestedActions.push('Keep B candidates in watchlist or downgrade/resolve them after review.');
+  }
+  if (watchlistFindings.length) {
+    suggestedActions.push('Review watchlist-state findings and update staging or resolution files as needed.');
   }
   if (!suggestedActions.length) {
     suggestedActions.push('No operator action required.');
@@ -80,6 +90,12 @@ ${sectionList(criticalHigh, (finding) => `- [${finding.severity}] ${finding.titl
 ## Data quality
 
 ${sectionList(dataQuality, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
+
+## Watchlist state
+
+${watchlistState ? `- watchlist_files: ${watchlistState.watchlist_files}\n- watchlist_candidates: ${watchlistState.watchlist_candidates}\n- class_A: ${watchlistState.watchlist_class_counts?.A || 0}\n- class_B: ${watchlistState.watchlist_class_counts?.B || 0}\n- class_C: ${watchlistState.watchlist_class_counts?.C || 0}\n- manual_staging_packages: ${watchlistState.manual_staging_packages}\n- resolution_files: ${watchlistState.resolution_files}` : '- Not available.'}
+
+${sectionList(watchlistFindings, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
 
 ## Site / SEO
 

--- a/scripts/monitoring/monitors/monitoring-health-watch.mjs
+++ b/scripts/monitoring/monitors/monitoring-health-watch.mjs
@@ -1,14 +1,141 @@
 import { MONITOR_NAMES } from '../core/constants.mjs';
 import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+import { loadWatchlists, loadManualStagingPackages, loadResolutionFiles, normalizeName } from '../core/load-watchlists.mjs';
+
+function daysSince(dateValue) {
+  if (!dateValue) return null;
+  const time = Date.parse(dateValue);
+  if (!Number.isFinite(time)) return null;
+  return Math.floor((Date.now() - time) / 86400000);
+}
+
+function canonicalNameSet(canonical) {
+  const names = new Set();
+  for (const entity of canonical?.entities || []) {
+    for (const value of [entity.canonical_name, entity.slug, ...(entity.aliases || [])]) {
+      if (value) names.add(normalizeName(value));
+    }
+  }
+  return names;
+}
+
+function addWatchlistFindings({ findings, monitor, watchlists, stagingPackages, resolutions, canonicalNames }) {
+  for (const entry of watchlists.parseErrors) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'watchlist_json_parse_error',
+      title: `Watchlist JSON parse error: ${entry.path}`,
+      summary: entry.error,
+      recommended_action: 'fix_watchlist_json',
+      confidence: 'high',
+      dedupe_key: `${monitor}:watchlist_parse:${entry.path}`,
+    }));
+  }
+
+  for (const entry of stagingPackages.parseErrors) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'staging_json_parse_error',
+      title: `Manual staging JSON parse error: ${entry.path}`,
+      summary: entry.error,
+      recommended_action: 'fix_staging_json',
+      confidence: 'high',
+      dedupe_key: `${monitor}:staging_parse:${entry.path}`,
+    }));
+  }
+
+  const stagedNames = new Set();
+  for (const pkg of stagingPackages.packages) {
+    for (const entity of pkg.entities) {
+      if (entity.normalized_name) stagedNames.add(entity.normalized_name);
+      if (entity.slug) stagedNames.add(normalizeName(entity.slug));
+    }
+  }
+
+  const countByClass = { A: 0, B: 0, C: 0, unknown: 0 };
+  for (const candidate of watchlists.candidates) {
+    const cls = ['A', 'B', 'C'].includes(candidate.candidate_class) ? candidate.candidate_class : 'unknown';
+    countByClass[cls] += 1;
+
+    const ageDays = daysSince(candidate.created_at);
+    const isCanonical = canonicalNames.has(candidate.normalized_name);
+    const isStaged = stagedNames.has(candidate.normalized_name);
+    const isResolved = resolutions.resolvedNames.has(candidate.normalized_name);
+
+    if (cls === 'A' && !isStaged && !isCanonical && !isResolved) {
+      const severity = ageDays !== null && ageDays >= 60 ? 'high' : 'medium';
+      findings.push(createFinding({
+        monitor,
+        severity,
+        category: 'watchlist_a_candidate_pending',
+        title: `A candidate still pending: ${candidate.name}`,
+        summary: `${candidate.name} is still in watchlist and has not been staged, canonicalized, or resolved.${ageDays === null ? '' : ` age_days=${ageDays}`}`,
+        recommended_action: 'stage_downgrade_or_resolve_candidate',
+        confidence: 'medium',
+        dedupe_key: `${monitor}:a_pending:${candidate.normalized_name}`,
+      }));
+    }
+
+    if (cls === 'B' && ageDays !== null && ageDays >= 90 && !isResolved && !isCanonical) {
+      findings.push(createFinding({
+        monitor,
+        severity: 'low',
+        category: 'watchlist_b_candidate_stale',
+        title: `B candidate may be stale: ${candidate.name}`,
+        summary: `${candidate.name} has remained in watchlist for ${ageDays} days.`,
+        recommended_action: 'review_keep_downgrade_or_resolve_candidate',
+        confidence: 'low',
+        dedupe_key: `${monitor}:b_stale:${candidate.normalized_name}`,
+      }));
+    }
+
+    if (isCanonical && !isResolved) {
+      findings.push(createFinding({
+        monitor,
+        severity: 'low',
+        category: 'canonicalized_watchlist_candidate_unresolved',
+        title: `Watchlist candidate appears canonicalized but unresolved: ${candidate.name}`,
+        summary: `${candidate.name} appears in canonical entities but is not recorded in resolution files.`,
+        recommended_action: 'add_resolution_promoted_to_canonical',
+        confidence: 'medium',
+        dedupe_key: `${monitor}:canonical_unresolved:${candidate.normalized_name}`,
+      }));
+    }
+  }
+
+  for (const pkg of stagingPackages.packages) {
+    for (const entity of pkg.entities) {
+      if (!entity.normalized_name) continue;
+      const inCanonical = canonicalNames.has(entity.normalized_name) || (entity.slug && canonicalNames.has(normalizeName(entity.slug)));
+      if (!inCanonical) {
+        findings.push(createFinding({
+          monitor,
+          severity: 'medium',
+          category: 'staging_package_not_canonicalized',
+          title: `Staging package entity not canonicalized: ${entity.canonical_name || entity.slug}`,
+          summary: `${pkg.path} contains ${entity.canonical_name || entity.slug}, but no canonical match was found.`,
+          recommended_action: 'canonicalize_or_resolve_staging_package',
+          confidence: 'medium',
+          dedupe_key: `${monitor}:staging_not_canonical:${entity.normalized_name}:${pkg.path}`,
+        }));
+      }
+    }
+  }
+
+  return countByClass;
+}
 
 export async function runMonitoringHealthWatch(context, { startedAt } = {}) {
+  const monitor = 'monitoring-health-watch';
   const started_at = startedAt || new Date().toISOString();
   const findings = [];
 
   const canonical = context?.canonicalData;
   if (!canonical) {
     findings.push(createFinding({
-      monitor: 'monitoring-health-watch',
+      monitor,
       severity: 'critical',
       category: 'canonical_load_missing',
       title: 'Canonical data was not loaded',
@@ -25,7 +152,7 @@ export async function runMonitoringHealthWatch(context, { startedAt } = {}) {
 
     if (counts.entities === 0 || counts.events === 0 || counts.evidence === 0) {
       findings.push(createFinding({
-        monitor: 'monitoring-health-watch',
+        monitor,
         severity: 'high',
         category: 'canonical_data_empty_or_missing',
         title: 'Canonical data appears empty or incomplete',
@@ -39,7 +166,7 @@ export async function runMonitoringHealthWatch(context, { startedAt } = {}) {
   const expectedReports = MONITOR_NAMES.length;
   if (expectedReports < 6) {
     findings.push(createFinding({
-      monitor: 'monitoring-health-watch',
+      monitor,
       severity: 'medium',
       category: 'monitor_registry_incomplete',
       title: 'Monitor registry has fewer monitors than expected',
@@ -49,8 +176,23 @@ export async function runMonitoringHealthWatch(context, { startedAt } = {}) {
     }));
   }
 
+  const [watchlists, stagingPackages, resolutions] = await Promise.all([
+    loadWatchlists(),
+    loadManualStagingPackages(),
+    loadResolutionFiles(),
+  ]);
+  const canonicalNames = canonicalNameSet(canonical);
+  const watchlistClassCounts = addWatchlistFindings({
+    findings,
+    monitor,
+    watchlists,
+    stagingPackages,
+    resolutions,
+    canonicalNames,
+  });
+
   return createMonitorResult({
-    monitor: 'monitoring-health-watch',
+    monitor,
     started_at,
     finished_at: new Date().toISOString(),
     findings,
@@ -60,6 +202,14 @@ export async function runMonitoringHealthWatch(context, { startedAt } = {}) {
       checked: {
         canonical_data_loaded: Boolean(canonical),
         registered_monitors: MONITOR_NAMES,
+      },
+      watchlist_state: {
+        watchlist_files: watchlists.files.length,
+        watchlist_candidates: watchlists.candidates.length,
+        watchlist_class_counts: watchlistClassCounts,
+        manual_staging_packages: stagingPackages.packages.length,
+        resolution_files: resolutions.files.length,
+        resolved_names: resolutions.resolvedNames.size,
       },
     },
   });


### PR DESCRIPTION
## Summary
- add `load-watchlists.mjs` for reading watchlists, manual staging packages, and resolution files
- add watchlist-state findings inside `monitoring-health-watch`
- detect parse errors, pending A candidates, stale B candidates, staging packages not yet canonicalized, and canonicalized watchlist candidates without resolution entries
- surface watchlist counts and findings in `summary.md`

## Scope
- no canonical data changes
- no external network checks
- no candidate discovery implementation yet
- no evidence URL HTTP checking yet

## Safety
- this PR only changes monitoring scripts
- canonical data remains protected by the existing monitoring guard

## Notes
- this corresponds to the next implementation step after PR #90: watchlist state + summary polish
- repeated low/medium watchlist findings may still need later noise-control/state-store work