### PR TITLE
Add HEI site and SEO monitoring checks

### DIFF
--- a/scripts/monitoring/adapters/sitemap-check.mjs
+++ b/scripts/monitoring/adapters/sitemap-check.mjs
@@ -1,0 +1,65 @@
+import { checkHttpUrl } from './http-check.mjs';
+
+function decodeXml(value) {
+  return String(value || '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+function extractLocs(xml) {
+  return [...String(xml || '').matchAll(/<loc>([\s\S]*?)<\/loc>/gi)]
+    .map((match) => decodeXml(match[1]))
+    .filter(Boolean);
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, {
+    headers: { 'user-agent': 'HEI-Monitoring/0.1' },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  return response.text();
+}
+
+export async function checkSitemap({ sitemapUrl, siteUrl, entities = [], requiredStaticRoutes = [] }) {
+  const health = await checkHttpUrl(sitemapUrl, { timeoutMs: 15000, maxBodyChars: 2000 });
+  if (health.status !== 'ok') {
+    return {
+      sitemap_url: sitemapUrl,
+      status: health.status,
+      http_status: health.http_status,
+      error: health.error,
+      urls: [],
+      expected_exchange_routes: entities.length,
+      actual_exchange_routes: 0,
+      missing_static_routes: requiredStaticRoutes,
+    };
+  }
+
+  const xml = await fetchText(sitemapUrl);
+  const urls = extractLocs(xml);
+  const normalizedSiteUrl = String(siteUrl || '').replace(/\/+$/, '');
+  const exchangePrefix = `${normalizedSiteUrl}/exchange/`;
+  const actualExchangeRoutes = urls.filter((url) => url.startsWith(exchangePrefix)).length;
+  const missingStaticRoutes = requiredStaticRoutes.filter((route) => {
+    const normalizedRoute = route === '/' ? '/' : route.replace(/\/+$/, '');
+    const expected = normalizedRoute === '/' ? `${normalizedSiteUrl}/` : `${normalizedSiteUrl}${normalizedRoute}`;
+    return !urls.includes(expected);
+  });
+
+  return {
+    sitemap_url: sitemapUrl,
+    status: 'ok',
+    http_status: 200,
+    error: null,
+    urls,
+    expected_exchange_routes: entities.length,
+    actual_exchange_routes: actualExchangeRoutes,
+    missing_static_routes: missingStaticRoutes,
+  };
+}

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -34,9 +34,11 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   const monitoringHealth = findResult(results, 'monitoring-health-watch');
   const evidenceHealth = findResult(results, 'evidence-health-watch');
   const newsAndEvent = findResult(results, 'news-and-event-watch');
+  const siteAndSeo = findResult(results, 'site-and-seo-watch');
   const watchlistState = monitoringHealth?.watchlist_state || null;
   const evidenceHealthSummary = evidenceHealth?.evidence_health_summary || null;
   const regulatorySummary = newsAndEvent?.regulatory_summary || null;
+  const siteSeoSummary = siteAndSeo?.site_seo_summary || null;
 
   const severityCounts = Object.fromEntries(SEVERITIES.map((severity) => [severity, 0]));
   for (const finding of findings) {
@@ -63,6 +65,9 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
   }
   if (evidenceHealthFindings.some((finding) => ['critical', 'high', 'medium'].includes(finding.severity))) {
     suggestedActions.push('Review evidence-health findings and add archives or replacement evidence where needed.');
+  }
+  if (siteSeo.some((finding) => ['critical', 'high', 'medium'].includes(finding.severity))) {
+    suggestedActions.push('Review site/SEO findings and inspect deploy, sitemap, robots, or route generation.');
   }
   if (!suggestedActions.length) {
     suggestedActions.push('No operator action required.');
@@ -125,6 +130,8 @@ ${watchlistState ? `- watchlist_files: ${watchlistState.watchlist_files}\n- watc
 ${sectionList(watchlistFindings, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
 
 ## Site / SEO
+
+${siteSeoSummary ? `- enabled: ${siteSeoSummary.enabled}\n- site_url: ${siteSeoSummary.site_url}\n- routes_checked: ${siteSeoSummary.routes_checked}\n- route_findings: ${siteSeoSummary.route_findings || 0}\n- sitemap_checked: ${siteSeoSummary.sitemap_checked}\n- sitemap_status: ${siteSeoSummary.sitemap_status}\n- sitemap_exchange_routes_expected: ${siteSeoSummary.sitemap_exchange_routes_expected || 0}\n- sitemap_exchange_routes_actual: ${siteSeoSummary.sitemap_exchange_routes_actual || 0}\n- robots_checked: ${siteSeoSummary.robots_checked}\n- robots_status: ${siteSeoSummary.robots_status || 'not_checked'}` : '- Not available.'}
 
 ${sectionList(siteSeo, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
 

--- a/scripts/monitoring/monitors/site-and-seo-watch.mjs
+++ b/scripts/monitoring/monitors/site-and-seo-watch.mjs
@@ -1,16 +1,201 @@
-import { createMonitorResult } from '../core/finding-utils.mjs';
+import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
+import { checkHttpUrl } from '../adapters/http-check.mjs';
+import { checkSitemap } from '../adapters/sitemap-check.mjs';
+import {
+  SITE_SEO_WATCH_ENABLED,
+  MONITORING_SITE_URL,
+  REQUIRED_SITEMAP_STATIC_ROUTES,
+  getRouteCheckTargets,
+  getRobotsUrl,
+  getSitemapUrl,
+} from '../sources/site-routes.mjs';
+
+function severityForRoute(check) {
+  if (check.status === 'ok' || check.status === 'redirected') return 'low';
+  if (['not_found', 'server_error', 'dns_failure', 'tls_failure', 'timeout'].includes(check.status)) return 'critical';
+  return 'high';
+}
+
+function routeAction(check) {
+  if (check.status === 'ok') return 'no_action';
+  if (check.status === 'redirected') return 'review_redirect_target';
+  if (['dns_failure', 'tls_failure'].includes(check.status)) return 'inspect_site_domain_or_tls';
+  if (check.status === 'not_found') return 'inspect_route_or_deploy';
+  if (['server_error', 'timeout'].includes(check.status)) return 'inspect_runtime_or_hosting';
+  return 'inspect_site_health';
+}
+
+function addRouteFinding(findings, monitor, target, check) {
+  if (check.status === 'ok') return;
+  findings.push(createFinding({
+    monitor,
+    severity: severityForRoute(check),
+    category: `site_route_${check.status}`,
+    title: `Site route check ${check.status}: ${target.route}`,
+    summary: `${target.url} -> ${check.status}${check.http_status ? ` HTTP ${check.http_status}` : ''}${check.error ? ` error=${check.error}` : ''}`,
+    recommended_action: routeAction(check),
+    source_urls: [target.url],
+    confidence: 'medium',
+    dedupe_key: `${monitor}:site_route:${target.route}:${check.status}`,
+  }));
+}
+
+function addSitemapFindings(findings, monitor, sitemapResult) {
+  if (sitemapResult.status !== 'ok') {
+    findings.push(createFinding({
+      monitor,
+      severity: 'critical',
+      category: `sitemap_${sitemapResult.status}`,
+      title: `Sitemap check failed: ${sitemapResult.status}`,
+      summary: `${sitemapResult.sitemap_url} -> ${sitemapResult.status}${sitemapResult.http_status ? ` HTTP ${sitemapResult.http_status}` : ''}${sitemapResult.error ? ` error=${sitemapResult.error}` : ''}`,
+      recommended_action: 'inspect_sitemap_route_or_deploy',
+      source_urls: [sitemapResult.sitemap_url],
+      confidence: 'medium',
+      dedupe_key: `${monitor}:sitemap:${sitemapResult.status}`,
+    }));
+    return;
+  }
+
+  if (sitemapResult.missing_static_routes.length > 0) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'sitemap_missing_static_routes',
+      title: 'Sitemap is missing required static routes',
+      summary: sitemapResult.missing_static_routes.join(', '),
+      recommended_action: 'inspect_sitemap_generation',
+      source_urls: [sitemapResult.sitemap_url],
+      confidence: 'high',
+      dedupe_key: `${monitor}:sitemap_missing_static_routes`,
+    }));
+  }
+
+  if (sitemapResult.actual_exchange_routes !== sitemapResult.expected_exchange_routes) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'high',
+      category: 'sitemap_exchange_route_count_mismatch',
+      title: 'Sitemap exchange route count does not match entity count',
+      summary: `expected=${sitemapResult.expected_exchange_routes}, actual=${sitemapResult.actual_exchange_routes}`,
+      recommended_action: 'inspect_sitemap_entity_route_generation',
+      source_urls: [sitemapResult.sitemap_url],
+      confidence: 'high',
+      dedupe_key: `${monitor}:sitemap_exchange_route_count_mismatch`,
+    }));
+  }
+}
 
 export async function runSiteAndSeoWatch(context, { startedAt } = {}) {
+  const monitor = 'site-and-seo-watch';
   const started_at = startedAt || new Date().toISOString();
+  const findings = [];
+  const errors = [];
+  const entities = context?.canonicalData?.entities || [];
+
+  if (!SITE_SEO_WATCH_ENABLED) {
+    findings.push(createFinding({
+      monitor,
+      severity: 'low',
+      category: 'site_seo_watch_disabled',
+      title: 'Site and SEO checks are disabled',
+      summary: 'Set HEI_MONITORING_ENABLE_SITE_SEO_CHECKS=1 to enable route, sitemap, and robots checks.',
+      recommended_action: 'enable_site_seo_checks_when_ready_for_scheduled_external_checks',
+      confidence: 'medium',
+      dedupe_key: `${monitor}:site_seo_checks_disabled`,
+    }));
+
+    return createMonitorResult({
+      monitor,
+      started_at,
+      finished_at: new Date().toISOString(),
+      findings,
+      candidates: [],
+      errors,
+      extra: {
+        site_seo_summary: {
+          enabled: false,
+          site_url: MONITORING_SITE_URL,
+          routes_checked: 0,
+          sitemap_checked: false,
+          robots_checked: false,
+        },
+      },
+    });
+  }
+
+  const routeTargets = getRouteCheckTargets(entities);
+  const routeChecks = [];
+  for (const target of routeTargets) {
+    const check = await checkHttpUrl(target.url, { timeoutMs: 15000, maxBodyChars: 8000 });
+    routeChecks.push({ ...target, check });
+    addRouteFinding(findings, monitor, target, check);
+  }
+
+  const sitemapUrl = getSitemapUrl(MONITORING_SITE_URL);
+  let sitemapResult = null;
+  try {
+    sitemapResult = await checkSitemap({
+      sitemapUrl,
+      siteUrl: MONITORING_SITE_URL,
+      entities,
+      requiredStaticRoutes: REQUIRED_SITEMAP_STATIC_ROUTES,
+    });
+    addSitemapFindings(findings, monitor, sitemapResult);
+  } catch (error) {
+    errors.push(error?.message || String(error));
+    findings.push(createFinding({
+      monitor,
+      severity: 'critical',
+      category: 'sitemap_check_failed',
+      title: 'Sitemap check failed unexpectedly',
+      summary: error?.stack || error?.message || String(error),
+      recommended_action: 'fix_site_seo_monitor_or_sitemap_route',
+      source_urls: [sitemapUrl],
+      confidence: 'medium',
+      dedupe_key: `${monitor}:sitemap_check_failed`,
+    }));
+  }
+
+  const robotsUrl = getRobotsUrl(MONITORING_SITE_URL);
+  const robotsCheck = await checkHttpUrl(robotsUrl, { timeoutMs: 15000, maxBodyChars: 8000 });
+  if (robotsCheck.status !== 'ok' && robotsCheck.status !== 'redirected') {
+    findings.push(createFinding({
+      monitor,
+      severity: 'medium',
+      category: `robots_${robotsCheck.status}`,
+      title: `robots.txt check ${robotsCheck.status}`,
+      summary: `${robotsUrl} -> ${robotsCheck.status}${robotsCheck.http_status ? ` HTTP ${robotsCheck.http_status}` : ''}${robotsCheck.error ? ` error=${robotsCheck.error}` : ''}`,
+      recommended_action: 'inspect_robots_txt_route',
+      source_urls: [robotsUrl],
+      confidence: 'medium',
+      dedupe_key: `${monitor}:robots:${robotsCheck.status}`,
+    }));
+  }
+
   return createMonitorResult({
-    monitor: 'site-and-seo-watch',
+    monitor,
     started_at,
     finished_at: new Date().toISOString(),
-    findings: [],
+    findings,
     candidates: [],
-    errors: [],
+    errors,
     extra: {
-      note: 'Skeleton monitor. Site route, sitemap, robots, and metadata checks are implemented in later phases.',
+      site_seo_summary: {
+        enabled: true,
+        site_url: MONITORING_SITE_URL,
+        routes_checked: routeTargets.length,
+        route_findings: routeChecks.filter((item) => item.check.status !== 'ok').length,
+        sitemap_checked: Boolean(sitemapResult),
+        sitemap_status: sitemapResult?.status || 'not_checked',
+        sitemap_urls: sitemapResult?.urls?.length || 0,
+        sitemap_exchange_routes_expected: entities.length,
+        sitemap_exchange_routes_actual: sitemapResult?.actual_exchange_routes || 0,
+        robots_checked: true,
+        robots_status: robotsCheck.status,
+      },
+      route_checks: routeChecks,
+      sitemap_check: sitemapResult,
+      robots_check: robotsCheck,
     },
   });
 }

--- a/scripts/monitoring/sources/site-routes.mjs
+++ b/scripts/monitoring/sources/site-routes.mjs
@@ -1,0 +1,58 @@
+const DEFAULT_SITE_URL = 'https://hei.badjoke-lab.com';
+
+export const SITE_SEO_WATCH_ENABLED = process.env.HEI_MONITORING_ENABLE_SITE_SEO_CHECKS === '1';
+export const MONITORING_SITE_URL = (process.env.HEI_MONITORING_SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL).replace(/\/+$/, '');
+
+export const STATIC_ROUTES = [
+  '/',
+  '/dead',
+  '/active',
+  '/stats',
+  '/methodology',
+  '/about',
+  '/donate',
+];
+
+export const REQUIRED_SITEMAP_STATIC_ROUTES = [
+  '/',
+  '/dead',
+  '/active',
+  '/stats',
+  '/methodology',
+  '/about',
+  '/donate',
+];
+
+export function routeUrl(route, siteUrl = MONITORING_SITE_URL) {
+  const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+  return `${siteUrl}${normalizedRoute}`;
+}
+
+export function getRouteCheckTargets(entities = []) {
+  const sampleEntity = entities.find((entity) => entity?.slug) || null;
+  const routeTargets = STATIC_ROUTES.map((route) => ({
+    route,
+    url: routeUrl(route),
+    kind: 'static_route',
+  }));
+
+  if (sampleEntity) {
+    routeTargets.push({
+      route: `/exchange/${sampleEntity.slug}`,
+      url: routeUrl(`/exchange/${sampleEntity.slug}`),
+      kind: 'sample_exchange_route',
+      entity_id: sampleEntity.id,
+      slug: sampleEntity.slug,
+    });
+  }
+
+  return routeTargets;
+}
+
+export function getSitemapUrl(siteUrl = MONITORING_SITE_URL) {
+  return `${siteUrl}/sitemap.xml`;
+}
+
+export function getRobotsUrl(siteUrl = MONITORING_SITE_URL) {
+  return `${siteUrl}/robots.txt`;
+}


### PR DESCRIPTION
## Summary
- add site route configuration for HEI monitoring
- add sitemap check adapter for sitemap URL extraction and exchange-route count validation
- replace the site-and-seo-watch placeholder with route, sitemap, and robots checks
- check main routes, `/stats`, `/donate`, and a sample `/exchange/[slug]` route when enabled
- validate sitemap required static routes and entity-route count against canonical entities
- surface site/SEO summary in `summary.md`

## Scope
- no canonical data changes
- site/SEO checks are disabled by default
- scheduled runs will not fetch public site URLs unless `HEI_MONITORING_ENABLE_SITE_SEO_CHECKS=1` is explicitly set
- this is route/sitemap/robots monitoring; it does not change metadata or sitemap generation

## Safety
- monitoring output remains report-only
- canonical data remains protected by the existing monitoring guard
- site/SEO findings are advisory and require review before source/app changes

## Notes
- this follows PR #98 by adding the site/SEO monitoring layer
- next PR should add noise-control/state-store to reduce repeated low/medium findings