### PR TITLE
Add HEI regulatory source watch

### DIFF
--- a/scripts/monitoring/core/news-extract.mjs
+++ b/scripts/monitoring/core/news-extract.mjs
@@ -59,7 +59,7 @@ function domainFromUrl(value) {
 function sourceQuality(item) {
   const domains = [domainFromUrl(item.url), domainFromUrl(item.source_url)].filter(Boolean);
   const trusted = domains.some((domain) => TRUSTED_NEWS_DOMAINS.some((trustedDomain) => domain === trustedDomain || domain.endsWith(`.${trustedDomain}`)));
-  if (trusted) return 'high';
+  if (trusted || item.source_category === 'regulatory_source') return 'high';
   if (item.source_name && item.source_name !== 'unknown') return 'medium';
   return 'low';
 }
@@ -69,7 +69,7 @@ export function inferEventCategory(textValue, fallbackCategory = 'unknown') {
   if (/\b(shutdown|shut down|closed|closure|cease operations|ceased operations|wind down|service ended|service discontinued)\b/.test(text)) return 'shutdown';
   if (/\b(hack|hacked|exploit|breach|unauthorized withdrawal|hot wallet|stolen|drained|suspicious outflows)\b/.test(text)) return 'hack_incident';
   if (/\b(withdrawals suspended|deposits suspended|trading halted|paused withdrawals|halted trading|withdrawal only|close only)\b/.test(text)) return 'withdrawal_deposit_trading_suspension';
-  if (/\b(regulatory|license revoked|license withdrawn|warning list|sanction|enforcement|regional exit|cease and desist)\b/.test(text)) return 'regulatory';
+  if (/\b(regulatory|license revoked|license withdrawn|warning list|sanction|enforcement|regional exit|cease and desist|registration cancelled|registration canceled)\b/.test(text)) return 'regulatory';
   if (/\b(acquired|acquisition|merged|merger|rebranded|renamed|customer transfer|asset transfer|migration|successor)\b/.test(text)) return 'acquisition_migration_rebrand';
   return fallbackCategory;
 }
@@ -79,7 +79,7 @@ export function extractCandidateNameFromNews(item) {
   const patterns = [
     /\b(?:exchange|platform|protocol|DEX)\s+([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\b/,
     /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\s+(?:exchange|DEX|protocol|platform)\b/,
-    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2})\s+(?:shuts down|ceases operations|halts trading|suspends withdrawals|is hacked|was hacked|rebrands|is acquired)\b/,
+    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2})\s+(?:shuts down|ceases operations|halts trading|suspends withdrawals|is hacked|was hacked|rebrands|is acquired|warning|enforcement action|sanctioned)\b/,
   ];
 
   for (const pattern of patterns) {
@@ -109,6 +109,10 @@ export function groupNewsItemsIntoCandidates(items) {
       source_names: [],
       query_categories: new Set(),
       likely_event_types: new Set(),
+      source_categories: new Set(),
+      regulatory_authorities: new Set(),
+      regulatory_regions: new Set(),
+      regulatory_signals: new Set(),
       source_quality: 'low',
     };
 
@@ -117,6 +121,10 @@ export function groupNewsItemsIntoCandidates(items) {
     existing.snippets.push(item.snippet);
     existing.source_names.push(item.source_name);
     existing.query_categories.add(inferEventCategory(`${item.title} ${item.snippet}`, item.query_category));
+    existing.source_categories.add(item.source_category || 'news_event');
+    if (item.regulatory_authority) existing.regulatory_authorities.add(item.regulatory_authority);
+    if (item.regulatory_region) existing.regulatory_regions.add(item.regulatory_region);
+    if (item.regulatory_signal) existing.regulatory_signals.add(item.regulatory_signal);
     for (const eventType of item.likely_event_types || []) existing.likely_event_types.add(eventType);
     const quality = sourceQuality(item);
     if (quality === 'high' || (quality === 'medium' && existing.source_quality === 'low')) existing.source_quality = quality;
@@ -125,6 +133,7 @@ export function groupNewsItemsIntoCandidates(items) {
 
   return [...grouped.values()].map((candidate) => {
     const categories = [...candidate.query_categories];
+    const sourceCategories = [...candidate.source_categories];
     return {
       canonical_name: candidate.canonical_name,
       aliases: uniqueStrings(candidate.aliases),
@@ -133,15 +142,20 @@ export function groupNewsItemsIntoCandidates(items) {
       source_urls: uniqueStrings(candidate.source_urls).slice(0, 8),
       source_quality: candidate.source_quality,
       source_name: uniqueStrings(candidate.source_names).join(', '),
-      source_category: 'news_event',
+      source_category: sourceCategories.includes('regulatory_source') ? 'regulatory_source' : 'news_event',
       likely_type: categories.some((category) => String(category).includes('dex')) ? 'dex' : 'unknown',
       signals: uniqueStrings([
-        'news/event watch',
+        sourceCategories.includes('regulatory_source') ? 'regulatory source watch' : 'news/event watch',
         ...categories,
+        ...sourceCategories,
         ...[...candidate.likely_event_types].map((eventType) => `event:${eventType}`),
+        ...[...candidate.regulatory_signals].map((signal) => `regulatory:${signal}`),
       ]),
       news_event_categories: categories,
       likely_event_types: [...candidate.likely_event_types],
+      regulatory_authorities: [...candidate.regulatory_authorities],
+      regulatory_regions: [...candidate.regulatory_regions],
+      regulatory_signals: [...candidate.regulatory_signals],
     };
   });
 }

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -24,6 +24,8 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   const candidates = flattenCandidates(results);
   const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
   const bCandidates = candidates.filter((candidate) => candidate.candidate_class === 'B');
+  const regulatoryCandidates = candidates.filter((candidate) => candidate.source_category === 'regulatory_source');
+  const regulatoryFindings = findings.filter((finding) => finding.monitor === 'news-and-event-watch' && finding.category?.includes('regulatory'));
   const criticalHigh = findings.filter((finding) => ['critical', 'high'].includes(finding.severity));
   const dataQuality = findings.filter((finding) => finding.monitor === 'evidence-and-record-quality-watch');
   const evidenceHealthFindings = findings.filter((finding) => finding.monitor === 'evidence-health-watch');
@@ -31,8 +33,10 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   const watchlistFindings = findings.filter((finding) => finding.monitor === 'monitoring-health-watch' && finding.category?.includes('watchlist'));
   const monitoringHealth = findResult(results, 'monitoring-health-watch');
   const evidenceHealth = findResult(results, 'evidence-health-watch');
+  const newsAndEvent = findResult(results, 'news-and-event-watch');
   const watchlistState = monitoringHealth?.watchlist_state || null;
   const evidenceHealthSummary = evidenceHealth?.evidence_health_summary || null;
+  const regulatorySummary = newsAndEvent?.regulatory_summary || null;
 
   const severityCounts = Object.fromEntries(SEVERITIES.map((severity) => [severity, 0]));
   for (const finding of findings) {
@@ -50,6 +54,9 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   }
   if (bCandidates.length) {
     suggestedActions.push('Keep B candidates in watchlist or downgrade/resolve them after review.');
+  }
+  if (regulatoryCandidates.length || regulatoryFindings.length) {
+    suggestedActions.push('Review regulatory-source candidates separately and avoid status/death_reason changes without source confirmation.');
   }
   if (watchlistFindings.length) {
     suggestedActions.push('Review watchlist-state findings and update staging or resolution files as needed.');
@@ -92,6 +99,14 @@ ${sectionList(bCandidates, (candidate) => `- ${candidate.canonical_name || candi
 ## Critical / high alerts
 
 ${sectionList(criticalHigh, (finding) => `- [${finding.severity}] ${finding.title} (${finding.monitor}) — ${finding.recommended_action || 'review'}`)}
+
+## Regulatory watch
+
+${regulatorySummary ? `- enabled: ${regulatorySummary.enabled}\n- authorities_configured: ${regulatorySummary.authorities_configured}\n- query_templates: ${regulatorySummary.query_templates}\n- queries: ${regulatorySummary.queries}\n- items: ${regulatorySummary.items}\n- candidates: ${regulatorySummary.candidates}` : '- Not available.'}
+
+${sectionList(regulatoryCandidates, (candidate) => `- [${candidate.candidate_class}] ${candidate.canonical_name || candidate.headline || candidate.candidate_id} — ${(candidate.regulatory_authorities || []).join(', ') || candidate.source_name || 'regulatory source'} — ${candidate.next_action || 'review'}`)}
+
+${sectionList(regulatoryFindings, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
 
 ## Data quality
 

--- a/scripts/monitoring/monitors/news-and-event-watch.mjs
+++ b/scripts/monitoring/monitors/news-and-event-watch.mjs
@@ -5,6 +5,7 @@ import { slugifyName, uniqueStrings } from '../core/normalize.mjs';
 import { buildEntityIndex, duplicateCheckForCandidate } from '../core/dedupe.mjs';
 import { classifyCandidate } from '../core/classify.mjs';
 import { NEWS_WATCH_ENABLED, getNewsQueries } from '../sources/news-queries.mjs';
+import { REGULATORY_WATCH_ENABLED, getRegulatoryQueries, getRegulatorySourceSummary } from '../sources/regulatory-sources.mjs';
 import { fetchGoogleNewsRss } from '../adapters/rss-google-news.mjs';
 import { groupNewsItemsIntoCandidates } from '../core/news-extract.mjs';
 
@@ -51,10 +52,48 @@ function toCandidateRecord(rawItem, index, runId, ordinal) {
     source_category: base.source_category,
     likely_event_types: rawItem.likely_event_types || [],
     news_event_categories: rawItem.news_event_categories || [],
+    regulatory_authorities: rawItem.regulatory_authorities || [],
+    regulatory_regions: rawItem.regulatory_regions || [],
+    regulatory_signals: rawItem.regulatory_signals || [],
     historical_dead_score: classification.historical_dead_score,
     historical_dead_strength: classification.historical_dead_strength,
     historical_dead_tags: classification.historical_dead_tags,
   };
+}
+
+async function fetchQueryGroup({ monitor, queryMetas, findings, errors }) {
+  const items = [];
+
+  for (const queryMeta of queryMetas) {
+    const result = await fetchGoogleNewsRss(queryMeta);
+    if (result.error) {
+      errors.push(`${queryMeta.query}: ${result.error}`);
+      findings.push(createFinding({
+        monitor,
+        severity: 'medium',
+        category: queryMeta.source_category === 'regulatory_source' ? 'regulatory_rss_fetch_failed' : 'news_rss_fetch_failed',
+        title: `${queryMeta.source_category === 'regulatory_source' ? 'Regulatory RSS' : 'News RSS'} fetch failed: ${queryMeta.query}`,
+        summary: `${result.url}: ${result.error}`,
+        recommended_action: queryMeta.source_category === 'regulatory_source' ? 'inspect_regulatory_source_query_or_network' : 'inspect_news_rss_source_or_network',
+        confidence: 'medium',
+        dedupe_key: `${monitor}:rss_failed:${queryMeta.query}`,
+      }));
+      continue;
+    }
+
+    items.push(...result.items.map((item) => ({
+      ...item,
+      source_category: queryMeta.source_category || 'news_event',
+      regulatory_authority: queryMeta.regulatory_authority || null,
+      regulatory_authority_short_name: queryMeta.regulatory_authority_short_name || null,
+      regulatory_authority_id: queryMeta.regulatory_authority_id || null,
+      regulatory_region: queryMeta.regulatory_region || null,
+      regulatory_domain: queryMeta.regulatory_domain || null,
+      regulatory_signal: queryMeta.regulatory_signal || null,
+    })));
+  }
+
+  return items;
 }
 
 export async function runNewsAndEventWatch(context, { startedAt } = {}) {
@@ -64,17 +103,18 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
   const errors = [];
   const entities = context?.canonicalData?.entities || [];
   const entityIndex = buildEntityIndex(entities);
+  const regulatorySourceSummary = getRegulatorySourceSummary();
 
-  if (!NEWS_WATCH_ENABLED) {
+  if (!NEWS_WATCH_ENABLED && !REGULATORY_WATCH_ENABLED) {
     findings.push(createFinding({
       monitor,
       severity: 'low',
-      category: 'news_watch_disabled',
-      title: 'News watch RSS fetching is disabled',
-      summary: 'Set HEI_MONITORING_ENABLE_NEWS_RSS=1 to enable Google News RSS candidate discovery.',
-      recommended_action: 'enable_news_rss_when_ready_for_scheduled_external_checks',
+      category: 'news_and_regulatory_watch_disabled',
+      title: 'News and regulatory RSS fetching is disabled',
+      summary: 'Set HEI_MONITORING_ENABLE_NEWS_RSS=1 and/or HEI_MONITORING_ENABLE_REGULATORY_WATCH=1 to enable external RSS candidate discovery.',
+      recommended_action: 'enable_external_rss_checks_when_ready_for_scheduled_external_checks',
       confidence: 'medium',
-      dedupe_key: `${monitor}:news_rss_disabled`,
+      dedupe_key: `${monitor}:news_and_regulatory_disabled`,
     }));
 
     return createMonitorResult({
@@ -91,48 +131,52 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
           items: 0,
           candidates: 0,
         },
+        regulatory_summary: {
+          ...regulatorySourceSummary,
+          queries: 0,
+          items: 0,
+          candidates: 0,
+        },
       },
     });
   }
 
-  const queries = getNewsQueries();
-  const allItems = [];
-
-  for (const queryMeta of queries) {
-    const result = await fetchGoogleNewsRss(queryMeta);
-    if (result.error) {
-      errors.push(`${queryMeta.query}: ${result.error}`);
-      findings.push(createFinding({
-        monitor,
-        severity: 'medium',
-        category: 'news_rss_fetch_failed',
-        title: `News RSS fetch failed: ${queryMeta.query}`,
-        summary: `${result.url}: ${result.error}`,
-        recommended_action: 'inspect_news_rss_source_or_network',
-        confidence: 'medium',
-        dedupe_key: `${monitor}:rss_failed:${queryMeta.query}`,
-      }));
-      continue;
-    }
-    allItems.push(...result.items);
-  }
+  const newsQueries = NEWS_WATCH_ENABLED ? getNewsQueries() : [];
+  const regulatoryQueries = REGULATORY_WATCH_ENABLED ? getRegulatoryQueries() : [];
+  const newsItems = await fetchQueryGroup({ monitor, queryMetas: newsQueries, findings, errors });
+  const regulatoryItems = await fetchQueryGroup({ monitor, queryMetas: regulatoryQueries, findings, errors });
+  const allItems = [...newsItems, ...regulatoryItems];
 
   const rawCandidates = groupNewsItemsIntoCandidates(allItems);
   const candidates = rawCandidates.map((candidate, index) => toCandidateRecord(candidate, entityIndex, context?.runId, index + 1));
   const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
+  const regulatoryCandidates = candidates.filter((candidate) => candidate.source_category === 'regulatory_source');
   const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity);
   const missingInHei = candidates.filter((candidate) => !candidate.duplicate_check.matched_existing_entity);
 
-  if (queries.length > 0 && allItems.length === 0) {
+  if (newsQueries.length > 0 && newsItems.length === 0) {
     findings.push(createFinding({
       monitor,
       severity: 'high',
       category: 'news_rss_zero_results',
       title: 'News RSS returned zero items for all queries',
-      summary: `queries=${queries.length}`,
+      summary: `queries=${newsQueries.length}`,
       recommended_action: 'inspect_news_rss_source_or_network',
       confidence: 'medium',
-      dedupe_key: `${monitor}:rss_zero_all`,
+      dedupe_key: `${monitor}:rss_zero_news`,
+    }));
+  }
+
+  if (regulatoryQueries.length > 0 && regulatoryItems.length === 0) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'regulatory_rss_zero_results',
+      title: 'Regulatory RSS returned zero items for all queries',
+      summary: `queries=${regulatoryQueries.length}`,
+      recommended_action: 'inspect_regulatory_source_queries_or_network',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:rss_zero_regulatory`,
     }));
   }
 
@@ -140,13 +184,13 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
     findings.push(createFinding({
       monitor,
       severity: 'high',
-      category: 'news_event_a_candidate',
-      title: `News/event A candidate: ${candidate.canonical_name}`,
+      category: candidate.source_category === 'regulatory_source' ? 'regulatory_a_candidate' : 'news_event_a_candidate',
+      title: `${candidate.source_category === 'regulatory_source' ? 'Regulatory' : 'News/event'} A candidate: ${candidate.canonical_name}`,
       summary: candidate.hei_relevance,
       recommended_action: candidate.next_action,
       source_urls: candidate.source_urls,
       confidence: candidate.source_quality === 'high' ? 'high' : 'medium',
-      dedupe_key: `${monitor}:a_candidate:${candidate.canonical_name.toLowerCase()}`,
+      dedupe_key: `${monitor}:a_candidate:${candidate.source_category}:${candidate.canonical_name.toLowerCase()}`,
     }));
   }
 
@@ -155,17 +199,24 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
     await writeJsonFile(`${WATCHLIST_AUTO_ROOT}/news-event-candidates-${runDate}.json`, {
       watchlist_type: 'auto_news_event_candidates',
       created_at: new Date().toISOString(),
-      purpose: 'Auto-generated news/event candidate output. Not canonical. Requires review before staging/canonical append.',
+      purpose: 'Auto-generated news/regulatory/event candidate output. Not canonical. Requires review before staging/canonical append.',
       news_summary: {
-        queries: queries.length,
-        items: allItems.length,
-        raw_candidates: rawCandidates.length,
+        enabled: NEWS_WATCH_ENABLED,
+        queries: newsQueries.length,
+        items: newsItems.length,
+      },
+      regulatory_summary: {
+        ...regulatorySourceSummary,
+        queries: regulatoryQueries.length,
+        items: regulatoryItems.length,
+        raw_candidates: regulatoryCandidates.length,
       },
       candidates,
       summary: {
         total: candidates.length,
         missing_in_hei: missingInHei.length,
         matched_existing: matchedExisting.length,
+        regulatory_candidates: regulatoryCandidates.length,
         A: candidates.filter((candidate) => candidate.candidate_class === 'A').length,
         B: candidates.filter((candidate) => candidate.candidate_class === 'B').length,
         C: candidates.filter((candidate) => candidate.candidate_class === 'C').length,
@@ -182,8 +233,18 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
     errors,
     extra: {
       news_summary: {
-        enabled: true,
-        queries: queries.length,
+        enabled: NEWS_WATCH_ENABLED,
+        queries: newsQueries.length,
+        items: newsItems.length,
+        candidates: candidates.length - regulatoryCandidates.length,
+      },
+      regulatory_summary: {
+        ...regulatorySourceSummary,
+        queries: regulatoryQueries.length,
+        items: regulatoryItems.length,
+        candidates: regulatoryCandidates.length,
+      },
+      combined_summary: {
         items: allItems.length,
         candidates: candidates.length,
         missing_in_hei: missingInHei.length,

--- a/scripts/monitoring/sources/regulatory-sources.mjs
+++ b/scripts/monitoring/sources/regulatory-sources.mjs
@@ -1,0 +1,126 @@
+const ENABLE_REGULATORY_WATCH = process.env.HEI_MONITORING_ENABLE_REGULATORY_WATCH === '1';
+
+export const REGULATORY_WATCH_ENABLED = ENABLE_REGULATORY_WATCH;
+
+export const REGULATORY_AUTHORITIES = [
+  {
+    authority_id: 'us-sec',
+    name: 'U.S. Securities and Exchange Commission',
+    short_name: 'SEC',
+    country_or_region: 'United States',
+    domain: 'sec.gov',
+  },
+  {
+    authority_id: 'us-cftc',
+    name: 'Commodity Futures Trading Commission',
+    short_name: 'CFTC',
+    country_or_region: 'United States',
+    domain: 'cftc.gov',
+  },
+  {
+    authority_id: 'uk-fca',
+    name: 'Financial Conduct Authority',
+    short_name: 'FCA',
+    country_or_region: 'United Kingdom',
+    domain: 'fca.org.uk',
+  },
+  {
+    authority_id: 'jp-fsa',
+    name: 'Financial Services Agency',
+    short_name: 'JFSA',
+    country_or_region: 'Japan',
+    domain: 'fsa.go.jp',
+  },
+  {
+    authority_id: 'hk-sfc',
+    name: 'Securities and Futures Commission',
+    short_name: 'SFC Hong Kong',
+    country_or_region: 'Hong Kong',
+    domain: 'sfc.hk',
+  },
+  {
+    authority_id: 'sg-mas',
+    name: 'Monetary Authority of Singapore',
+    short_name: 'MAS',
+    country_or_region: 'Singapore',
+    domain: 'mas.gov.sg',
+  },
+  {
+    authority_id: 'us-ofac',
+    name: 'Office of Foreign Assets Control',
+    short_name: 'OFAC',
+    country_or_region: 'United States',
+    domain: 'treasury.gov',
+  },
+];
+
+export const REGULATORY_QUERY_TEMPLATES = [
+  {
+    query_template: 'site:{domain} crypto exchange warning',
+    category: 'regulatory',
+    likely_event_types: ['regulatory_action'],
+    signal: 'warning_list',
+  },
+  {
+    query_template: 'site:{domain} crypto exchange enforcement action',
+    category: 'regulatory',
+    likely_event_types: ['regulatory_action', 'lawsuit'],
+    signal: 'enforcement_action',
+  },
+  {
+    query_template: 'site:{domain} virtual asset service provider exchange warning',
+    category: 'regulatory',
+    likely_event_types: ['regulatory_action'],
+    signal: 'vasp_warning',
+  },
+  {
+    query_template: 'site:{domain} crypto exchange license revoked OR registration cancelled',
+    category: 'regulatory',
+    likely_event_types: ['regulatory_action', 'shutdown_announced'],
+    signal: 'license_or_registration_removed',
+  },
+  {
+    query_template: 'site:{domain} crypto exchange sanctions OR sanctioned',
+    category: 'regulatory',
+    likely_event_types: ['regulatory_action'],
+    signal: 'sanctions',
+  },
+];
+
+function renderQuery(template, authority) {
+  return template.replaceAll('{domain}', authority.domain);
+}
+
+export function getRegulatoryQueries() {
+  const maxAuthorities = Number.parseInt(process.env.HEI_MONITORING_REGULATORY_AUTHORITY_LIMIT || String(REGULATORY_AUTHORITIES.length), 10);
+  const maxQueries = Number.parseInt(process.env.HEI_MONITORING_REGULATORY_QUERY_LIMIT || '25', 10);
+  const authorities = REGULATORY_AUTHORITIES.slice(0, Number.isFinite(maxAuthorities) ? maxAuthorities : REGULATORY_AUTHORITIES.length);
+  const queries = [];
+
+  for (const authority of authorities) {
+    for (const template of REGULATORY_QUERY_TEMPLATES) {
+      queries.push({
+        query: renderQuery(template.query_template, authority),
+        category: template.category,
+        likely_event_types: template.likely_event_types,
+        source_category: 'regulatory_source',
+        regulatory_authority: authority.name,
+        regulatory_authority_short_name: authority.short_name,
+        regulatory_authority_id: authority.authority_id,
+        regulatory_region: authority.country_or_region,
+        regulatory_domain: authority.domain,
+        regulatory_signal: template.signal,
+      });
+    }
+  }
+
+  return queries.slice(0, Number.isFinite(maxQueries) ? maxQueries : 25);
+}
+
+export function getRegulatorySourceSummary() {
+  return {
+    enabled: REGULATORY_WATCH_ENABLED,
+    authorities_configured: REGULATORY_AUTHORITIES.length,
+    query_templates: REGULATORY_QUERY_TEMPLATES.length,
+  };
+}


### PR DESCRIPTION
## Summary
- add regulatory source query configuration for SEC, CFTC, FCA, JFSA, Hong Kong SFC, MAS, and OFAC/Treasury
- add optional regulatory watch gated by `HEI_MONITORING_ENABLE_REGULATORY_WATCH=1`
- reuse the existing Google News RSS adapter for site-scoped regulatory queries
- preserve regulatory metadata on candidates, including authority, region, and regulatory signal
- surface regulatory candidates/findings in `summary.md`

## Scope
- no canonical data changes
- regulatory fetching is disabled by default
- scheduled runs will not fetch regulatory RSS queries unless `HEI_MONITORING_ENABLE_REGULATORY_WATCH=1` is explicitly set
- this is source/watch plumbing only; it does not auto-change status, death_reason, or canonical records

## Safety
- generated candidates remain report/watchlist-only
- canonical data remains protected by the existing monitoring guard
- regulatory findings must be reviewed separately before staging or canonical changes

## Notes
- this follows PR #97 by adding dedicated regulatory-source watch plumbing
- next PRs should add site/SEO checks and then noise-control/state store