### PR TITLE
Add HEI monitoring external list adapter plumbing

### DIFF
--- a/scripts/monitoring/monitors/candidate-discovery.mjs
+++ b/scripts/monitoring/monitors/candidate-discovery.mjs
@@ -4,7 +4,7 @@ import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
 import { slugifyName, uniqueStrings } from '../core/normalize.mjs';
 import { buildEntityIndex, duplicateCheckForCandidate } from '../core/dedupe.mjs';
 import { classifyCandidate } from '../core/classify.mjs';
-import { getStaticExternalItems } from '../sources/external-lists.mjs';
+import { getExternalItems } from '../sources/external-lists.mjs';
 
 function runDateFromRunId(runId) {
   return String(runId || new Date().toISOString().slice(0, 10).replace(/-/g, '')).slice(0, 8);
@@ -23,6 +23,7 @@ function toCandidateRecord(rawItem, index, runId, ordinal) {
     source_urls: uniqueStrings(rawItem.source_urls || rawItem.urls || (rawItem.url ? [rawItem.url] : [])),
     source_quality: rawItem.source_quality || 'low',
     source_name: rawItem.source_name || 'unknown',
+    source_category: rawItem.source_category || 'unknown',
     description: rawItem.description || rawItem.summary || rawItem.notes || '',
     signals: uniqueStrings(rawItem.signals || []),
   };
@@ -51,6 +52,7 @@ function toCandidateRecord(rawItem, index, runId, ordinal) {
     source_quality: base.source_quality,
     next_action: classification.next_action,
     source_name: base.source_name,
+    source_category: base.source_category,
   };
 }
 
@@ -58,9 +60,25 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
   const monitor = 'candidate-discovery';
   const started_at = startedAt || new Date().toISOString();
   const findings = [];
+  const errors = [];
   const entities = context?.canonicalData?.entities || [];
   const entityIndex = buildEntityIndex(entities);
