### PR TITLE
Add HEI monitoring candidate discovery base

### DIFF
--- a/scripts/monitoring/core/classify.mjs
+++ b/scripts/monitoring/core/classify.mjs
@@ -1,0 +1,99 @@
+import { isExchangeLikeText, isLikelyOutOfScopeText, normalizeText } from './normalize.mjs';
+
+function includesAny(text, patterns) {
+  return patterns.some((pattern) => text.includes(pattern));
+}
+
+export function classifyCandidate(candidate, duplicateCheck) {
+  const text = normalizeText([
+    candidate?.canonical_name,
+    candidate?.name,
+    candidate?.description,
+    candidate?.headline,
+    candidate?.notes,
+    ...(candidate?.signals || []),
+  ].filter(Boolean).join(' '));
+
+  const hasShutdown = includesAny(text, [
+    'shutdown',
+    'shut down',
+    'closed',
+    'cease operations',
+    'ceased operations',
+    'wind down',
+    'service ended',
+    'service discontinued',
+  ]);
+  const hasIncident = includesAny(text, [
+    'hack',
+    'hacked',
+    'exploit',
+    'breach',
+    'unauthorized withdrawal',
+    'hot wallet',
+    'stolen',
+    'drained',
+  ]);
+  const hasSuspension = includesAny(text, [
+    'withdrawals suspended',
+    'deposits suspended',
+    'trading halted',
+    'paused withdrawals',
+    'halted trading',
+  ]);
+  const hasRegulatory = includesAny(text, [
+    'regulatory',
+    'license',
+    'sanction',
+    'enforcement',
+    'regional exit',
+    'warning list',
+  ]);
+  const exchangeLike = isExchangeLikeText(text) || candidate?.likely_type === 'cex' || candidate?.likely_type === 'dex';
+  const outOfScope = isLikelyOutOfScopeText(text);
+
+  let candidateClass = 'B';
+  let likelyStatus = candidate?.likely_status || 'unknown';
+  let likelyDeathReason = candidate?.likely_death_reason || null;
+  let recordShape = duplicateCheck.matched_existing_entity ? 'existing_entity_event_update' : 'new_entity';
+  let nextAction = 'hold_for_review';
+  let heiRelevance = 'Potential HEI candidate, but requires scope/source review.';
+
+  if (outOfScope || !exchangeLike) {
+    candidateClass = 'C';
+    recordShape = 'out_of_scope';
+    nextAction = 'ignore_or_keep_for_reference';
+    heiRelevance = 'Likely out of scope or too weak for canonical insertion.';
+  } else if (hasShutdown) {
+    candidateClass = 'A';
+    likelyStatus = 'dead';
+    likelyDeathReason = hasRegulatory ? 'regulation' : 'voluntary_shutdown';
+    nextAction = 'review_and_stage_public_quality_record';
+    heiRelevance = 'Likely HEI-relevant shutdown / wind-down candidate.';
+  } else if (hasIncident || hasSuspension) {
+    candidateClass = 'A';
+    likelyStatus = duplicateCheck.matched_existing_entity ? 'active' : 'unknown';
+    nextAction = 'review_for_event_or_entity_staging';
+    heiRelevance = 'Likely HEI-relevant active-side incident or service restriction candidate.';
+  } else if (hasRegulatory) {
+    candidateClass = 'B';
+    likelyStatus = 'limited';
+    nextAction = 'hold_for_regulatory_scope_review';
+    heiRelevance = 'Potential HEI regulatory candidate; do not mark dead unless service closure is proven.';
+  } else if (!duplicateCheck.matched_existing_entity) {
+    candidateClass = 'B';
+    likelyStatus = candidate?.likely_status || 'active';
+    recordShape = 'new_entity';
+    nextAction = 'hold_for_active_baseline_or_batch_add';
+    heiRelevance = 'Potential active exchange motherlist candidate.';
+  }
+
+  return {
+    candidate_class: candidateClass,
+    likely_status: likelyStatus,
+    likely_death_reason: likelyDeathReason,
+    record_shape: recordShape,
+    hei_relevance: heiRelevance,
+    next_action: nextAction,
+  };
+}

