### PR TITLE
Allow partial official URL status in monitoring

### DIFF
--- a/scripts/monitoring/core/constants.mjs
+++ b/scripts/monitoring/core/constants.mjs
@@ -49,6 +49,7 @@ export const DEATH_REASON_VALUES = [
 export const OFFICIAL_URL_STATUS_VALUES = [
   'live_verified',
   'live_unverified',
+  'partial',
   'dead_domain',
   'redirected',
   'repurposed',


### PR DESCRIPTION
## Summary
- add `partial` to `OFFICIAL_URL_STATUS_VALUES`
- fix the monitoring enum error raised for LocalCryptos (`hei_ex_000268`)

## Why
PR #131 added LocalCryptos with `official_url_status: "partial"` because the marketplace is dead for new trade creation, while the official domain / wallet interface may still be partially available. The monitoring constants did not include `partial`, so #133 reported `Invalid official_url_status on hei_ex_000268`.

## Scope
- monitoring/schema constant only
- no canonical data changes
- no entity/event/evidence changes

## Expected validation
After merge, run HEI Monitoring again. The `Invalid official_url_status on hei_ex_000268` finding should disappear.