### PR TITLE
Allow insolvency event type

### DIFF
--- a/scripts/monitoring/core/constants.mjs
+++ b/scripts/monitoring/core/constants.mjs
@@ -72,6 +72,7 @@ export const EVENT_TYPE_VALUES = [
   'regulatory_action',
   'lawsuit',
   'bankruptcy_filed',
+  'insolvency',
   'insolvency_declared',
   'shutdown_announced',
   'shutdown_effective',


### PR DESCRIPTION
Add `insolvency` to the monitoring event type allowlist.

This covers the BitMarket.eu balance-freeze event added in PR #159 without changing canonical data.

Scope:
- monitoring constants only
- no entity, event, or evidence data changes