-  const rawItems = getStaticExternalItems();
+  const external = await getExternalItems();
+  const rawItems = external.items;
+
+  for (const error of external.errors) {
+    errors.push(`${error.source_name}: ${error.error}`);
+    findings.push(createFinding({
+      monitor,
+      severity: 'medium',
+      category: 'external_source_fetch_failed',
+      title: `External source fetch failed: ${error.source_name}`,
+      summary: `${error.url}: ${error.error}`,
+      recommended_action: 'inspect_external_source_adapter',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:source_fetch_failed:${error.source_name}`,
+    }));
+  }
 
   const candidates = rawItems
     .filter((item) => item && (item.canonical_name || item.name || item.title || item.slug))
@@ -76,10 +94,10 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
       severity: 'low',
       category: 'candidate_discovery_source_empty',
       title: 'Candidate discovery source is empty',
-      summary: 'The static external-list seed is empty. This is expected until external source adapters are added.',
-      recommended_action: 'add_external_source_adapter_or_seed_items_in_later_phase',
+      summary: 'No candidate source items were available. Static seeds may be empty and remote lists may be disabled.',
+      recommended_action: 'enable_remote_lists_or_add_seed_items_in_later_phase',
       confidence: 'medium',
-      dedupe_key: `${monitor}:source_empty:manual_seed`,
+      dedupe_key: `${monitor}:source_empty:all_sources`,
     }));
   }
 
@@ -103,6 +121,7 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
       watchlist_type: 'auto_candidate_discovery',
       created_at: new Date().toISOString(),
       purpose: 'Auto-generated candidate discovery output. Not canonical. Requires review before staging/canonical append.',
+      source_summary: external.source_summary,
       candidates,
       summary: {
         total: candidates.length,
@@ -121,13 +140,14 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
     finished_at: new Date().toISOString(),
     findings,
     candidates,
-    errors: [],
+    errors,
     extra: {
       discovery_summary: {
         raw_items: rawItems.length,
         candidates: candidates.length,
         missing_in_hei: missingInHei.length,
         matched_existing: matchedExisting.length,
+        source_summary: external.source_summary,
       },
     },
   });

--- a/scripts/monitoring/sources/external-lists.mjs
+++ b/scripts/monitoring/sources/external-lists.mjs
@@ -1,19 +1,132 @@
+const ENABLE_REMOTE_LISTS = process.env.HEI_MONITORING_ENABLE_REMOTE_LISTS === '1';
+const DEFAULT_TIMEOUT_MS = 15000;
+
 export const EXTERNAL_LIST_SOURCES = [
   {
     name: 'manual-seed',
     type: 'static',
-    description: 'Empty static seed for validating candidate-discovery plumbing. Populate in later PRs or generated reports.',
+    description: 'Static seed for validating candidate-discovery plumbing. Keep small and curated.',
+    category: 'manual',
     items: [],
   },
+  {
+    name: 'historical-dead-seed',
+    type: 'static',
+    description: 'Curated local seed for historical dead/rebranded/acquired exchange candidates. Empty by default; filled by later research or generated watchlists.',
+    category: 'historical_dead',
+    items: [],
+  },
+  {
+    name: 'defillama-protocols-dexlike',
+    type: 'remote_json',
+    enabled: ENABLE_REMOTE_LISTS,
+    url: 'https://api.llama.fi/protocols',
+    description: 'Optional remote adapter for DEX-like protocol discovery. Disabled by default to avoid noisy scheduled runs.',
+    category: 'active_motherlist',
+    item_limit: 100,
+    transform: 'defillama_protocols_dexlike',
+  },
 ];
+
+function withSource(item, source) {
+  return {
+    ...item,
+    source_name: source.name,
+    source_type: source.type,
+    source_category: source.category || 'unknown',
+  };
+}
+
+function controllerWithTimeout(timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return { controller, timeout };
+}
+
+async function fetchJson(url) {
+  const { controller, timeout } = controllerWithTimeout();
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'user-agent': 'HEI-Monitoring/0.1' },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function transformDefillamaProtocolsDexlike(json, source) {
+  const protocols = Array.isArray(json) ? json : [];
+  const dexLike = protocols.filter((item) => {
+    const text = `${item.name || ''} ${item.category || ''} ${(item.chains || []).join(' ')}`.toLowerCase();
+    return /\b(dex|derivatives|options|synthetics|yield aggregator|liquid staking)\b/.test(text)
+      && !/\b(lending|wallet|nft|bridge)\b/.test(text);
+  });
+
+  return dexLike.slice(0, source.item_limit || 100).map((item) => withSource({
+    canonical_name: item.name,
+    aliases: [],
+    likely_type: /dex|derivatives|options|synthetics/i.test(item.category || '') ? 'dex' : 'hybrid',
+    likely_status: 'active',
+    headline: `${item.name} appears in a remote protocol directory`,
+    description: `${item.name} category=${item.category || 'unknown'} chains=${(item.chains || []).slice(0, 8).join(', ')}`,
+    source_urls: [item.url || `https://defillama.com/protocol/${item.slug}`].filter(Boolean),
+    source_quality: 'medium',
+    signals: ['external list diff', 'active motherlist candidate', item.category || 'unknown'],
+    url: item.url || null,
+    official_url: item.url || null,
+  }, source));
+}
+
+function transformRemoteJson(json, source) {
+  if (source.transform === 'defillama_protocols_dexlike') {
+    return transformDefillamaProtocolsDexlike(json, source);
+  }
+  return [];
+}
 
 export function getStaticExternalItems() {
   return EXTERNAL_LIST_SOURCES.flatMap((source) => {
     if (source.type !== 'static') return [];
-    return (source.items || []).map((item) => ({
-      ...item,
-      source_name: source.name,
-      source_type: source.type,
-    }));
+    return (source.items || []).map((item) => withSource(item, source));
   });
+}
+
+export async function getRemoteExternalItems() {
+  const enabledRemoteSources = EXTERNAL_LIST_SOURCES.filter((source) => source.type === 'remote_json' && source.enabled);
+  const items = [];
+  const errors = [];
+
+  for (const source of enabledRemoteSources) {
+    try {
+      const json = await fetchJson(source.url);
+      items.push(...transformRemoteJson(json, source));
+    } catch (error) {
+      errors.push({
+        source_name: source.name,
+        url: source.url,
+        error: error?.message || String(error),
+      });
+    }
+  }
+
+  return { items, errors };
+}
+
+export async function getExternalItems() {
+  const staticItems = getStaticExternalItems();
+  const remote = await getRemoteExternalItems();
+  return {
+    items: [...staticItems, ...remote.items],
+    errors: remote.errors,
+    source_summary: {
+      static_sources: EXTERNAL_LIST_SOURCES.filter((source) => source.type === 'static').length,
+      remote_sources: EXTERNAL_LIST_SOURCES.filter((source) => source.type === 'remote_json').length,
+      remote_enabled: EXTERNAL_LIST_SOURCES.filter((source) => source.type === 'remote_json' && source.enabled).length,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add external list adapter plumbing for candidate discovery
- add static historical-dead seed source placeholder
- add optional remote JSON source support behind `HEI_MONITORING_ENABLE_REMOTE_LISTS=1`
- add optional DefiLlama protocol-directory adapter for DEX-like active motherlist discovery
- wire candidate discovery to combined static/remote external items and expose source summary in auto watchlist output

## Scope
- no canonical data changes
- remote external lists are disabled by default
- no scheduled network fetch is enabled unless `HEI_MONITORING_ENABLE_REMOTE_LISTS=1` is explicitly set
- this is adapter plumbing and external-list-diff foundation, not final high-confidence candidate curation

## Safety
- generated candidates are written only to `data-staging/watchlists/auto/**`
- canonical data remains protected by the existing monitoring guard

## Notes
- this follows PR #92 by adding the first real external-list adapter layer
- next PR should add historical-dead signal scoring and/or curated seed ingestion rules