### PR TITLE
Add HEI news and event watch base

### DIFF
--- a/scripts/monitoring/adapters/rss-google-news.mjs
+++ b/scripts/monitoring/adapters/rss-google-news.mjs
@@ -1,0 +1,83 @@
+const DEFAULT_TIMEOUT_MS = 15000;
+
+function decodeXml(value) {
+  return String(value || '')
+    .replace(/<!\[CDATA\[(.*?)\]\]>/gs, '$1')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+function stripHtml(value) {
+  return decodeXml(value).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function getTag(block, tag) {
+  const match = block.match(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, 'i'));
+  return match ? decodeXml(match[1]) : '';
+}
+
+function getSource(block) {
+  const match = block.match(/<source(?:\s+url="([^"]*)")?[^>]*>([\s\S]*?)<\/source>/i);
+  if (!match) return { name: 'unknown', url: '' };
+  return { name: decodeXml(match[2]) || 'unknown', url: decodeXml(match[1] || '') };
+}
+
+function controllerWithTimeout(timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return { controller, timeout };
+}
+
+function parseRssItems(xml, queryMeta) {
+  const itemBlocks = [...String(xml || '').matchAll(/<item>([\s\S]*?)<\/item>/gi)].map((match) => match[1]);
+  return itemBlocks.map((block) => {
+    const source = getSource(block);
+    const link = getTag(block, 'link');
+    const pubDate = getTag(block, 'pubDate');
+    return {
+      title: stripHtml(getTag(block, 'title')),
+      url: link,
+      source_name: source.name,
+      source_url: source.url,
+      published_at: pubDate ? new Date(pubDate).toISOString() : null,
+      snippet: stripHtml(getTag(block, 'description')),
+      query: queryMeta.query,
+      query_category: queryMeta.category,
+      likely_event_types: queryMeta.likely_event_types || [],
+    };
+  }).filter((item) => item.title || item.url);
+}
+
+export async function fetchGoogleNewsRss(queryMeta) {
+  const encoded = encodeURIComponent(queryMeta.query);
+  const url = `https://news.google.com/rss/search?q=${encoded}&hl=en-US&gl=US&ceid=US:en`;
+  const { controller, timeout } = controllerWithTimeout();
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'user-agent': 'HEI-Monitoring/0.1' },
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    const xml = await response.text();
+    return {
+      items: parseRssItems(xml, queryMeta),
+      error: null,
+      url,
+    };
+  } catch (error) {
+    return {
+      items: [],
+      error: error?.message || String(error),
+      url,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/scripts/monitoring/core/news-extract.mjs
+++ b/scripts/monitoring/core/news-extract.mjs
@@ -1,0 +1,147 @@
+import { normalizeText, slugifyName, uniqueStrings } from './normalize.mjs';
+import { TRUSTED_NEWS_DOMAINS } from '../sources/news-queries.mjs';
+
+const STOP_PREFIXES = [
+  'crypto',
+  'cryptocurrency',
+  'bitcoin',
+  'ethereum',
+  'defi',
+  'dex',
+  'centralized',
+  'decentralized',
+  'exchange',
+  'trading',
+  'platform',
+  'protocol',
+  'users',
+  'hackers',
+  'regulators',
+  'court',
+  'police',
+  'authorities',
+];
+
+const KNOWN_BAD_NAMES = new Set([
+  'crypto',
+  'cryptocurrency',
+  'bitcoin',
+  'ethereum',
+  'defi',
+  'dex',
+  'exchange',
+  'users',
+  'hackers',
+  'regulators',
+]);
+
+function cleanCandidateName(value) {
+  const raw = String(value || '')
+    .replace(/['"“”‘’]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const words = raw.split(' ').filter(Boolean);
+  while (words.length > 1 && STOP_PREFIXES.includes(words[0].toLowerCase())) {
+    words.shift();
+  }
+  return words.join(' ').replace(/\b(exchange|dex|protocol|platform)$/i, '').trim();
+}
+
+function domainFromUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+function sourceQuality(item) {
+  const domains = [domainFromUrl(item.url), domainFromUrl(item.source_url)].filter(Boolean);
+  const trusted = domains.some((domain) => TRUSTED_NEWS_DOMAINS.some((trustedDomain) => domain === trustedDomain || domain.endsWith(`.${trustedDomain}`)));
+  if (trusted) return 'high';
+  if (item.source_name && item.source_name !== 'unknown') return 'medium';
+  return 'low';
+}
+
+export function inferEventCategory(textValue, fallbackCategory = 'unknown') {
+  const text = normalizeText(textValue);
+  if (/\b(shutdown|shut down|closed|closure|cease operations|ceased operations|wind down|service ended|service discontinued)\b/.test(text)) return 'shutdown';
+  if (/\b(hack|hacked|exploit|breach|unauthorized withdrawal|hot wallet|stolen|drained|suspicious outflows)\b/.test(text)) return 'hack_incident';
+  if (/\b(withdrawals suspended|deposits suspended|trading halted|paused withdrawals|halted trading|withdrawal only|close only)\b/.test(text)) return 'withdrawal_deposit_trading_suspension';
+  if (/\b(regulatory|license revoked|license withdrawn|warning list|sanction|enforcement|regional exit|cease and desist)\b/.test(text)) return 'regulatory';
+  if (/\b(acquired|acquisition|merged|merger|rebranded|renamed|customer transfer|asset transfer|migration|successor)\b/.test(text)) return 'acquisition_migration_rebrand';
+  return fallbackCategory;
+}
+
+export function extractCandidateNameFromNews(item) {
+  const text = `${item.title || ''} ${item.snippet || ''}`;
+  const patterns = [
+    /\b(?:exchange|platform|protocol|DEX)\s+([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\b/,
+    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\s+(?:exchange|DEX|protocol|platform)\b/,
+    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2})\s+(?:shuts down|ceases operations|halts trading|suspends withdrawals|is hacked|was hacked|rebrands|is acquired)\b/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) {
+      const name = cleanCandidateName(match[1]);
+      if (name && !KNOWN_BAD_NAMES.has(normalizeText(name))) return name;
+    }
+  }
+
+  return null;
+}
+
+export function groupNewsItemsIntoCandidates(items) {
+  const grouped = new Map();
+
+  for (const item of items) {
+    const name = extractCandidateNameFromNews(item);
+    if (!name) continue;
+    const key = slugifyName(name);
+    const existing = grouped.get(key) || {
+      canonical_name: name,
+      aliases: [],
+      source_urls: [],
+      headlines: [],
+      snippets: [],
+      source_names: [],
+      query_categories: new Set(),
+      likely_event_types: new Set(),
+      source_quality: 'low',
+    };
+
+    existing.source_urls.push(item.url);
+    existing.headlines.push(item.title);
+    existing.snippets.push(item.snippet);
+    existing.source_names.push(item.source_name);
+    existing.query_categories.add(inferEventCategory(`${item.title} ${item.snippet}`, item.query_category));
+    for (const eventType of item.likely_event_types || []) existing.likely_event_types.add(eventType);
+    const quality = sourceQuality(item);
+    if (quality === 'high' || (quality === 'medium' && existing.source_quality === 'low')) existing.source_quality = quality;
+    grouped.set(key, existing);
+  }
+
+  return [...grouped.values()].map((candidate) => {
+    const categories = [...candidate.query_categories];
+    return {
+      canonical_name: candidate.canonical_name,
+      aliases: uniqueStrings(candidate.aliases),
+      headline: candidate.headlines[0] || candidate.canonical_name,
+      description: uniqueStrings([...candidate.headlines, ...candidate.snippets]).slice(0, 8).join(' | '),
+      source_urls: uniqueStrings(candidate.source_urls).slice(0, 8),
+      source_quality: candidate.source_quality,
+      source_name: uniqueStrings(candidate.source_names).join(', '),
+      source_category: 'news_event',
+      likely_type: categories.some((category) => String(category).includes('dex')) ? 'dex' : 'unknown',
+      signals: uniqueStrings([
+        'news/event watch',
+        ...categories,
+        ...[...candidate.likely_event_types].map((eventType) => `event:${eventType}`),
+      ]),
+      news_event_categories: categories,
+      likely_event_types: [...candidate.likely_event_types],
+    };
+  });
+}

--- a/scripts/monitoring/monitors/news-and-event-watch.mjs
+++ b/scripts/monitoring/monitors/news-and-event-watch.mjs
@@ -1,16 +1,194 @@
-import { createMonitorResult } from '../core/finding-utils.mjs';
+import { WATCHLIST_AUTO_ROOT } from '../core/constants.mjs';
+import { writeJsonFile } from '../core/fs-utils.mjs';
+import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+import { slugifyName, uniqueStrings } from '../core/normalize.mjs';
+import { buildEntityIndex, duplicateCheckForCandidate } from '../core/dedupe.mjs';
+import { classifyCandidate } from '../core/classify.mjs';
+import { NEWS_WATCH_ENABLED, getNewsQueries } from '../sources/news-queries.mjs';
+import { fetchGoogleNewsRss } from '../adapters/rss-google-news.mjs';
+import { groupNewsItemsIntoCandidates } from '../core/news-extract.mjs';
+
+function runDateFromRunId(runId) {
+  return String(runId || new Date().toISOString().slice(0, 10).replace(/-/g, '')).slice(0, 8);
+}
+
+function toCandidateRecord(rawItem, index, runId, ordinal) {
+  const canonicalName = rawItem.canonical_name || rawItem.name || rawItem.title || rawItem.slug;
+  const base = {
+    candidate_id: `news_${runDateFromRunId(runId)}_${String(ordinal).padStart(3, '0')}`,
+    canonical_name: canonicalName,
+    aliases: uniqueStrings(rawItem.aliases || []),
+    slug: rawItem.slug || slugifyName(canonicalName),
+    likely_type: rawItem.likely_type || rawItem.type || 'unknown',
+    headline: rawItem.headline || rawItem.title || canonicalName,
+    source_urls: uniqueStrings(rawItem.source_urls || rawItem.urls || (rawItem.url ? [rawItem.url] : [])),
+    source_quality: rawItem.source_quality || 'low',
+    source_name: rawItem.source_name || 'unknown',
+    source_category: rawItem.source_category || 'news_event',
+    description: rawItem.description || rawItem.summary || rawItem.notes || '',
+    signals: uniqueStrings(rawItem.signals || []),
+  };
+
+  const duplicateCheck = duplicateCheckForCandidate(base, index);
+  const classification = classifyCandidate(base, duplicateCheck);
+
+  return {
+    candidate_id: base.candidate_id,
+    canonical_name: base.canonical_name,
+    aliases: base.aliases,
+    candidate_class: classification.candidate_class,
+    likely_type: base.likely_type,
+    likely_status: classification.likely_status,
+    likely_death_reason: classification.likely_death_reason,
+    record_shape: classification.record_shape,
+    headline: base.headline,
+    hei_relevance: classification.hei_relevance,
+    duplicate_check: duplicateCheck,
+    source_urls: base.source_urls,
+    source_quality: base.source_quality,
+    next_action: classification.next_action,
+    source_name: base.source_name,
+    source_category: base.source_category,
+    likely_event_types: rawItem.likely_event_types || [],
+    news_event_categories: rawItem.news_event_categories || [],
+    historical_dead_score: classification.historical_dead_score,
+    historical_dead_strength: classification.historical_dead_strength,
+    historical_dead_tags: classification.historical_dead_tags,
+  };
+}
 
 export async function runNewsAndEventWatch(context, { startedAt } = {}) {
+  const monitor = 'news-and-event-watch';
   const started_at = startedAt || new Date().toISOString();
+  const findings = [];
+  const errors = [];
+  const entities = context?.canonicalData?.entities || [];
+  const entityIndex = buildEntityIndex(entities);
+
+  if (!NEWS_WATCH_ENABLED) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'low',
+      category: 'news_watch_disabled',
+      title: 'News watch RSS fetching is disabled',
+      summary: 'Set HEI_MONITORING_ENABLE_NEWS_RSS=1 to enable Google News RSS candidate discovery.',
+      recommended_action: 'enable_news_rss_when_ready_for_scheduled_external_checks',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:news_rss_disabled`,
+    }));
+
+    return createMonitorResult({
+      monitor,
+      started_at,
+      finished_at: new Date().toISOString(),
+      findings,
+      candidates: [],
+      errors,
+      extra: {
+        news_summary: {
+          enabled: false,
+          queries: 0,
+          items: 0,
+          candidates: 0,
+        },
+      },
+    });
+  }
+
+  const queries = getNewsQueries();
+  const allItems = [];
+
+  for (const queryMeta of queries) {
+    const result = await fetchGoogleNewsRss(queryMeta);
+    if (result.error) {
+      errors.push(`${queryMeta.query}: ${result.error}`);
+      findings.push(createFinding({
+        monitor,
+        severity: 'medium',
+        category: 'news_rss_fetch_failed',
+        title: `News RSS fetch failed: ${queryMeta.query}`,
+        summary: `${result.url}: ${result.error}`,
+        recommended_action: 'inspect_news_rss_source_or_network',
+        confidence: 'medium',
+        dedupe_key: `${monitor}:rss_failed:${queryMeta.query}`,
+      }));
+      continue;
+    }
+    allItems.push(...result.items);
+  }
+
+  const rawCandidates = groupNewsItemsIntoCandidates(allItems);
+  const candidates = rawCandidates.map((candidate, index) => toCandidateRecord(candidate, entityIndex, context?.runId, index + 1));
+  const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
+  const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity);
+  const missingInHei = candidates.filter((candidate) => !candidate.duplicate_check.matched_existing_entity);
+
+  if (queries.length > 0 && allItems.length === 0) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'news_rss_zero_results',
+      title: 'News RSS returned zero items for all queries',
+      summary: `queries=${queries.length}`,
+      recommended_action: 'inspect_news_rss_source_or_network',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:rss_zero_all`,
+    }));
+  }
+
+  for (const candidate of aCandidates) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'news_event_a_candidate',
+      title: `News/event A candidate: ${candidate.canonical_name}`,
+      summary: candidate.hei_relevance,
+      recommended_action: candidate.next_action,
+      source_urls: candidate.source_urls,
+      confidence: candidate.source_quality === 'high' ? 'high' : 'medium',
+      dedupe_key: `${monitor}:a_candidate:${candidate.canonical_name.toLowerCase()}`,
+    }));
+  }
+
+  if (candidates.length > 0) {
+    const runDate = runDateFromRunId(context?.runId);
+    await writeJsonFile(`${WATCHLIST_AUTO_ROOT}/news-event-candidates-${runDate}.json`, {
+      watchlist_type: 'auto_news_event_candidates',
+      created_at: new Date().toISOString(),
+      purpose: 'Auto-generated news/event candidate output. Not canonical. Requires review before staging/canonical append.',
+      news_summary: {
+        queries: queries.length,
+        items: allItems.length,
+        raw_candidates: rawCandidates.length,
+      },
+      candidates,
+      summary: {
+        total: candidates.length,
+        missing_in_hei: missingInHei.length,
+        matched_existing: matchedExisting.length,
+        A: candidates.filter((candidate) => candidate.candidate_class === 'A').length,
+        B: candidates.filter((candidate) => candidate.candidate_class === 'B').length,
+        C: candidates.filter((candidate) => candidate.candidate_class === 'C').length,
+      },
+    });
+  }
+
   return createMonitorResult({
-    monitor: 'news-and-event-watch',
+    monitor,
     started_at,
     finished_at: new Date().toISOString(),
-    findings: [],
-    candidates: [],
-    errors: [],
+    findings,
+    candidates,
+    errors,
     extra: {
-      note: 'Skeleton monitor. News/RSS, regulatory, incident, suspension, and continuity detection are implemented in later phases.',
+      news_summary: {
+        enabled: true,
+        queries: queries.length,
+        items: allItems.length,
+        candidates: candidates.length,
+        missing_in_hei: missingInHei.length,
+        matched_existing: matchedExisting.length,
+      },
     },
   });
 }

