### PR TITLE
Opt HEI monitoring workflow into Node 24 action runtime

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -54,6 +54,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: hei-monitoring-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the HEI Monitoring workflow environment
- keep the project runtime at Node 20 for `npm ci`, smoke test, and monitoring scripts
- address the GitHub Actions warning about Node.js 20 action runtime deprecation

## Scope
- workflow-only change
- no canonical data changes
- no monitoring output changes
- no schedule or permission changes

## Notes
The warning is about the JavaScript runtime used by GitHub actions such as `actions/checkout@v4` and `actions/setup-node@v4`, not the repository's application Node runtime. This opts those actions into the future Node 24 action runtime while leaving the monitoring scripts on Node 20.