### PR TITLE
Add HEI active status and domain watch

### DIFF
--- a/scripts/monitoring/adapters/http-check.mjs
+++ b/scripts/monitoring/adapters/http-check.mjs
@@ -1,0 +1,94 @@
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const PARKING_PATTERNS = [
+  /domain\s+for\s+sale/i,
+  /buy\s+this\s+domain/i,
+  /this\s+domain\s+is\s+for\s+sale/i,
+  /parking/i,
+  /sedo/i,
+  /afternic/i,
+  /dan\.com/i,
+  /hugedomains/i,
+];
+
+function controllerWithTimeout(timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return { controller, timeout };
+}
+
+function normalizeUrl(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  if (/^https?:\/\//i.test(raw)) return raw;
+  return `https://${raw}`;
+}
+
+function classifyStatus({ status, finalUrl, startUrl, body }) {
+  if (status >= 200 && status < 400) {
+    if (PARKING_PATTERNS.some((pattern) => pattern.test(body || ''))) return 'parked_or_for_sale';
+    if (finalUrl && startUrl && finalUrl !== startUrl) return 'redirected';
+    return 'ok';
+  }
+  if (status === 404 || status === 410) return 'not_found';
+  if (status >= 500) return 'server_error';
+  return 'http_error';
+}
+
+export async function checkHttpUrl(urlLike, options = {}) {
+  const url = normalizeUrl(urlLike);
+  if (!url) {
+    return {
+      input_url: urlLike,
+      normalized_url: null,
+      status: 'unchecked',
+      http_status: null,
+      final_url: null,
+      error: 'empty_url',
+    };
+  }
+
+  const { controller, timeout } = controllerWithTimeout(options.timeoutMs || DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'user-agent': 'HEI-Monitoring/0.1' },
+    });
+    const contentType = response.headers.get('content-type') || '';
+    let body = '';
+    if (/text|html|xml|json/i.test(contentType)) {
+      body = (await response.text()).slice(0, options.maxBodyChars || 20000);
+    }
+
+    return {
+      input_url: urlLike,
+      normalized_url: url,
+      status: classifyStatus({ status: response.status, finalUrl: response.url, startUrl: url, body }),
+      http_status: response.status,
+      final_url: response.url,
+      content_type: contentType,
+      error: null,
+    };
+  } catch (error) {
+    const message = error?.message || String(error);
+    let status = 'server_error';
+    if (/ENOTFOUND|getaddrinfo|Name or service not known|fetch failed/i.test(message)) status = 'dns_failure';
+    if (/certificate|SSL|TLS/i.test(message)) status = 'tls_failure';
+    if (/aborted|timeout/i.test(message)) status = 'timeout';
+
+    return {
+      input_url: urlLike,
+      normalized_url: url,
+      status,
+      http_status: null,
+      final_url: null,
+      content_type: null,
+      error: message,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/scripts/monitoring/monitors/active-status-watch.mjs
+++ b/scripts/monitoring/monitors/active-status-watch.mjs
@@ -1,16 +1,133 @@
-import { createMonitorResult } from '../core/finding-utils.mjs';
+import { ACTIVE_SIDE_STATUSES } from '../core/constants.mjs';
+import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+import { checkHttpUrl } from '../adapters/http-check.mjs';
+
+const ENABLE_DOMAIN_CHECKS = process.env.HEI_MONITORING_ENABLE_DOMAIN_CHECKS === '1';
+const DEFAULT_LIMIT = 50;
+
+function getCheckLimit() {
+  const parsed = Number.parseInt(process.env.HEI_MONITORING_DOMAIN_CHECK_LIMIT || String(DEFAULT_LIMIT), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMIT;
+}
+
+function entityUrl(entity) {
+  return entity.official_url_original || entity.official_domain_original || null;
+}
+
+function activeSideEntities(entities = []) {
+  return entities
+    .filter((entity) => ACTIVE_SIDE_STATUSES.includes(entity.status))
+    .filter((entity) => entityUrl(entity))
+    .sort((a, b) => String(a.slug || '').localeCompare(String(b.slug || '')));
+}
+
+function severityForCheck(entity, check) {
+  if (['dns_failure', 'tls_failure', 'parked_or_for_sale'].includes(check.status)) return entity.status === 'active' ? 'high' : 'medium';
+  if (['not_found', 'server_error', 'timeout'].includes(check.status)) return entity.status === 'active' ? 'medium' : 'low';
+  if (check.status === 'redirected') return 'low';
+  return 'low';
+}
+
+function actionForCheck(check) {
+  if (check.status === 'parked_or_for_sale') return 'investigate_active_status_and_domain_repurpose';
+  if (check.status === 'dns_failure') return 'investigate_active_to_inactive_candidate';
+  if (check.status === 'tls_failure') return 'review_official_site_tls_status';
+  if (check.status === 'not_found') return 'review_official_url_or_archive';
+  if (check.status === 'server_error' || check.status === 'timeout') return 'recheck_before_status_change';
+  if (check.status === 'redirected') return 'review_redirect_target';
+  return 'review';
+}
 
 export async function runActiveStatusWatch(context, { startedAt } = {}) {
+  const monitor = 'active-status-watch';
   const started_at = startedAt || new Date().toISOString();
+  const findings = [];
+  const errors = [];
+  const entities = context?.canonicalData?.entities || [];
+  const targets = activeSideEntities(entities);
+
+  if (!ENABLE_DOMAIN_CHECKS) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'low',
+      category: 'domain_watch_disabled',
+      title: 'Official site/domain checks are disabled',
+      summary: 'Set HEI_MONITORING_ENABLE_DOMAIN_CHECKS=1 to enable active-side official URL checks.',
+      recommended_action: 'enable_domain_checks_when_ready_for_scheduled_external_checks',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:domain_checks_disabled`,
+    }));
+
+    return createMonitorResult({
+      monitor,
+      started_at,
+      finished_at: new Date().toISOString(),
+      findings,
+      candidates: [],
+      errors,
+      extra: {
+        active_status_summary: {
+          enabled: false,
+          active_side_entities_with_urls: targets.length,
+          checked: 0,
+        },
+      },
+    });
+  }
+
+  const limit = getCheckLimit();
+  const selected = targets.slice(0, limit);
+  const checks = [];
+
+  for (const entity of selected) {
+    const url = entityUrl(entity);
+    const check = await checkHttpUrl(url);
+    checks.push({
+      entity_id: entity.id,
+      slug: entity.slug,
+      canonical_name: entity.canonical_name,
+      status: entity.status,
+      official_url: url,
+      check,
+    });
+
+    if (check.status !== 'ok') {
+      const severity = severityForCheck(entity, check);
+      findings.push(createFinding({
+        monitor,
+        severity,
+        category: `official_site_${check.status}`,
+        title: `Official site check ${check.status}: ${entity.canonical_name}`,
+        summary: `${entity.id} ${url} -> ${check.status}${check.http_status ? ` HTTP ${check.http_status}` : ''}${check.error ? ` error=${check.error}` : ''}`,
+        affected_entity: {
+          matched_existing_entity: true,
+          id: entity.id,
+          slug: entity.slug,
+          canonical_name: entity.canonical_name,
+        },
+        recommended_action: actionForCheck(check),
+        source_urls: [url].filter(Boolean),
+        confidence: severity === 'high' ? 'medium' : 'low',
+        dedupe_key: `${monitor}:official_site_${check.status}:${entity.id}`,
+      }));
+    }
+  }
+
   return createMonitorResult({
-    monitor: 'active-status-watch',
+    monitor,
     started_at,
     finished_at: new Date().toISOString(),
-    findings: [],
+    findings,
     candidates: [],
-    errors: [],
+    errors,
     extra: {
-      note: 'Skeleton monitor. Official site/domain checks and active status-change candidates are implemented in later phases.',
+      active_status_summary: {
+        enabled: true,
+        active_side_entities_with_urls: targets.length,
+        checked: selected.length,
+        findings: findings.length,
+      },
+      official_site_checks: checks,
     },
   });
 }


### PR DESCRIPTION
## Summary
- add reusable HTTP check adapter for monitoring URL/domain status
- replace active-status-watch placeholder with active-side official site/domain checks
- detect ok, redirected, not_found, server_error, dns_failure, tls_failure, timeout, and parked_or_for_sale statuses
- report active/limited/inactive official-site anomalies as findings with recommended actions
- include official_site_checks and active_status_summary in the monitor output

## Scope
- no canonical data changes
- domain checks are disabled by default
- scheduled runs will not fetch external URLs unless `HEI_MONITORING_ENABLE_DOMAIN_CHECKS=1` is explicitly set
- this is official-site/domain monitoring base, not final repeated-failure state tracking

## Safety
- monitoring output remains report-only
- canonical data remains protected by the existing monitoring guard

## Notes
- this follows PR #95 by adding active-status / official-site-domain watch base
- next PRs should add evidence URL health checks, regulatory sources, site/SEO checks, and noise-control state store