### PR TITLE
Tighten news watch filtering and URL status enum

### DIFF
--- a/scripts/monitoring/core/constants.mjs
+++ b/scripts/monitoring/core/constants.mjs
@@ -50,6 +50,7 @@ export const OFFICIAL_URL_STATUS_VALUES = [
   'live_verified',
   'live_unverified',
   'partial',
+  'offline',
   'dead_domain',
   'redirected',
   'repurposed',

--- a/scripts/monitoring/monitors/news-and-event-watch.mjs
+++ b/scripts/monitoring/monitors/news-and-event-watch.mjs
@@ -20,11 +20,13 @@ const GENERIC_CANDIDATE_NAMES = new Set([
   'complex',
   'consumer',
   'dominance',
+  'etherdelta still holds',
   'first fca',
   'germany',
   'korea',
   'launch',
   'london block',
+  'mango markets shutting down',
   'monthly volume smashes',
   'network introduces build-your-own perp',
   'offering the complete solution',
@@ -50,6 +52,13 @@ const GENERIC_CANDIDATE_NAMES = new Set([
   'volumes nearly triple',
 ]);
 
+const AMBIGUOUS_GLOBAL_BRANDS = new Set([
+  'coinbase',
+  'huobi',
+  'mercado libre',
+  'tokenize',
+]);
+
 function runDateFromRunId(runId) {
   return String(runId || new Date().toISOString().slice(0, 10).replace(/-/g, '')).slice(0, 8);
 }
@@ -60,12 +69,30 @@ function isGenericCandidateName(name) {
   if (GENERIC_CANDIDATE_NAMES.has(normalized)) return true;
   if (normalized.length < 3) return true;
   if (/^(the|this|that|these|those)\b/.test(normalized)) return true;
-  if (/\b(after|before|following|amid|faces|announces|offers|introduces|proposes|surges|soars|suffers|shutters|shuts down)\b/.test(normalized) && normalized.split(/\s+/).length > 2) return true;
+  if (/\b(after|before|following|amid|faces|announces|offers|introduces|proposes|surges|soars|suffers|shutters|holds|shuts down)\b/.test(normalized) && normalized.split(/\s+/).length > 2) return true;
   return false;
+}
+
+function isAmbiguousBrandCandidate(candidate) {
+  const normalized = String(candidate?.canonical_name || '').trim().toLowerCase();
+  if (!AMBIGUOUS_GLOBAL_BRANDS.has(normalized)) return false;
+
+  const headline = String(candidate?.headline || '').toLowerCase();
+  return /\b(unit|operations|services|tool|product|coin|market|region|country|india|thai|thailand|singapore)\b/.test(headline);
+}
+
+function isLikelyHeadlineFragment(candidate) {
+  const name = String(candidate?.canonical_name || '').trim();
+  const headline = String(candidate?.headline || '').trim();
+  if (!name || !headline) return false;
+  if (name.split(/\s+/).length < 3) return false;
+  return headline.toLowerCase().includes(name.toLowerCase());
 }
 
 function isActionableNewsCandidate(candidate) {
   if (!candidate || isGenericCandidateName(candidate.canonical_name)) return false;
+  if (isAmbiguousBrandCandidate(candidate)) return false;
+  if (isLikelyHeadlineFragment(candidate)) return false;
 
   const sourceUrls = candidate.source_urls || [];
   if (sourceUrls.length === 0) return false;
@@ -284,7 +311,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
     await writeJsonFile(`${WATCHLIST_AUTO_ROOT}/news-event-candidates-${runDate}.json`, {
       watchlist_type: 'auto_news_event_candidates',
       created_at: new Date().toISOString(),
-      purpose: 'Conservatively filtered auto-generated news/regulatory/event candidate output. Not canonical. Requires review before staging/canonical append.',
+      purpose: 'Tightly filtered auto-generated news/regulatory/event candidate output. Not canonical. Requires review before staging/canonical append.',
       news_summary: {
         enabled: NEWS_WATCH_ENABLED,
         queries: newsQueries.length,


### PR DESCRIPTION
## Summary
- allow `offline` as an official URL status value for records such as CoinGather
- tighten news candidate filtering after PR #151 still retained headline fragments and ambiguous brand/regional shutdowns
- drop headline-fragment candidates such as `Etherdelta Still Holds` and `Mango Markets Shutting Down`
- drop ambiguous major-brand regional/product shutdown candidates such as Coinbase, Huobi, Mercado Libre, and Tokenize until manually reviewed

## Why
The news/regulatory monitor improved from 215 visible findings to 22, but the retained auto watchlist still contained noisy candidates and a canonical enum error appeared for `hei_ex_000273` with `official_url_status: "offline"`.

## Scope
- monitoring constants and news filtering only
- no canonical data changes
- no entity/event/evidence changes

## Expected validation
After merge, run HEI Monitoring with `enable_news_rss=true` and `enable_regulatory_watch=true`. Expected result:
- no `Invalid official_url_status on hei_ex_000273`
- retained news candidates should be fewer and more reviewable
- no headline fragments should be retained as candidate names