### PR TITLE
Use Node 24 for monitoring workflow

### DIFF
--- a/.github/workflows/hei-monitoring.yml
+++ b/.github/workflows/hei-monitoring.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: package-lock.json
 


### PR DESCRIPTION
## Summary
- change the HEI Monitoring workflow setup-node version from Node 20 to Node 24
- keep the existing FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment flag
- no monitoring logic or canonical data changes

## Why
The monitoring workflow is currently successful, but GitHub Actions logs still show a Node.js 20 deprecation warning. Moving the workflow runtime to Node 24 removes that warning path for the monitoring job.

## Scope
- workflow runtime only
- no data/entities.json, data/events.json, or data/evidence.json changes
- no package or lockfile changes

## Expected validation
Run HEI Monitoring after merge. Expected result:
- setup-node uses Node 24
- monitoring smoke test passes
- monitoring run passes
- canonical data guard remains clean