### PR TITLE
Fix HEI monitoring PR creation when watchlist paths are missing

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -151,7 +151,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution
+          for path in data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution; do
+            if [ -e "$path" ]; then
+              git add "$path"
+            else
+              echo "Skipping missing monitoring path: $path"
+            fi
+          done
           git commit -m "Add HEI auto monitoring report"
           git push origin "$BRANCH"
           SUMMARY_FILE="$(find data-staging/monitoring -name summary.md | sort | tail -n 1)"


### PR DESCRIPTION
## Summary
- fix the monitoring workflow PR creation step so it does not fail when optional watchlist directories do not exist
- replace a single `git add data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution` call with a path-existence loop
- keep adding existing monitoring/watchlist paths normally

## Why
The first manual validation run reached the PR creation step but failed with:

```txt
fatal: pathspec 'data-staging/watchlists/auto' did not match any files
```

That is expected when no auto watchlist candidates were generated. The workflow should still commit the monitoring report if `data-staging/monitoring` exists.

## Scope
- no canonical data changes
- no monitoring script changes
- workflow-only fix

## Safety
- missing optional paths are skipped with a log line
- existing monitoring output paths are still committed
- canonical data remains protected by the existing guard