### PR TITLE
Add HEI historical dead candidate signals

### DIFF
--- a/scripts/monitoring/core/classify.mjs
+++ b/scripts/monitoring/core/classify.mjs
@@ -1,4 +1,5 @@
 import { isExchangeLikeText, isLikelyOutOfScopeText, normalizeText } from './normalize.mjs';
+import { evaluateHistoricalDeadSignals } from './historical-dead-signals.mjs';
 
 function includesAny(text, patterns) {
   return patterns.some((pattern) => text.includes(pattern));
@@ -13,11 +14,13 @@ export function classifyCandidate(candidate, duplicateCheck) {
     candidate?.notes,
     ...(candidate?.signals || []),
   ].filter(Boolean).join(' '));
+  const historical = evaluateHistoricalDeadSignals(candidate);
 
   const hasShutdown = includesAny(text, [
     'shutdown',
     'shut down',
     'closed',
+    'closure',
     'cease operations',
     'ceased operations',
     'wind down',
@@ -49,12 +52,12 @@ export function classifyCandidate(candidate, duplicateCheck) {
     'regional exit',
     'warning list',
   ]);
-  const exchangeLike = isExchangeLikeText(text) || candidate?.likely_type === 'cex' || candidate?.likely_type === 'dex';
+  const exchangeLike = isExchangeLikeText(text) || candidate?.likely_type === 'cex' || candidate?.likely_type === 'dex' || candidate?.likely_type === 'hybrid';
   const outOfScope = isLikelyOutOfScopeText(text);
 
   let candidateClass = 'B';
-  let likelyStatus = candidate?.likely_status || 'unknown';
-  let likelyDeathReason = candidate?.likely_death_reason || null;
+  let likelyStatus = historical.suggested_status || candidate?.likely_status || 'unknown';
+  let likelyDeathReason = historical.suggested_death_reason || candidate?.likely_death_reason || null;
   let recordShape = duplicateCheck.matched_existing_entity ? 'existing_entity_event_update' : 'new_entity';
   let nextAction = 'hold_for_review';
   let heiRelevance = 'Potential HEI candidate, but requires scope/source review.';
@@ -64,6 +67,13 @@ export function classifyCandidate(candidate, duplicateCheck) {
     recordShape = 'out_of_scope';
     nextAction = 'ignore_or_keep_for_reference';
     heiRelevance = 'Likely out of scope or too weak for canonical insertion.';
+  } else if (historical.historical_dead_strength === 'strong') {
+    candidateClass = 'A';
+    likelyStatus = historical.suggested_status;
+    likelyDeathReason = historical.suggested_death_reason;
+    recordShape = duplicateCheck.matched_existing_entity ? 'existing_entity_event_update' : 'new_entity';
+    nextAction = 'review_and_stage_public_quality_record';
+    heiRelevance = 'Likely HEI-relevant historical dead/continuity candidate.';
   } else if (hasShutdown) {
     candidateClass = 'A';
     likelyStatus = 'dead';
@@ -80,6 +90,12 @@ export function classifyCandidate(candidate, duplicateCheck) {
     likelyStatus = 'limited';
     nextAction = 'hold_for_regulatory_scope_review';
     heiRelevance = 'Potential HEI regulatory candidate; do not mark dead unless service closure is proven.';
+  } else if (historical.historical_dead_strength === 'medium') {
+    candidateClass = 'B';
+    likelyStatus = historical.suggested_status;
+    likelyDeathReason = historical.suggested_death_reason;
+    nextAction = 'hold_for_more_sources_or_scope_decision';
+    heiRelevance = 'Potential historical dead/continuity candidate; needs more source review.';
   } else if (!duplicateCheck.matched_existing_entity) {
     candidateClass = 'B';
     likelyStatus = candidate?.likely_status || 'active';
@@ -95,5 +111,8 @@ export function classifyCandidate(candidate, duplicateCheck) {
     record_shape: recordShape,
     hei_relevance: heiRelevance,
     next_action: nextAction,
+    historical_dead_score: historical.historical_dead_score,
+    historical_dead_strength: historical.historical_dead_strength,
+    historical_dead_tags: historical.historical_dead_tags,
   };
 }

--- a/scripts/monitoring/core/historical-dead-signals.mjs
+++ b/scripts/monitoring/core/historical-dead-signals.mjs
@@ -1,0 +1,181 @@
+import { normalizeDomain, normalizeText } from './normalize.mjs';
+
+const SHUTDOWN_TERMS = [
+  'shutdown',
+  'shut down',
+  'closed',
+  'closure',
+  'cease operations',
+  'ceased operations',
+  'wind down',
+  'wound down',
+  'service ended',
+  'service discontinued',
+  'permanently closed',
+  'no longer operating',
+];
+
+const INSOLVENCY_TERMS = [
+  'insolvent',
+  'insolvency',
+  'bankruptcy',
+  'bankrupt',
+  'shortfall',
+  'liabilities',
+  'unable to repay',
+];
+
+const SCAM_TERMS = [
+  'exit scam',
+  'scam',
+  'rug pull',
+  'fraud',
+  'ponzi',
+];
+
+const REGULATORY_TERMS = [
+  'regulatory',
+  'license revoked',
+  'license withdrawn',
+  'warning list',
+  'cease and desist',
+  'enforcement',
+  'sanction',
+];
+
+const CONTINUITY_TERMS = [
+  'acquired by',
+  'acquisition',
+  'merged with',
+  'merger',
+  'rebranded',
+  'renamed',
+  'customer transfer',
+  'asset transfer',
+  'migration',
+];
+
+function includesAny(text, terms) {
+  return terms.some((term) => text.includes(normalizeText(term)));
+}
+
+function countUrls(urls = []) {
+  return Array.isArray(urls) ? urls.filter(Boolean).length : 0;
+}
+
+function hasArchiveUrl(urls = []) {
+  return urls.some((url) => /web\.archive\.org|archive\.org/i.test(String(url || '')));
+}
+
+function hasDeadDomainSignal(candidate) {
+  const status = normalizeText(candidate.official_url_status || '');
+  if (status.includes('dead domain') || status.includes('repurposed')) return true;
+
+  const domain = normalizeDomain(candidate.official_domain || candidate.official_url || candidate.url || '');
+  if (!domain) return false;
+  return /expired|parking|forsale|for-sale/i.test(String(candidate.notes || candidate.description || ''));
+}
+
+export function evaluateHistoricalDeadSignals(candidate = {}) {
+  const text = normalizeText([
+    candidate.canonical_name,
+    candidate.name,
+    candidate.description,
+    candidate.summary,
+    candidate.headline,
+    candidate.notes,
+    candidate.status,
+    candidate.likely_status,
+    candidate.death_reason,
+    candidate.likely_death_reason,
+    ...(candidate.signals || []),
+  ].filter(Boolean).join(' '));
+  const urls = [
+    ...(candidate.source_urls || []),
+    ...(candidate.urls || []),
+    candidate.url,
+    candidate.official_url,
+    candidate.archived_url,
+  ].filter(Boolean);
+
+  const tags = [];
+  let score = 0;
+
+  if (includesAny(text, SHUTDOWN_TERMS)) {
+    tags.push('shutdown_language');
+    score += 3;
+  }
+  if (includesAny(text, INSOLVENCY_TERMS)) {
+    tags.push('insolvency_language');
+    score += 3;
+  }
+  if (includesAny(text, SCAM_TERMS)) {
+    tags.push('scam_or_exit_language');
+    score += 2;
+  }
+  if (includesAny(text, REGULATORY_TERMS)) {
+    tags.push('regulatory_language');
+    score += 2;
+  }
+  if (includesAny(text, CONTINUITY_TERMS)) {
+    tags.push('continuity_language');
+    score += 2;
+  }
+  if (hasArchiveUrl(urls)) {
+    tags.push('archive_url_present');
+    score += 2;
+  }
+  if (hasDeadDomainSignal(candidate)) {
+    tags.push('dead_or_repurposed_domain_signal');
+    score += 2;
+  }
+  if (countUrls(urls) >= 2) {
+    tags.push('multiple_source_urls');
+    score += 1;
+  }
+  if (candidate.source_quality === 'high') {
+    tags.push('high_quality_source');
+    score += 1;
+  }
+
+  let suggestedStatus = candidate.likely_status || 'unknown';
+  let suggestedDeathReason = candidate.likely_death_reason || null;
+
+  if (tags.includes('continuity_language')) {
+    if (text.includes('rebrand') || text.includes('renamed')) {
+      suggestedStatus = 'rebranded';
+      suggestedDeathReason = 'rebrand';
+    } else if (text.includes('acquired')) {
+      suggestedStatus = 'acquired';
+      suggestedDeathReason = 'acquisition';
+    } else if (text.includes('merged')) {
+      suggestedStatus = 'merged';
+      suggestedDeathReason = 'merger';
+    }
+  }
+  if (tags.includes('shutdown_language') || tags.includes('dead_or_repurposed_domain_signal')) {
+    suggestedStatus = ['acquired', 'merged', 'rebranded'].includes(suggestedStatus) ? suggestedStatus : 'dead';
+    suggestedDeathReason = suggestedDeathReason || 'voluntary_shutdown';
+  }
+  if (tags.includes('insolvency_language')) {
+    suggestedStatus = 'dead';
+    suggestedDeathReason = 'insolvency';
+  }
+  if (tags.includes('scam_or_exit_language')) {
+    suggestedStatus = 'dead';
+    suggestedDeathReason = 'scam_rug';
+  }
+  if (tags.includes('regulatory_language') && suggestedStatus === 'dead') {
+    suggestedDeathReason = 'regulation';
+  }
+
+  const strength = score >= 6 ? 'strong' : score >= 3 ? 'medium' : score > 0 ? 'weak' : 'none';
+
+  return {
+    historical_dead_score: score,
+    historical_dead_strength: strength,
+    historical_dead_tags: tags,
+    suggested_status: suggestedStatus,
+    suggested_death_reason: suggestedDeathReason,
+  };
+}

--- a/scripts/monitoring/monitors/candidate-discovery.mjs
+++ b/scripts/monitoring/monitors/candidate-discovery.mjs
@@ -53,6 +53,9 @@ function toCandidateRecord(rawItem, index, runId, ordinal) {
     next_action: classification.next_action,
     source_name: base.source_name,
     source_category: base.source_category,
+    historical_dead_score: classification.historical_dead_score,
+    historical_dead_strength: classification.historical_dead_strength,
+    historical_dead_tags: classification.historical_dead_tags,
   };
 }
 
@@ -87,6 +90,7 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
   const missingInHei = candidates.filter((candidate) => !candidate.duplicate_check.matched_existing_entity);
   const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity);
   const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
