### PR TITLE
Suppress repeated HEI monitoring backlog noise

### DIFF
--- a/scripts/monitoring/core/state-store.mjs
+++ b/scripts/monitoring/core/state-store.mjs
@@ -3,6 +3,28 @@ import { readJsonFile, writeJsonFile } from './fs-utils.mjs';
 
 export const MONITORING_STATE_PATH = 'data-staging/monitoring/state/latest-findings.json';
 
+const ALWAYS_VISIBLE_CATEGORIES = new Set([
+  'monitor_failed',
+]);
+
+const REPEATED_BACKLOG_CATEGORIES = new Set([
+  'invalid_entity_enum',
+  'invalid_event_enum',
+  'invalid_evidence_enum',
+  'source_count_mismatch',
+  'thin_evidence',
+  'missing_events',
+  'missing_archive',
+  'official_url_status_unknown',
+  'country_or_origin_unknown',
+  'possible_lineage_missing',
+  'provisional_text',
+]);
+
+const REPEATED_BACKLOG_MONITORS = new Set([
+  'evidence-and-record-quality-watch',
+]);
+
 function findingKey(finding) {
   return finding?.dedupe_key || [finding?.monitor, finding?.category, finding?.title]
     .filter(Boolean)
@@ -11,11 +33,35 @@ function findingKey(finding) {
     .replace(/\s+/g, '-');
 }
 
-function isSuppressible(finding, repeatCount) {
+function isRepeatedBacklogFinding(finding) {
   if (!finding) return false;
-  if (finding.severity === 'critical' || finding.severity === 'high') return false;
-  if (finding.severity === 'medium') return false;
-  return finding.severity === 'low' && repeatCount > 1;
+  if (!REPEATED_BACKLOG_MONITORS.has(finding.monitor)) return false;
+  if (REPEATED_BACKLOG_CATEGORIES.has(finding.category)) return true;
+
+  const recommendedAction = String(finding.recommended_action || '');
+  return [
+    'fix_entity_enum',
+    'fix_event_enum',
+    'fix_evidence_enum',
+    'review_event_source_count',
+    'add_minimum_event_or_review_record_shape',
+    'improve_evidence_or_review_confidence',
+    'add_second_source_or_archive',
+    'review_official_url_status_when_available',
+    'add_origin_if_sourceable',
+    'review_lineage_fields_when_record_is_touched',
+    'replace_provisional_notes_with_reviewed_text',
+  ].includes(recommendedAction);
+}
+
+function isSuppressible(finding, repeatCount) {
+  if (!finding || repeatCount <= 1) return false;
+  if (finding.severity === 'critical') return false;
+  if (ALWAYS_VISIBLE_CATEGORIES.has(finding.category)) return false;
+
+  if (isRepeatedBacklogFinding(finding)) return true;
+
+  return finding.severity === 'low';
 }
 
 function flattenFindings(results = []) {
@@ -57,7 +103,7 @@ export function applyNoiseControl(results, previousState, nowIso = new Date().to
     finding.is_new = !previous;
     finding.is_repeated = Boolean(previous);
     finding.suppressed = suppressed;
-    finding.noise_control = suppressed ? 'suppressed_repeated_low' : 'visible';
+    finding.noise_control = suppressed ? 'suppressed_repeated_backlog' : 'visible';
 
     if (!previous) new_count += 1;
     else repeated_count += 1;

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -87,7 +87,7 @@ export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, resul
 
 ## Noise control
 
-${noiseSummary ? `- total_findings_seen: ${noiseSummary.total_findings}\n- visible_findings: ${noiseSummary.visible_count}\n- suppressed_repeated_low_findings: ${noiseSummary.suppressed_count}\n- new_findings: ${noiseSummary.new_count}\n- repeated_findings: ${noiseSummary.repeated_count}` : '- Not available.'}
+${noiseSummary ? `- total_findings_seen: ${noiseSummary.total_findings}\n- visible_findings: ${noiseSummary.visible_count}\n- suppressed_repeated_backlog_findings: ${noiseSummary.suppressed_count}\n- new_findings: ${noiseSummary.new_count}\n- repeated_findings: ${noiseSummary.repeated_count}` : '- Not available.'}
 
 ## Counts
 


### PR DESCRIPTION
## Summary
- suppress repeated evidence-and-record-quality backlog findings after the first seen run
- keep critical and monitor_failed findings visible every time
- keep genuinely new findings visible
- update summary wording from repeated low findings to repeated backlog findings

## Why
The previous monitoring fixes addressed PR creation failures, but not the root cause of repeated monitoring noise. The monitoring state already records finding repeat counts, but only repeated low-severity findings were suppressed. That means known medium/high data-quality backlog items such as invalid enum records and source_count mismatches keep appearing as visible findings and can keep generating monitoring PRs.

## Scope
- monitoring noise-control only
- no canonical data changes
- no data-staging output changes in this PR

## Behavior after this change
- first detection of a backlog issue remains visible
- repeated known data-quality backlog findings are suppressed
- critical findings are never suppressed
- monitor failures are never suppressed
- new findings still trigger visibility

## Notes
This does not fix the underlying data-quality backlog. It stops the monitoring system from treating the same backlog as a fresh operational alert every run.