### PR TITLE
Use schedule-safe HEI monitoring workflow inputs

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -80,17 +80,17 @@ jobs:
       - name: Run monitoring
         id: monitor
         env:
-          INPUT_ENABLE_EXTERNAL_LISTS: ${{ inputs.enable_external_lists || 'false' }}
-          INPUT_ENABLE_NEWS_RSS: ${{ inputs.enable_news_rss || 'false' }}
-          INPUT_ENABLE_DOMAIN_CHECKS: ${{ inputs.enable_domain_checks || 'false' }}
-          INPUT_ENABLE_EVIDENCE_URL_CHECKS: ${{ inputs.enable_evidence_url_checks || 'false' }}
-          INPUT_ENABLE_REGULATORY_WATCH: ${{ inputs.enable_regulatory_watch || 'false' }}
-          INPUT_ENABLE_SITE_SEO_CHECKS: ${{ inputs.enable_site_seo_checks || 'false' }}
-          INPUT_SITE_URL: ${{ inputs.site_url || 'https://hei.badjoke-lab.com' }}
-          INPUT_NEWS_QUERY_LIMIT: ${{ inputs.news_query_limit || '20' }}
-          INPUT_REGULATORY_QUERY_LIMIT: ${{ inputs.regulatory_query_limit || '25' }}
-          INPUT_DOMAIN_CHECK_LIMIT: ${{ inputs.domain_check_limit || '50' }}
-          INPUT_EVIDENCE_URL_CHECK_LIMIT: ${{ inputs.evidence_url_check_limit || '50' }}
+          INPUT_ENABLE_EXTERNAL_LISTS: ${{ github.event.inputs.enable_external_lists || 'false' }}
+          INPUT_ENABLE_NEWS_RSS: ${{ github.event.inputs.enable_news_rss || 'false' }}
+          INPUT_ENABLE_DOMAIN_CHECKS: ${{ github.event.inputs.enable_domain_checks || 'false' }}
+          INPUT_ENABLE_EVIDENCE_URL_CHECKS: ${{ github.event.inputs.enable_evidence_url_checks || 'false' }}
+          INPUT_ENABLE_REGULATORY_WATCH: ${{ github.event.inputs.enable_regulatory_watch || 'false' }}
+          INPUT_ENABLE_SITE_SEO_CHECKS: ${{ github.event.inputs.enable_site_seo_checks || 'false' }}
+          INPUT_SITE_URL: ${{ github.event.inputs.site_url || 'https://hei.badjoke-lab.com' }}
+          INPUT_NEWS_QUERY_LIMIT: ${{ github.event.inputs.news_query_limit || '20' }}
+          INPUT_REGULATORY_QUERY_LIMIT: ${{ github.event.inputs.regulatory_query_limit || '25' }}
+          INPUT_DOMAIN_CHECK_LIMIT: ${{ github.event.inputs.domain_check_limit || '50' }}
+          INPUT_EVIDENCE_URL_CHECK_LIMIT: ${{ github.event.inputs.evidence_url_check_limit || '50' }}
         run: |
           bool_to_flag() {
             if [ "$1" = "true" ]; then

--- a/docs/monitoring-workflow-dispatch-safety.md
+++ b/docs/monitoring-workflow-dispatch-safety.md
@@ -1,0 +1,78 @@
+# Monitoring workflow dispatch input safety
+
+Status: workflow hardening note  
+Scope: `.github/workflows/hei-monitoring.yml`
+
+---
+
+## Purpose
+
+The HEI monitoring workflow supports both scheduled runs and manual `workflow_dispatch` runs.
+
+Manual runs expose optional inputs for external checks:
+
+```txt
+enable_external_lists
+enable_news_rss
+enable_domain_checks
+enable_evidence_url_checks
+enable_regulatory_watch
+enable_site_seo_checks
+site_url
+news_query_limit
+regulatory_query_limit
+domain_check_limit
+evidence_url_check_limit
+```
+
+Scheduled runs do not provide these input values.
+
+---
+
+## Rule
+
+Workflow expressions must read manual inputs through:
+
+```txt
+github.event.inputs.<name>
+```
+
+and provide safe defaults:
+
+```txt
+${{ github.event.inputs.enable_news_rss || 'false' }}
+```
+
+This keeps scheduled runs safe and avoids relying on the shorthand `inputs` context where scheduled-event behavior may be less obvious.
+
+---
+
+## Default scheduled behavior
+
+Scheduled runs keep every optional external fetch disabled:
+
+```txt
+HEI_MONITORING_ENABLE_REMOTE_LISTS=0
+HEI_MONITORING_ENABLE_NEWS_RSS=0
+HEI_MONITORING_ENABLE_DOMAIN_CHECKS=0
+HEI_MONITORING_ENABLE_EVIDENCE_URL_CHECKS=0
+HEI_MONITORING_ENABLE_REGULATORY_WATCH=0
+HEI_MONITORING_ENABLE_SITE_SEO_CHECKS=0
+```
+
+This means the scheduled monitor remains internal and low-cost by default.
+
+---
+
+## Manual behavior
+
+Manual workflow runs can explicitly enable one or more external checks. Boolean inputs are converted into the `0`/`1` environment flags used by the monitoring scripts.
+
+---
+
+## Final rule
+
+```txt
+Scheduled: safe defaults, no optional external fetching.
+Manual: explicit external checks only when selected.
+```


### PR DESCRIPTION
## Summary
- switch monitoring workflow input references from `inputs.*` to `github.event.inputs.*`
- keep safe defaults for scheduled runs where workflow_dispatch inputs are absent
- add a short workflow-dispatch safety note documenting the scheduled/manual behavior

## Scope
- no canonical data changes
- no monitoring script changes
- no external checks enabled by default

## Safety
- scheduled runs still default all optional external fetches to disabled
- manual runs still allow explicit opt-in for each external check
- canonical data remains protected by the existing monitoring guard

## Notes
- this is a small follow-up after PR #107 to make the scheduled/manual input behavior explicit and less ambiguous