+  const historicalCandidates = candidates.filter((candidate) => ['strong', 'medium'].includes(candidate.historical_dead_strength));
 
   if (rawItems.length === 0) {
     findings.push(createFinding({
@@ -127,6 +131,7 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
         total: candidates.length,
         missing_in_hei: missingInHei.length,
         matched_existing: matchedExisting.length,
+        historical_dead_or_continuity: historicalCandidates.length,
         A: candidates.filter((candidate) => candidate.candidate_class === 'A').length,
         B: candidates.filter((candidate) => candidate.candidate_class === 'B').length,
         C: candidates.filter((candidate) => candidate.candidate_class === 'C').length,
@@ -147,6 +152,7 @@ export async function runCandidateDiscovery(context, { startedAt } = {}) {
         candidates: candidates.length,
         missing_in_hei: missingInHei.length,
         matched_existing: matchedExisting.length,
+        historical_dead_or_continuity: historicalCandidates.length,
         source_summary: external.source_summary,
       },
     },


### PR DESCRIPTION
## Summary
- add historical dead / continuity signal evaluator for candidate discovery
- score shutdown, insolvency, scam/exit, regulatory, continuity, archive, dead-domain, and multi-source signals
- use historical-dead strength in A/B/C candidate classification
- expose historical-dead score, strength, and tags in auto candidate watchlist output

## Scope
- no canonical data changes
- no external network checks added
- no curated seed data added yet
- this improves classification for future static seeds, external-list diff items, and news/event candidates

## Safety
- generated candidates remain report/watchlist-only
- canonical data remains protected by the existing monitoring guard

## Notes
- this follows PR #93 by adding historical-dead signal scoring
- next PR should add curated seed ingestion rules or real news/event watch plumbing