--- a/scripts/monitoring/core/dedupe.mjs
+++ b/scripts/monitoring/core/dedupe.mjs
@@ -1,0 +1,58 @@
+import { normalizeText, slugifyName, normalizeDomain } from './normalize.mjs';
+
+export function buildEntityIndex(entities = []) {
+  const bySlug = new Map();
+  const byName = new Map();
+  const byDomain = new Map();
+
+  for (const entity of entities) {
+    if (entity.slug) bySlug.set(entity.slug, entity);
+    for (const name of [entity.canonical_name, ...(entity.aliases || [])]) {
+      const normalized = normalizeText(name);
+      if (normalized) byName.set(normalized, entity);
+    }
+    const domain = normalizeDomain(entity.official_domain_original || entity.official_url_original || '');
+    if (domain) byDomain.set(domain, entity);
+  }
+
+  return { bySlug, byName, byDomain };
+}
+
+export function findExistingEntity(candidate, index) {
+  const name = candidate?.canonical_name || candidate?.name || '';
+  const slug = candidate?.slug || slugifyName(name);
+  const domain = normalizeDomain(candidate?.official_domain || candidate?.official_url || candidate?.url || '');
+  const aliases = candidate?.aliases || [];
+
+  if (slug && index.bySlug.has(slug)) {
+    return { entity: index.bySlug.get(slug), method: 'slug' };
+  }
+
+  const normalizedName = normalizeText(name);
+  if (normalizedName && index.byName.has(normalizedName)) {
+    return { entity: index.byName.get(normalizedName), method: 'canonical_name' };
+  }
+
+  for (const alias of aliases) {
+    const normalizedAlias = normalizeText(alias);
+    if (normalizedAlias && index.byName.has(normalizedAlias)) {
+      return { entity: index.byName.get(normalizedAlias), method: 'alias' };
+    }
+  }
+
+  if (domain && index.byDomain.has(domain)) {
+    return { entity: index.byDomain.get(domain), method: 'domain' };
+  }
+
+  return { entity: null, method: 'no_match' };
+}
+
+export function duplicateCheckForCandidate(candidate, index) {
+  const match = findExistingEntity(candidate, index);
+  return {
+    matched_existing_entity: Boolean(match.entity),
+    matched_id: match.entity?.id || null,
+    matched_slug: match.entity?.slug || null,
+    method: match.method,
+  };
+}

