### PR TITLE
Add HEI monitoring smoke test

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Smoke test monitoring modules
+        run: npm run monitor:smoke
+
       - name: Run monitoring
         id: monitor
         env:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "monitor": "node scripts/monitoring/run.mjs",
     "monitor:dry": "HEI_MONITORING_MODE=manual node scripts/monitoring/run.mjs",
-    "monitor:promote-candidate": "node scripts/monitoring/promote-candidate-to-staging.mjs"
+    "monitor:promote-candidate": "node scripts/monitoring/promote-candidate-to-staging.mjs",
+    "monitor:smoke": "node scripts/monitoring/smoke-test.mjs"
   },
   "dependencies": {
     "next": "15.2.4",

--- a/scripts/monitoring/core/monitor-registry.mjs
+++ b/scripts/monitoring/core/monitor-registry.mjs
@@ -1,0 +1,21 @@
+import { runCandidateDiscovery } from '../monitors/candidate-discovery.mjs';
+import { runNewsAndEventWatch } from '../monitors/news-and-event-watch.mjs';
+import { runActiveStatusWatch } from '../monitors/active-status-watch.mjs';
+import { runEvidenceAndRecordQualityWatch } from '../monitors/evidence-and-record-quality-watch.mjs';
+import { runEvidenceHealthWatch } from '../monitors/evidence-health-watch.mjs';
+import { runSiteAndSeoWatch } from '../monitors/site-and-seo-watch.mjs';
+import { runMonitoringHealthWatch } from '../monitors/monitoring-health-watch.mjs';
+
+export const MONITOR_REGISTRY = [
+  ['candidate-discovery', runCandidateDiscovery],
+  ['news-and-event-watch', runNewsAndEventWatch],
+  ['active-status-watch', runActiveStatusWatch],
+  ['evidence-and-record-quality-watch', runEvidenceAndRecordQualityWatch],
+  ['evidence-health-watch', runEvidenceHealthWatch],
+  ['site-and-seo-watch', runSiteAndSeoWatch],
+  ['monitoring-health-watch', runMonitoringHealthWatch],
+];
+
+export function monitorRegistryNames() {
+  return MONITOR_REGISTRY.map(([name]) => name);
+}

--- a/scripts/monitoring/run.mjs
+++ b/scripts/monitoring/run.mjs
@@ -5,23 +5,7 @@ import { createRunId, writeAllReports } from './core/report-writer.mjs';
 import { buildSummaryMarkdown } from './core/summary-writer.mjs';
 import { hasMeaningfulFindings, runMonitorSafely } from './core/finding-utils.mjs';
 import { loadMonitoringState, applyNoiseControl, writeMonitoringState, writeGitHubOutput } from './core/state-store.mjs';
-import { runCandidateDiscovery } from './monitors/candidate-discovery.mjs';
-import { runNewsAndEventWatch } from './monitors/news-and-event-watch.mjs';
-import { runActiveStatusWatch } from './monitors/active-status-watch.mjs';
-import { runEvidenceAndRecordQualityWatch } from './monitors/evidence-and-record-quality-watch.mjs';
-import { runEvidenceHealthWatch } from './monitors/evidence-health-watch.mjs';
-import { runSiteAndSeoWatch } from './monitors/site-and-seo-watch.mjs';
-import { runMonitoringHealthWatch } from './monitors/monitoring-health-watch.mjs';
-
-const monitorFns = [
-  ['candidate-discovery', runCandidateDiscovery],
-  ['news-and-event-watch', runNewsAndEventWatch],
-  ['active-status-watch', runActiveStatusWatch],
-  ['evidence-and-record-quality-watch', runEvidenceAndRecordQualityWatch],
-  ['evidence-health-watch', runEvidenceHealthWatch],
-  ['site-and-seo-watch', runSiteAndSeoWatch],
-  ['monitoring-health-watch', runMonitoringHealthWatch],
-];
+import { MONITOR_REGISTRY } from './core/monitor-registry.mjs';
 
 async function main() {
   const runId = process.env.HEI_MONITORING_RUN_ID || createRunId();
@@ -34,7 +18,7 @@ async function main() {
   };
 
   const rawResults = [];
-  for (const [name, fn] of monitorFns) {
+  for (const [name, fn] of MONITOR_REGISTRY) {
     rawResults.push(await runMonitorSafely(name, fn, context));
   }
 

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -1,0 +1,65 @@
+import { MONITOR_NAMES } from './core/constants.mjs';
+import { monitorRegistryNames, MONITOR_REGISTRY } from './core/monitor-registry.mjs';
+import { loadCanonicalData } from './core/load-canonical-data.mjs';
+import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertSameSet(left, right, message) {
+  const leftSorted = [...left].sort();
+  const rightSorted = [...right].sort();
+  assert(JSON.stringify(leftSorted) === JSON.stringify(rightSorted), `${message}: left=${leftSorted.join(',')} right=${rightSorted.join(',')}`);
+}
+
+function validateMonitorResult(result, expectedName) {
+  assert(result && typeof result === 'object', `${expectedName} did not return an object`);
+  assert(result.monitor === expectedName, `${expectedName} returned monitor=${result.monitor}`);
+  assert(['ok', 'degraded'].includes(result.status), `${expectedName} returned invalid status=${result.status}`);
+  assert(typeof result.started_at === 'string' && result.started_at, `${expectedName} missing started_at`);
+  assert(typeof result.finished_at === 'string' && result.finished_at, `${expectedName} missing finished_at`);
+  assert(Array.isArray(result.findings), `${expectedName} findings must be an array`);
+  assert(Array.isArray(result.candidates), `${expectedName} candidates must be an array`);
+  assert(Array.isArray(result.errors), `${expectedName} errors must be an array`);
+  assert(result.summary && typeof result.summary === 'object', `${expectedName} missing summary object`);
+  assert(Number.isInteger(result.summary.findings_count), `${expectedName} summary.findings_count must be integer`);
+  assert(Number.isInteger(result.summary.candidate_count), `${expectedName} summary.candidate_count must be integer`);
+  assert(Number.isInteger(result.summary.errors_count), `${expectedName} summary.errors_count must be integer`);
+}
+
+async function main() {
+  assertSameSet(MONITOR_NAMES, monitorRegistryNames(), 'MONITOR_NAMES and MONITOR_REGISTRY are out of sync');
+
+  const canonicalData = await loadCanonicalData();
+  assert(Array.isArray(canonicalData.entities), 'entities must load as array');
+  assert(Array.isArray(canonicalData.events), 'events must load as array');
+  assert(Array.isArray(canonicalData.evidence), 'evidence must load as array');
+
+  const context = {
+    runId: 'smoke-test',
+    mode: 'smoke',
+    canonicalData,
+  };
+
+  for (const [name, fn] of MONITOR_REGISTRY) {
+    const result = await runMonitorSafely(name, fn, context);
+    validateMonitorResult(result, name);
+  }
+
+  const synthetic = createMonitorResult({
+    monitor: 'smoke-synthetic',
+    started_at: new Date().toISOString(),
+    finished_at: new Date().toISOString(),
+  });
+  validateMonitorResult(synthetic, 'smoke-synthetic');
+
+  console.log('HEI monitoring smoke test passed.');
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a shared monitoring registry so the runner and tests use the same monitor list
- add `scripts/monitoring/smoke-test.mjs`
- add `npm run monitor:smoke`
- run the smoke test before the scheduled/manual monitoring workflow
- validate monitor registry consistency, canonical data loading, and monitor result shape

## Scope
- no canonical data changes
- no optional external checks enabled
- no monitoring behavior changes except centralizing the monitor registry

## Safety
- smoke test runs with default disabled external checks
- catches import/registry/result-shape failures before the monitoring workflow writes reports or opens PRs
- canonical data remains protected by the existing monitoring guard

## Notes
- this follows PR #108 by adding an operational smoke test layer for the monitoring system
- next work can move to manual first-run validation, or pause monitoring implementation and begin using the workflow