### PR TITLE
Skip resolved news watch candidates

### DIFF
--- a/data-staging/watchlists/resolution/20260429-news-watch-triage-candidates.json
+++ b/data-staging/watchlists/resolution/20260429-news-watch-triage-candidates.json
@@ -3,7 +3,7 @@
   "created_at": "2026-04-29",
   "source_monitoring_pr": "https://github.com/badjoke-lab/historical-exchange-index/pull/155",
   "source_monitoring_run": "data-staging/monitoring/20260429/news-and-event-watch.json",
-  "purpose": "Record the remaining auto-discovered news candidates from the first filtered news/regulatory monitoring pass as triaged, so monitoring-health-watch no longer treats them as unresolved A candidates every run. This does not decide final canonical inclusion.",
+  "purpose": "Record auto-discovered news candidates from the first filtered news/regulatory monitoring pass as triaged, so monitoring-health-watch no longer treats them as unresolved A candidates every run. This does not decide final canonical inclusion.",
   "hold_or_out_of_scope": [
     {
       "canonical_name": "Zedxion",
@@ -19,6 +19,11 @@
       "canonical_name": "Serum",
       "resolution": "triaged_for_manual_review",
       "notes": "Potentially HEI-relevant DEX/protocol continuity candidate after FTX/Alameda-related disruption. Requires manual scope review before canonical inclusion because it may be protocol-level rather than exchange-entity-level."
+    },
+    {
+      "canonical_name": "DX.",
+      "resolution": "triaged_for_manual_review",
+      "notes": "Auto-extracted shorthand from a DX.Exchange shutdown headline. Keep out of automatic pending-A alert loop; manually review as DX.Exchange before any canonical inclusion."
     }
   ],
   "canonical_data_changed": false,

--- a/scripts/monitoring/monitors/news-and-event-watch.mjs
+++ b/scripts/monitoring/monitors/news-and-event-watch.mjs
@@ -4,6 +4,7 @@ import { createFinding, createMonitorResult } from '../core/finding-utils.mjs';
 import { slugifyName, uniqueStrings } from '../core/normalize.mjs';
 import { buildEntityIndex, duplicateCheckForCandidate } from '../core/dedupe.mjs';
 import { classifyCandidate } from '../core/classify.mjs';
+import { loadResolutionFiles, normalizeName } from '../core/load-watchlists.mjs';
 import { NEWS_WATCH_ENABLED, getNewsQueries } from '../sources/news-queries.mjs';
 import { REGULATORY_WATCH_ENABLED, getRegulatoryQueries, getRegulatorySourceSummary } from '../sources/regulatory-sources.mjs';
 import { fetchGoogleNewsRss } from '../adapters/rss-google-news.mjs';
@@ -20,6 +21,7 @@ const GENERIC_CANDIDATE_NAMES = new Set([
   'complex',
   'consumer',
   'dominance',
+  'dx.',
   'etherdelta still holds',
   'first fca',
   'germany',
@@ -89,8 +91,13 @@ function isLikelyHeadlineFragment(candidate) {
   return headline.toLowerCase().includes(name.toLowerCase());
 }
 
-function isActionableNewsCandidate(candidate) {
+function isResolvedCandidate(candidate, resolutions) {
+  return resolutions?.resolvedNames?.has(normalizeName(candidate?.canonical_name || '')) || false;
+}
+
+function isActionableNewsCandidate(candidate, resolutions) {
   if (!candidate || isGenericCandidateName(candidate.canonical_name)) return false;
+  if (isResolvedCandidate(candidate, resolutions)) return false;
   if (isAmbiguousBrandCandidate(candidate)) return false;
   if (isLikelyHeadlineFragment(candidate)) return false;
 
@@ -116,8 +123,9 @@ function isActionableNewsCandidate(candidate) {
   return hasStrongSignal && qualityOk;
 }
 
-function isActionableRegulatoryCandidate(candidate) {
+function isActionableRegulatoryCandidate(candidate, resolutions) {
   if (!candidate || isGenericCandidateName(candidate.canonical_name)) return false;
+  if (isResolvedCandidate(candidate, resolutions)) return false;
   if (candidate.source_category !== 'regulatory_source') return false;
   if (candidate.duplicate_check?.matched_existing_entity) return false;
   if (!['A', 'B'].includes(candidate.candidate_class)) return false;
@@ -215,6 +223,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
   const entities = context?.canonicalData?.entities || [];
   const entityIndex = buildEntityIndex(entities);
   const regulatorySourceSummary = getRegulatorySourceSummary();
+  const resolutions = await loadResolutionFiles();
 
   if (!NEWS_WATCH_ENABLED && !REGULATORY_WATCH_ENABLED) {
     findings.push(createFinding({
@@ -260,7 +269,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
 
   const rawCandidates = groupNewsItemsIntoCandidates(allItems);
   const allCandidates = rawCandidates.map((candidate, index) => toCandidateRecord(candidate, entityIndex, context?.runId, index + 1));
-  const candidates = allCandidates.filter((candidate) => isActionableNewsCandidate(candidate) || isActionableRegulatoryCandidate(candidate));
+  const candidates = allCandidates.filter((candidate) => isActionableNewsCandidate(candidate, resolutions) || isActionableRegulatoryCandidate(candidate, resolutions));
   const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
   const regulatoryCandidates = candidates.filter((candidate) => candidate.source_category === 'regulatory_source');
   const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity);
@@ -327,6 +336,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
         raw_candidates: allCandidates.length,
         retained_candidates: candidates.length,
         dropped_candidates: allCandidates.length - candidates.length,
+        resolved_candidate_names: resolutions.resolvedNames.size,
       },
       candidates,
       summary: {
@@ -366,6 +376,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
         raw_candidates: allCandidates.length,
         candidates: candidates.length,
         dropped_candidates: allCandidates.length - candidates.length,
+        resolved_candidate_names: resolutions.resolvedNames.size,
         missing_in_hei: missingInHei.length,
         matched_existing: matchedExisting.length,
       },


### PR DESCRIPTION
## Summary
- make `news-and-event-watch` load watchlist resolution files and skip already-resolved candidates
- add `DX.` to the triaged news-watch resolution file
- add `DX.` to generic candidate filtering as a shorthand extraction artifact
- report resolved candidate count in news filtering summaries

## Why
After PR #156, Zedxion, Txbit, and Serum were resolved for monitoring-health-watch, but news-and-event-watch still emitted them as fresh actionable candidates because it did not read resolution files. The latest run also extracted `DX.` from a DX.Exchange headline, which should be triaged/reviewed manually as DX.Exchange instead of repeatedly alerting as a new A candidate.

## Scope
- monitoring logic and watchlist resolution bookkeeping only
- no canonical data changes
- no entity/event/evidence changes

## Expected validation
After merge, run HEI Monitoring with `enable_news_rss=true` and `enable_regulatory_watch=true`. Expected result:
- Zedxion, Txbit, Serum, and DX. are skipped by news-and-event-watch
- pending-A watchlist alerts for those names do not reappear
- canonical data guard remains clean