### PR TITLE
Ignore non-alert candidates for monitoring PR creation

### DIFF
--- a/scripts/monitoring/core/finding-utils.mjs
+++ b/scripts/monitoring/core/finding-utils.mjs
@@ -101,10 +101,14 @@ export async function runMonitorSafely(monitorName, monitorFn, context) {
   }
 }
 
+function hasAlertCandidate(result) {
+  const candidates = result?.candidates || [];
+  return candidates.some((candidate) => candidate?.candidate_class === 'A');
+}
+
 export function hasMeaningfulFindings(results = []) {
   return results.some((result) => {
     const findings = visibleFindings(result?.findings || []);
-    const candidates = result?.candidates || [];
-    return candidates.length > 0 || findings.length > 0;
+    return findings.length > 0 || hasAlertCandidate(result);
   });
 }


### PR DESCRIPTION
## Summary
- change monitoring PR trigger logic so candidate output alone is only meaningful when an A candidate exists
- keep visible findings as PR-triggering alerts
- prevent B-only external-list candidate batches from creating monitoring PRs every run

## Why
The external-list validation run produced `visible_findings=0`, but still created PR #163 because B candidates were counted as meaningful. Those B candidates are watchlist/baseline material, not operational alerts.

## Scope
- monitoring trigger logic only
- no canonical data changes
- no candidate classification changes

## Expected validation
After merge, run HEI Monitoring with `enable_external_lists=true`. Expected result:
- B-only candidate output does not create a monitoring PR
- A candidates or visible findings still create PRs
- canonical data guard remains clean