### PR TITLE
Resolve triaged news watch candidates

### DIFF
--- a/data-staging/watchlists/resolution/20260429-news-watch-triage-candidates.json
+++ b/data-staging/watchlists/resolution/20260429-news-watch-triage-candidates.json
@@ -1,0 +1,26 @@
+{
+  "resolution_type": "news_watch_candidates_triaged",
+  "created_at": "2026-04-29",
+  "source_monitoring_pr": "https://github.com/badjoke-lab/historical-exchange-index/pull/155",
+  "source_monitoring_run": "data-staging/monitoring/20260429/news-and-event-watch.json",
+  "purpose": "Record the remaining auto-discovered news candidates from the first filtered news/regulatory monitoring pass as triaged, so monitoring-health-watch no longer treats them as unresolved A candidates every run. This does not decide final canonical inclusion.",
+  "hold_or_out_of_scope": [
+    {
+      "canonical_name": "Zedxion",
+      "resolution": "triaged_for_manual_review",
+      "notes": "Potentially HEI-relevant regulatory shutdown candidate. Keep out of automatic pending-A alert loop until manually researched for public-quality entity/event/evidence records."
+    },
+    {
+      "canonical_name": "Txbit",
+      "resolution": "triaged_for_manual_review",
+      "notes": "Potentially HEI-relevant exchange closure candidate. Keep out of automatic pending-A alert loop until manually researched for public-quality entity/event/evidence records."
+    },
+    {
+      "canonical_name": "Serum",
+      "resolution": "triaged_for_manual_review",
+      "notes": "Potentially HEI-relevant DEX/protocol continuity candidate after FTX/Alameda-related disruption. Requires manual scope review before canonical inclusion because it may be protocol-level rather than exchange-entity-level."
+    }
+  ],
+  "canonical_data_changed": false,
+  "operator_notes": "This is watchlist bookkeeping only. It does not modify data/entities.json, data/events.json, or data/evidence.json. These candidates can still be promoted later through normal public-quality record PRs."
+}


### PR DESCRIPTION
## Summary
- add a watchlist resolution file for the remaining filtered news-watch candidates from PR #155
- mark Zedxion, Txbit, and Serum as `triaged_for_manual_review`
- keep the candidates available for future manual research while removing them from repeated pending-A monitoring alerts

## Scope
- staging/watchlist bookkeeping only
- no canonical data changes
- no entity/event/evidence changes

## Why
After tightening news/regulatory monitoring, the retained auto candidates were narrowed to Zedxion, Txbit, and Serum. These are potentially HEI-relevant, but they still require manual public-quality research before canonical inclusion. Without a resolution file, monitoring-health-watch continues to report them as pending A candidates every run.

## Expected validation
After merge, run HEI Monitoring with `enable_news_rss=true` and `enable_regulatory_watch=true`. Expected result:
- `A candidate still pending` findings for Zedxion, Txbit, and Serum disappear
- candidates remain recorded in the auto watchlist and can still be promoted later via normal public-quality record PRs
- canonical data guard remains clean