### PR TITLE
Resolve canonicalized HEI watchlist candidates

### DIFF
--- a/data-staging/watchlists/resolution/20260429-canonicalized-watchlist-candidates.json
+++ b/data-staging/watchlists/resolution/20260429-canonicalized-watchlist-candidates.json
@@ -1,0 +1,45 @@
+{
+  "resolution_type": "watchlist_candidates_canonicalized",
+  "created_at": "2026-04-29",
+  "source_monitoring_run": "data-staging/monitoring/20260429/monitoring-health-watch.json",
+  "purpose": "Record watchlist candidates that already appear in canonical entities so monitoring-health-watch no longer treats them as unresolved watchlist items.",
+  "promoted_to_canonical": [
+    {
+      "canonical_name": "CoinDCX",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    },
+    {
+      "canonical_name": "Bybit",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    },
+    {
+      "canonical_name": "DMM Bitcoin",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    },
+    {
+      "canonical_name": "BtcTurk",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    },
+    {
+      "canonical_name": "GMX",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    },
+    {
+      "canonical_name": "BingX",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    },
+    {
+      "canonical_name": "Bithumb",
+      "resolution": "promoted_to_canonical",
+      "notes": "Detected by monitoring-health-watch as present in canonical entities. This resolution records the watchlist candidate as handled."
+    }
+  ],
+  "canonical_data_changed": false,
+  "operator_notes": "This is a staging/watchlist bookkeeping change only. It does not modify data/entities.json, data/events.json, or data/evidence.json."
+}


### PR DESCRIPTION
## Summary
- add a watchlist resolution file for 7 candidates already detected as canonicalized
- mark CoinDCX, Bybit, DMM Bitcoin, BtcTurk, GMX, BingX, and Bithumb as `promoted_to_canonical`
- clear the monitoring-health bookkeeping issue where canonicalized candidates remained unresolved

## Scope
- staging/watchlist bookkeeping only
- no canonical data changes
- no entity/event/evidence changes

## Why
`monitoring-health-watch` reported these candidates as already present in canonical entities but not recorded in resolution files. The resolution loader treats names in `promoted_to_canonical` as resolved, so this should remove the repeated `canonicalized_watchlist_candidate_unresolved` findings after merge.

## Validation expectation
After merge, run HEI Monitoring again. Expected result for monitoring-health-watch:
- resolution_files increases from 0 to 1
- resolved_names increases by 7
- canonicalized_watchlist_candidate_unresolved findings disappear
- canonical data guard remains clean