### PR TITLE
Add HEI monitoring noise control state store

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -27,6 +27,7 @@ jobs:
         run: npm ci
 
       - name: Run monitoring
+        id: monitor
         run: npm run monitor
 
       - name: Guard canonical data files
@@ -39,6 +40,10 @@ jobs:
       - name: Check monitoring changes
         id: changes
         run: |
+          if [ "${{ steps.monitor.outputs.meaningful_findings }}" != "true" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if git status --porcelain -- data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution | grep .; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/monitoring/core/finding-utils.mjs
+++ b/scripts/monitoring/core/finding-utils.mjs
@@ -4,6 +4,10 @@ function safeText(value, fallback = '') {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
+export function visibleFindings(findings = []) {
+  return findings.filter((finding) => !finding?.suppressed);
+}
+
 export function countBySeverity(findings = []) {
   const counts = Object.fromEntries(SEVERITIES.map((severity) => [severity, 0]));
   for (const finding of findings) {
@@ -62,6 +66,7 @@ export function createMonitorResult({ monitor, started_at, finished_at, findings
     errors,
     summary: {
       findings_count: findings.length,
+      visible_findings_count: visibleFindings(findings).length,
       candidate_count: candidates.length,
       errors_count: errors.length,
       ...severityCounts,
@@ -98,7 +103,7 @@ export async function runMonitorSafely(monitorName, monitorFn, context) {
 
 export function hasMeaningfulFindings(results = []) {
   return results.some((result) => {
-    const findings = result?.findings || [];
+    const findings = visibleFindings(result?.findings || []);
     const candidates = result?.candidates || [];
     return candidates.length > 0 || findings.length > 0;
   });

--- a/scripts/monitoring/core/state-store.mjs
+++ b/scripts/monitoring/core/state-store.mjs
@@ -1,0 +1,105 @@
+import { appendFile } from 'node:fs/promises';
+import { readJsonFile, writeJsonFile } from './fs-utils.mjs';
+
+export const MONITORING_STATE_PATH = 'data-staging/monitoring/state/latest-findings.json';
+
+function findingKey(finding) {
+  return finding?.dedupe_key || [finding?.monitor, finding?.category, finding?.title]
+    .filter(Boolean)
+    .join(':')
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+}
+
+function isSuppressible(finding, repeatCount) {
+  if (!finding) return false;
+  if (finding.severity === 'critical' || finding.severity === 'high') return false;
+  if (finding.severity === 'medium') return false;
+  return finding.severity === 'low' && repeatCount > 1;
+}
+
+function flattenFindings(results = []) {
+  return results.flatMap((result) => (result.findings || []).map((finding) => ({ finding, result })));
+}
+
+export async function loadMonitoringState() {
+  const state = await readJsonFile(MONITORING_STATE_PATH, null);
+  if (!state || typeof state !== 'object') {
+    return {
+      version: 1,
+      updated_at: null,
+      findings: {},
+    };
+  }
+  return {
+    version: state.version || 1,
+    updated_at: state.updated_at || null,
+    findings: state.findings && typeof state.findings === 'object' ? state.findings : {},
+  };
+}
+
+export function applyNoiseControl(results, previousState, nowIso = new Date().toISOString()) {
+  const nextFindings = {};
+  let suppressed_count = 0;
+  let new_count = 0;
+  let repeated_count = 0;
+
+  for (const { finding } of flattenFindings(results)) {
+    const key = findingKey(finding);
+    const previous = previousState.findings[key] || null;
+    const repeatCount = previous ? (previous.repeat_count || 1) + 1 : 1;
+    const firstSeenAt = previous?.first_seen_at || nowIso;
+    const suppressed = isSuppressible(finding, repeatCount);
+
+    finding.first_seen_at = firstSeenAt;
+    finding.last_seen_at = nowIso;
+    finding.repeat_count = repeatCount;
+    finding.is_new = !previous;
+    finding.is_repeated = Boolean(previous);
+    finding.suppressed = suppressed;
+    finding.noise_control = suppressed ? 'suppressed_repeated_low' : 'visible';
+
+    if (!previous) new_count += 1;
+    else repeated_count += 1;
+    if (suppressed) suppressed_count += 1;
+
+    nextFindings[key] = {
+      key,
+      monitor: finding.monitor,
+      category: finding.category,
+      title: finding.title,
+      severity: finding.severity,
+      first_seen_at: firstSeenAt,
+      last_seen_at: nowIso,
+      repeat_count: repeatCount,
+      last_suppressed: suppressed,
+    };
+  }
+
+  return {
+    results,
+    state: {
+      version: 1,
+      updated_at: nowIso,
+      findings: nextFindings,
+    },
+    summary: {
+      total_findings: Object.keys(nextFindings).length,
+      new_count,
+      repeated_count,
+      suppressed_count,
+      visible_count: Object.keys(nextFindings).length - suppressed_count,
+    },
+  };
+}
+
+export async function writeMonitoringState(state) {
+  await writeJsonFile(MONITORING_STATE_PATH, state);
+}
+
+export async function writeGitHubOutput(values) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`);
+  await appendFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -1,4 +1,5 @@
 import { SEVERITIES } from './constants.mjs';
+import { visibleFindings } from './finding-utils.mjs';
 
 function flattenFindings(results) {
   return results.flatMap((result) => (result.findings || []).map((finding) => ({ ...finding, monitor: finding.monitor || result.monitor })));
@@ -19,8 +20,9 @@ function findResult(results, monitor) {
   return results.find((result) => result.monitor === monitor) || null;
 }
 
-export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, results, hasMeaningfulFindings }) {
-  const findings = flattenFindings(results);
+export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, results, hasMeaningfulFindings, noiseSummary = null }) {
+  const allFindings = flattenFindings(results);
+  const findings = visibleFindings(allFindings);
   const candidates = flattenCandidates(results);
   const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
   const bCandidates = candidates.filter((candidate) => candidate.candidate_class === 'B');
@@ -83,10 +85,15 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
 - finished_at: ${finishedAt}
 - meaningful_findings: ${hasMeaningfulFindings ? 'yes' : 'no'}
 
+## Noise control
+
+${noiseSummary ? `- total_findings_seen: ${noiseSummary.total_findings}\n- visible_findings: ${noiseSummary.visible_count}\n- suppressed_repeated_low_findings: ${noiseSummary.suppressed_count}\n- new_findings: ${noiseSummary.new_count}\n- repeated_findings: ${noiseSummary.repeated_count}` : '- Not available.'}
+
 ## Counts
 
 - monitors: ${results.length}
 - findings: ${findings.length}
+- suppressed_findings: ${allFindings.length - findings.length}
 - candidates: ${candidates.length}
 - critical: ${severityCounts.critical}
 - high: ${severityCounts.high}

--- a/scripts/monitoring/run.mjs
+++ b/scripts/monitoring/run.mjs
@@ -4,6 +4,7 @@ import { assertCanonicalUnchanged, checkCanonicalGuard } from './core/guard-cano
 import { createRunId, writeAllReports } from './core/report-writer.mjs';
 import { buildSummaryMarkdown } from './core/summary-writer.mjs';
 import { hasMeaningfulFindings, runMonitorSafely } from './core/finding-utils.mjs';
+import { loadMonitoringState, applyNoiseControl, writeMonitoringState, writeGitHubOutput } from './core/state-store.mjs';
 import { runCandidateDiscovery } from './monitors/candidate-discovery.mjs';
 import { runNewsAndEventWatch } from './monitors/news-and-event-watch.mjs';
 import { runActiveStatusWatch } from './monitors/active-status-watch.mjs';
@@ -32,13 +33,18 @@ async function main() {
     canonicalData,
   };
 
-  const results = [];
+  const rawResults = [];
   for (const [name, fn] of monitorFns) {
-    results.push(await runMonitorSafely(name, fn, context));
+    rawResults.push(await runMonitorSafely(name, fn, context));
   }
 
-  const meaningfulFindings = hasMeaningfulFindings(results);
+  const previousState = await loadMonitoringState();
   const finishedAt = new Date().toISOString();
+  const noise = applyNoiseControl(rawResults, previousState, finishedAt);
+  const results = noise.results;
+  await writeMonitoringState(noise.state);
+
+  const meaningfulFindings = hasMeaningfulFindings(results);
   const preWriteGuard = await checkCanonicalGuard();
 
   const summaryMarkdown = buildSummaryMarkdown({
@@ -48,6 +54,7 @@ async function main() {
     finishedAt,
     results,
     hasMeaningfulFindings: meaningfulFindings,
+    noiseSummary: noise.summary,
   });
 
   const { runDir } = await writeAllReports({
@@ -60,6 +67,12 @@ async function main() {
     canonicalGuard: preWriteGuard,
   });
 
+  await writeGitHubOutput({
+    meaningful_findings: meaningfulFindings ? 'true' : 'false',
+    visible_findings: String(noise.summary.visible_count),
+    suppressed_findings: String(noise.summary.suppressed_count),
+  });
+
   if (monitoringConfig.shouldFailOnCanonicalChange) {
     await assertCanonicalUnchanged();
   }
@@ -67,6 +80,7 @@ async function main() {
   console.log(`HEI monitoring run complete: ${runId}`);
   console.log(`Reports written to: ${runDir}`);
   console.log(`Meaningful findings: ${meaningfulFindings ? 'yes' : 'no'}`);
+  console.log(`Suppressed repeated low findings: ${noise.summary.suppressed_count}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- add `state-store.mjs` for tracking finding repeat counts by dedupe key
- add suppression metadata for repeated low-severity findings
- keep high/critical and medium findings visible while suppressing repeated low findings after the first appearance
- add noise-control counts to the monitoring summary
- make the workflow use `meaningful_findings` from the monitor step before opening auto report PRs

## Scope
- no canonical data changes
- no external checks added
- this PR only changes monitoring control flow, summary output, and workflow PR gating

## Safety
- canonical data remains protected by the existing monitoring guard
- suppressed findings are still recorded in JSON/state, but repeated low-severity findings no longer force noisy PRs
- candidates and visible findings still create monitoring report PRs

## Notes
- this follows PR #103 by adding the planned noise-control/state-store layer
- next PR should add optional staging draft support or final workflow hardening depending on priorities