--- a/scripts/monitoring/sources/news-queries.mjs
+++ b/scripts/monitoring/sources/news-queries.mjs
@@ -1,0 +1,94 @@
+const ENABLE_NEWS_RSS = process.env.HEI_MONITORING_ENABLE_NEWS_RSS === '1';
+
+export const NEWS_WATCH_ENABLED = ENABLE_NEWS_RSS;
+
+export const TRUSTED_NEWS_DOMAINS = [
+  'reuters.com',
+  'bloomberg.com',
+  'coindesk.com',
+  'theblock.co',
+  'cointelegraph.com',
+  'techcrunch.com',
+  'sec.gov',
+  'cftc.gov',
+  'fca.org.uk',
+  'fsa.go.jp',
+  'sfc.hk',
+  'mas.gov.sg',
+  'treasury.gov',
+];
+
+export const NEWS_QUERY_GROUPS = [
+  {
+    category: 'shutdown',
+    likely_event_types: ['shutdown_announced', 'shutdown_effective'],
+    queries: [
+      'crypto exchange shuts down',
+      'crypto exchange ceases operations',
+      'crypto exchange wind down',
+      'cryptocurrency exchange service discontinued',
+      'DEX protocol shuts down exchange',
+    ],
+  },
+  {
+    category: 'hack_incident',
+    likely_event_types: ['hack', 'exploit', 'withdrawal_suspended'],
+    queries: [
+      'crypto exchange hacked unauthorized withdrawals',
+      'crypto exchange hot wallet breach',
+      'cryptocurrency exchange exploit withdrawals suspended',
+      'DEX exploit trading halted',
+      'perp DEX exploit',
+    ],
+  },
+  {
+    category: 'withdrawal_deposit_trading_suspension',
+    likely_event_types: ['withdrawal_suspended', 'deposit_suspended', 'trading_halted'],
+    queries: [
+      'crypto exchange suspends withdrawals',
+      'crypto exchange deposits suspended',
+      'crypto exchange trading halted',
+      'exchange users unable to withdraw crypto',
+      'withdrawal only mode crypto exchange',
+    ],
+  },
+  {
+    category: 'regulatory',
+    likely_event_types: ['regulatory_action'],
+    queries: [
+      'crypto exchange regulatory action',
+      'crypto exchange license revoked',
+      'crypto exchange warning list regulator',
+      'crypto exchange regional exit users close accounts',
+      'crypto exchange sanctions enforcement',
+    ],
+  },
+  {
+    category: 'acquisition_migration_rebrand',
+    likely_event_types: ['acquired', 'merged', 'rebranded', 'other'],
+    queries: [
+      'crypto exchange acquired customer migration',
+      'crypto exchange asset transfer users migrated',
+      'crypto exchange rebranded renamed',
+      'crypto exchange merged with',
+      'crypto exchange service migration successor',
+    ],
+  },
+];
+
+export function getNewsQueries() {
+  const maxQueries = Number.parseInt(process.env.HEI_MONITORING_NEWS_QUERY_LIMIT || '20', 10);
+  const queries = [];
+
+  for (const group of NEWS_QUERY_GROUPS) {
+    for (const query of group.queries) {
+      queries.push({
+        query,
+        category: group.category,
+        likely_event_types: group.likely_event_types,
+      });
+    }
+  }
+
+  return queries.slice(0, Number.isFinite(maxQueries) ? maxQueries : 20);
+}


### PR DESCRIPTION
## Summary
- add news query groups for shutdown, hack/incident, withdrawal/deposit/trading suspension, regulatory, and acquisition/migration/rebrand monitoring
- add Google News RSS adapter without third-party dependencies
- add news candidate extraction and grouping helpers
- replace the news-and-event-watch placeholder with a working base that can fetch RSS when explicitly enabled, classify candidates, write auto watchlists, and surface A candidates as findings

## Scope
- no canonical data changes
- news RSS fetching is disabled by default
- scheduled runs will not fetch external news unless `HEI_MONITORING_ENABLE_NEWS_RSS=1` is explicitly set
- this is the base news/event monitor; it does not yet include dedicated regulatory-source scrapers or final noise-control state

## Safety
- generated candidates are written only to `data-staging/watchlists/auto/**`
- canonical data remains protected by the existing monitoring guard

## Notes
- this follows PR #94 by adding the real news/event watch plumbing
- next PRs should add active-status/domain watch, evidence URL health checks, regulatory sources, site/SEO checks, and noise-control state store