--- a/scripts/monitoring/core/normalize.mjs
+++ b/scripts/monitoring/core/normalize.mjs
@@ -1,0 +1,53 @@
+export function normalizeText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function slugifyName(value) {
+  return normalizeText(value)
+    .replace(/\s+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function normalizeDomain(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+
+  try {
+    const url = raw.includes('://') ? new URL(raw) : new URL(`https://${raw}`);
+    return url.hostname.toLowerCase().replace(/^www\./, '');
+  } catch {
+    return raw
+      .toLowerCase()
+      .replace(/^https?:\/\//, '')
+      .replace(/^www\./, '')
+      .split('/')[0]
+      .trim();
+  }
+}
+
+export function extractDomain(value) {
+  return normalizeDomain(value);
+}
+
+export function uniqueStrings(values) {
+  return [...new Set(values.map((value) => String(value || '').trim()).filter(Boolean))];
+}
+
+export function isExchangeLikeText(value) {
+  const text = normalizeText(value);
+  if (!text) return false;
+  return /\b(exchange|dex|swap|trading|markets?|perp|derivatives?|crypto)\b/.test(text);
+}
+
+export function isLikelyOutOfScopeText(value) {
+  const text = normalizeText(value);
+  if (!text) return false;
+  return /\b(wallet|nft|mining|stablecoin|airdrop|memecoin|meme coin|lending only|portfolio|analytics)\b/.test(text);
+}

--- a/scripts/monitoring/monitors/candidate-discovery.mjs
+++ b/scripts/monitoring/monitors/candidate-discovery.mjs
@@ -1,16 +1,134 @@
-import { createMonitorResult } from '../core/finding-utils.mjs';
+import { WATCHLIST_AUTO_ROOT } from '../core/constants.mjs';
+import { writeJsonFile } from '../core/fs-utils.mjs';
+import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+import { slugifyName, uniqueStrings } from '../core/normalize.mjs';
+import { buildEntityIndex, duplicateCheckForCandidate } from '../core/dedupe.mjs';
+import { classifyCandidate } from '../core/classify.mjs';
+import { getStaticExternalItems } from '../sources/external-lists.mjs';
+
+function runDateFromRunId(runId) {
+  return String(runId || new Date().toISOString().slice(0, 10).replace(/-/g, '')).slice(0, 8);
+}
+
+function toCandidateRecord(rawItem, index, runId, ordinal) {
+  const canonicalName = rawItem.canonical_name || rawItem.name || rawItem.title || rawItem.slug;
+  const slug = rawItem.slug || slugifyName(canonicalName);
+  const base = {
+    candidate_id: `auto_${runDateFromRunId(runId)}_${String(ordinal).padStart(3, '0')}`,
+    canonical_name: canonicalName,
+    aliases: uniqueStrings(rawItem.aliases || []),
+    slug,
+    likely_type: rawItem.likely_type || rawItem.type || 'unknown',
+    headline: rawItem.headline || rawItem.title || canonicalName,
+    source_urls: uniqueStrings(rawItem.source_urls || rawItem.urls || (rawItem.url ? [rawItem.url] : [])),
+    source_quality: rawItem.source_quality || 'low',
+    source_name: rawItem.source_name || 'unknown',
+    description: rawItem.description || rawItem.summary || rawItem.notes || '',
+    signals: uniqueStrings(rawItem.signals || []),
+  };
+
+  const duplicateCheck = duplicateCheckForCandidate({
+    ...base,
+    official_domain: rawItem.official_domain,
+    official_url: rawItem.official_url,
+    url: rawItem.url,
+  }, index);
+  const classification = classifyCandidate(base, duplicateCheck);
+
+  return {
+    candidate_id: base.candidate_id,
+    canonical_name: base.canonical_name,
+    aliases: base.aliases,
+    candidate_class: classification.candidate_class,
+    likely_type: base.likely_type,
+    likely_status: classification.likely_status,
+    likely_death_reason: classification.likely_death_reason,
+    record_shape: classification.record_shape,
+    headline: base.headline,
+    hei_relevance: classification.hei_relevance,
+    duplicate_check: duplicateCheck,
+    source_urls: base.source_urls,
+    source_quality: base.source_quality,
+    next_action: classification.next_action,
+    source_name: base.source_name,
+  };
+}
 
 export async function runCandidateDiscovery(context, { startedAt } = {}) {
+  const monitor = 'candidate-discovery';
   const started_at = startedAt || new Date().toISOString();
+  const findings = [];
+  const entities = context?.canonicalData?.entities || [];
+  const entityIndex = buildEntityIndex(entities);
+  const rawItems = getStaticExternalItems();
+
+  const candidates = rawItems
+    .filter((item) => item && (item.canonical_name || item.name || item.title || item.slug))
+    .map((item, index) => toCandidateRecord(item, entityIndex, context?.runId, index + 1));
+
+  const missingInHei = candidates.filter((candidate) => !candidate.duplicate_check.matched_existing_entity);
+  const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity);
+  const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
+
+  if (rawItems.length === 0) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'low',
+      category: 'candidate_discovery_source_empty',
+      title: 'Candidate discovery source is empty',
+      summary: 'The static external-list seed is empty. This is expected until external source adapters are added.',
+      recommended_action: 'add_external_source_adapter_or_seed_items_in_later_phase',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:source_empty:manual_seed`,
+    }));
+  }
+
+  for (const candidate of aCandidates) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'candidate_discovery_a_candidate',
+      title: `A candidate discovered: ${candidate.canonical_name}`,
+      summary: candidate.hei_relevance,
+      recommended_action: candidate.next_action,
+      source_urls: candidate.source_urls,
+      confidence: candidate.source_quality === 'high' ? 'high' : 'medium',
+      dedupe_key: `${monitor}:a_candidate:${candidate.canonical_name.toLowerCase()}`,
+    }));
+  }
+
+  if (candidates.length > 0) {
+    const runDate = runDateFromRunId(context?.runId);
+    await writeJsonFile(`${WATCHLIST_AUTO_ROOT}/recent-candidates-${runDate}.json`, {
+      watchlist_type: 'auto_candidate_discovery',
+      created_at: new Date().toISOString(),
+      purpose: 'Auto-generated candidate discovery output. Not canonical. Requires review before staging/canonical append.',
+      candidates,
+      summary: {
+        total: candidates.length,
+        missing_in_hei: missingInHei.length,
+        matched_existing: matchedExisting.length,
+        A: candidates.filter((candidate) => candidate.candidate_class === 'A').length,
+        B: candidates.filter((candidate) => candidate.candidate_class === 'B').length,
+        C: candidates.filter((candidate) => candidate.candidate_class === 'C').length,
+      },
+    });
+  }
+
   return createMonitorResult({
-    monitor: 'candidate-discovery',
+    monitor,
     started_at,
     finished_at: new Date().toISOString(),
-    findings: [],
-    candidates: [],
+    findings,
+    candidates,
     errors: [],
     extra: {
-      note: 'Skeleton monitor. External list diff and candidate discovery are implemented in later phases.',
+      discovery_summary: {
+        raw_items: rawItems.length,
+        candidates: candidates.length,
+        missing_in_hei: missingInHei.length,
+        matched_existing: matchedExisting.length,
+      },
     },
   });
 }

--- a/scripts/monitoring/sources/external-lists.mjs
+++ b/scripts/monitoring/sources/external-lists.mjs
@@ -1,0 +1,19 @@
+export const EXTERNAL_LIST_SOURCES = [
+  {
+    name: 'manual-seed',
+    type: 'static',
+    description: 'Empty static seed for validating candidate-discovery plumbing. Populate in later PRs or generated reports.',
+    items: [],
+  },
+];
+
+export function getStaticExternalItems() {
+  return EXTERNAL_LIST_SOURCES.flatMap((source) => {
+    if (source.type !== 'static') return [];
+    return (source.items || []).map((item) => ({
+      ...item,
+      source_name: source.name,
+      source_type: source.type,
+    }));
+  });
+}


### PR DESCRIPTION
## Summary
- add normalization helpers for candidate names, slugs, domains, and exchange-like/out-of-scope text checks
- add dedupe helpers for slug/name/alias/domain matching against canonical entities
- add candidate classifier for A/B/C candidate class, likely status, record shape, and next action
- add static external-list source plumbing
- replace the candidate-discovery placeholder with a working base that can classify seed items, write auto watchlists, and surface A candidates as findings

## Scope
- no canonical data changes
- no external network checks yet
- static source seed is intentionally empty until later source adapters are added
- candidate-discovery now has the plumbing needed for historical-dead and external-list-diff PRs

## Safety
- generated candidates are written only to `data-staging/watchlists/auto/**`
- canonical data remains protected by the existing monitoring guard

## Notes
- this corresponds to the implementation plan step for candidate-discovery base
- next PRs should add historical-dead signals and at least one real external list adapter