### PR TITLE
Add HEI publishing draft generator

### DIFF
--- a/data-staging/publishing-drafts/no-monitoring-run/publication-decision.json
+++ b/data-staging/publishing-drafts/no-monitoring-run/publication-decision.json
@@ -1,0 +1,21 @@
+{
+  "run_id": "no-monitoring-run",
+  "source_monitoring_dir": null,
+  "generated_at": "2026-05-02T00:00:00.000Z",
+  "should_publish": false,
+  "recommended_publication_type": "no_publish",
+  "homepage_headliner_available": false,
+  "x_post_available": false,
+  "counts": {
+    "publishable": 0,
+    "review_needed": 0,
+    "internal_only": 0,
+    "no_material": 1
+  },
+  "reasons": [
+    "No monitoring run directory was found."
+  ],
+  "next_actions": [
+    "Run HEI Monitoring first, then run publish:draft against that monitoring output."
+  ]
+}

--- a/docs/publishing-safety-policy.md
+++ b/docs/publishing-safety-policy.md
@@ -1,0 +1,111 @@
+# HEI Publishing Safety Policy
+
+Status: initial implementation policy  
+Scope: Publishing drafts generated from HEI internal monitoring outputs
+
+## Core rule
+
+HEI monitoring output is internal by default.
+
+External publishing must use edited drafts only. Raw monitoring output must not be copied directly into public pages, social posts, or update articles.
+
+## Allowed first-stage external materials
+
+The first-stage publishing draft generator may prepare drafts for:
+
+- reviewed HEI registry updates
+- monitoring-signal summaries that require manual review
+- evidence / coverage aggregate summaries
+- X post drafts for manual posting
+- homepage headliner drafts for later manual review
+
+## Not allowed in public drafts
+
+The following must remain internal unless separately reviewed and rewritten:
+
+- raw active-status checks
+- DNS failure lists
+- HTTP error lists
+- evidence URL 404 lists
+- GitHub Actions failure logs
+- internal scores
+- duplicate matching internals
+- possible-dead or at-risk raw classifications
+- monitoring system error details
+
+## Required labels for unconfirmed material
+
+Unconfirmed material must use labels such as:
+
+- monitoring signal only
+- not canonical yet
+- under review
+- requires further source review
+
+Japanese equivalents may be used when writing Japanese copy:
+
+- 監視シグナル
+- HEI正式分類ではありません
+- 確認中
+- 追加確認が必要です
+
+## Strong language restrictions
+
+Auto-generated publishing drafts should avoid:
+
+- dangerous
+- scam
+- fraud
+- dead soon
+- will collapse
+- bankrupt confirmed
+- unsafe exchange
+- 詐欺
+- 危険
+- 死にそう
+- 破綻確定
+- 出金できないらしい
+- 飛んだ
+
+Canonical HEI enum values may still appear when already reviewed in canonical records, but they should not be used as sensational headlines.
+
+## Publication workflow
+
+The safe workflow is:
+
+```txt
+monitoring output
+↓
+publishing draft generation
+↓
+manual / AI review
+↓
+copy edit and source check
+↓
+optional promotion to content/updates
+↓
+manual X post
+```
+
+The generator must not:
+
+- write to `content/updates/**`
+- update app pages
+- post to X
+- change canonical JSON data
+
+## First implementation goal
+
+The first goal is not to publish content.
+
+The first goal is to determine whether monitoring output consistently produces usable external material.
+
+The key outputs are:
+
+- `publication-decision.json`
+- `publication-items.json`
+- `internal-review.md`
+- `homepage-headliner.md`
+- `updates-article-draft.md`
+- `x-post-drafts.md`
+- `source-map.json`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "monitor": "node scripts/monitoring/run.mjs",
     "monitor:dry": "HEI_MONITORING_MODE=manual node scripts/monitoring/run.mjs",
     "monitor:promote-candidate": "node scripts/monitoring/promote-candidate-to-staging.mjs",
-    "monitor:smoke": "node scripts/monitoring/smoke-test.mjs"
+    "monitor:smoke": "node scripts/monitoring/smoke-test.mjs",
+    "publish:draft": "node scripts/publishing/build-publishing-drafts.mjs"
   },
   "dependencies": {
     "next": "^15.2.8",

--- a/scripts/publishing/build-publishing-drafts.mjs
+++ b/scripts/publishing/build-publishing-drafts.mjs
@@ -91,9 +91,7 @@ async function findLatestMonitoringDir() {
     .filter((name) => /^\d{8}$/.test(name))
     .sort();
 
-  if (dirs.length === 0) {
-    throw new Error(`No monitoring run directories found under ${MONITORING_ROOT}`);
-  }
+  if (dirs.length === 0) return null;
 
   return path.join(MONITORING_ROOT, dirs.at(-1));
 }
@@ -264,6 +262,9 @@ function buildDecision({ runId, monitoringDir, generatedAt, items, minPublishabl
   } else if (counts.review_needed > 0) {
     reasons.push('No publishable items, but review-needed items exist.');
     nextActions.push('Manually verify review-needed items and add source review before publication.');
+  } else if (!monitoringDir) {
+    reasons.push('No monitoring run directory was found.');
+    nextActions.push('Run HEI Monitoring first, then run publish:draft against that monitoring output.');
   } else {
     reasons.push('No publishable material after safety filtering.');
     nextActions.push('Do not publish this run.');
@@ -271,7 +272,7 @@ function buildDecision({ runId, monitoringDir, generatedAt, items, minPublishabl
 
   return {
     run_id: runId,
-    source_monitoring_dir: monitoringDir,
+    source_monitoring_dir: monitoringDir || null,
     generated_at: generatedAt,
     should_publish: shouldPublish,
     recommended_publication_type: recommendedPublicationType,
@@ -341,7 +342,7 @@ function buildHomepageHeadliner({ dateLabel, decision, items }) {
 function buildUpdatesArticleDraft({ dateLabel, decision, items }) {
   const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
   const publishable = items.filter((item) => item.publishability === 'publishable');
-  const safeToPublish = decision.should_publish ? 'false' : 'false';
+  const safeToPublish = 'false';
   const type = decision.recommended_publication_type;
   const lines = [];
 
@@ -435,7 +436,22 @@ function truncate(value, length) {
   return text.length <= length ? text : `${text.slice(0, length - 1)}…`;
 }
 
+function makeNoMonitoringRun() {
+  return {
+    manifest: {
+      run_id: 'no-monitoring-run',
+      created_at: new Date().toISOString(),
+      mode: 'publishing-draft-only',
+      monitors: [],
+    },
+    summary: '',
+    monitorReports: [],
+  };
+}
+
 async function loadMonitoringRun(monitoringDir) {
+  if (!monitoringDir) return makeNoMonitoringRun();
+
   const manifestPath = path.join(monitoringDir, 'manifest.json');
   const manifest = await readJson(manifestPath, null);
   if (!manifest) {
@@ -464,7 +480,7 @@ async function loadMonitoringRun(monitoringDir) {
 
 function collectPublicationItems(monitorReports) {
   const items = [];
-  for (const { fileName, filePath, report } of monitorReports) {
+  for (const { filePath, report } of monitorReports) {
     const sourceMonitor = report.monitor;
     for (const finding of report.findings || []) {
       items.push(makePublicationItem({
@@ -481,9 +497,6 @@ function collectPublicationItems(monitorReports) {
         sourceType: 'candidate',
         source: candidate,
       }));
-    }
-    if ((report.findings || []).length === 0 && (report.candidates || []).length === 0 && report.summary) {
-      // No item needed. The decision file records no_material when nothing is collected.
     }
   }
 
@@ -506,7 +519,7 @@ async function main() {
   const args = parseArgs(process.argv);
   const monitoringDir = normalizeMonitoringDir(args.monitoringDir) || await findLatestMonitoringDir();
   const { manifest, monitorReports } = await loadMonitoringRun(monitoringDir);
-  const runId = manifest.run_id || path.basename(monitoringDir);
+  const runId = manifest.run_id || path.basename(monitoringDir || 'no-monitoring-run');
   const generatedAt = new Date().toISOString();
   const dateLabel = generatedAt.slice(0, 10);
   const outputDir = path.join(OUTPUT_ROOT, runId);

--- a/scripts/publishing/build-publishing-drafts.mjs
+++ b/scripts/publishing/build-publishing-drafts.mjs
@@ -1,0 +1,543 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const MONITORING_ROOT = path.join('data-staging', 'monitoring');
+const OUTPUT_ROOT = path.join('data-staging', 'publishing-drafts');
+const INTERNAL_ONLY_MONITORS = new Set([
+  'active-status-watch',
+  'site-and-seo-watch',
+  'monitoring-health-watch',
+]);
+const NOISE_ONLY_CATEGORIES = new Set([
+  'official_site_dns_failure',
+  'official_site_http_error',
+  'official_site_redirected',
+  'evidence_url_http_error',
+  'evidence_url_dns_failure',
+  'evidence_url_redirected',
+  'candidate_discovery_source_empty',
+  'news_rss_disabled',
+  'regulatory_watch_disabled',
+  'site_seo_checks_disabled',
+]);
+const FORBIDDEN_TERMS = [
+  'dangerous',
+  'dead soon',
+  'will collapse',
+  'bankrupt confirmed',
+  'unsafe exchange',
+  '詐欺',
+  '危険',
+  '死にそう',
+  '破綻確定',
+  '出金できないらしい',
+  '飛んだ',
+];
+
+function parseArgs(argv) {
+  const args = {
+    monitoringDir: null,
+    mode: 'dry-run',
+    minPublishable: 1,
+    includeReviewNeeded: true,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--monitoring-dir') {
+      args.monitoringDir = next;
+      i += 1;
+    } else if (arg === '--mode') {
+      args.mode = next || args.mode;
+      i += 1;
+    } else if (arg === '--min-publishable') {
+      args.minPublishable = Number.parseInt(next || '1', 10);
+      i += 1;
+    } else if (arg === '--include-review-needed') {
+      args.includeReviewNeeded = next !== 'false';
+      i += 1;
+    }
+  }
+
+  return args;
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(filePath, fallback = null) {
+  if (!(await exists(filePath))) return fallback;
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function readText(filePath, fallback = '') {
+  if (!(await exists(filePath))) return fallback;
+  return fs.readFile(filePath, 'utf8');
+}
+
+async function findLatestMonitoringDir() {
+  const entries = await fs.readdir(MONITORING_ROOT, { withFileTypes: true }).catch(() => []);
+  const dirs = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => /^\d{8}$/.test(name))
+    .sort();
+
+  if (dirs.length === 0) {
+    throw new Error(`No monitoring run directories found under ${MONITORING_ROOT}`);
+  }
+
+  return path.join(MONITORING_ROOT, dirs.at(-1));
+}
+
+function normalizeMonitoringDir(input) {
+  if (!input) return null;
+  return input.replace(/\/$/, '');
+}
+
+function makePublicationItem({ sourceMonitor, sourceFile, sourceType, source }) {
+  const sourceId = source.finding_id || source.candidate_id || source.id || null;
+  const title = source.title || source.headline || source.canonical_name || `${sourceMonitor} item`;
+  const summary = source.summary || source.hei_relevance || source.description || 'Monitoring item requires review.';
+  const sourceUrls = Array.isArray(source.source_urls) ? source.source_urls.filter(Boolean) : [];
+  const category = source.category || source.record_shape || source.candidate_class || 'unknown';
+  const candidateClass = source.candidate_class || null;
+  const severity = source.severity || null;
+
+  const item = {
+    publication_item_id: null,
+    source_monitor: sourceMonitor,
+    source_file: sourceFile,
+    source_type: sourceType,
+    source_ids: sourceId ? [sourceId] : [],
+    source_category: category,
+    source_severity: severity,
+    candidate_class: candidateClass,
+    publishability: 'internal_only',
+    recommended_type: 'no_publish',
+    title,
+    safe_summary: toSafeSummary(summary),
+    public_status_label: 'Internal only',
+    source_urls: sourceUrls,
+    safety_notes: [],
+    recommended_action: source.recommended_action || source.next_action || 'review',
+  };
+
+  applyPublishabilityRules(item, source);
+  return item;
+}
+
+function applyPublishabilityRules(item, source) {
+  const monitor = item.source_monitor;
+  const category = item.source_category;
+  const sourceUrls = item.source_urls;
+  const candidateClass = item.candidate_class;
+  const recommendedAction = String(item.recommended_action || '');
+
+  if (INTERNAL_ONLY_MONITORS.has(monitor)) {
+    item.publishability = 'internal_only';
+    item.recommended_type = 'no_publish';
+    item.public_status_label = 'Internal monitoring only';
+    item.safety_notes.push(`${monitor} is not used for external publication in v1.`);
+    return;
+  }
+
+  if (NOISE_ONLY_CATEGORIES.has(category)) {
+    item.publishability = 'internal_only';
+    item.recommended_type = 'no_publish';
+    item.public_status_label = 'Internal monitoring only';
+    item.safety_notes.push('Noise/control/status category is not publishable.');
+    return;
+  }
+
+  if (monitor === 'candidate-discovery') {
+    if (candidateClass === 'A' || candidateClass === 'B') {
+      item.publishability = 'review_needed';
+      item.recommended_type = 'research_note';
+      item.public_status_label = 'Not canonical yet';
+      item.safety_notes.push('Candidate discovery requires manual source review before publication.');
+    } else {
+      item.publishability = 'internal_only';
+      item.recommended_type = 'no_publish';
+      item.public_status_label = 'Internal only';
+    }
+    return;
+  }
+
+  if (monitor === 'news-and-event-watch') {
+    if (sourceUrls.length > 0) {
+      item.publishability = source.review_status === 'reviewed' ? 'publishable' : 'review_needed';
+      item.recommended_type = 'weekly_watch';
+      item.public_status_label = source.review_status === 'reviewed' ? 'Reviewed item' : 'Monitoring signal only';
+      item.safety_notes.push('News/event item should not be treated as a final HEI classification before review.');
+    } else {
+      item.publishability = 'internal_only';
+      item.recommended_type = 'no_publish';
+      item.public_status_label = 'Internal only';
+      item.safety_notes.push('No public source URLs available.');
+    }
+    return;
+  }
+
+  if (monitor === 'evidence-and-record-quality-watch' || monitor === 'evidence-health-watch') {
+    if (category.includes('coverage') || category.includes('aggregate')) {
+      item.publishability = 'review_needed';
+      item.recommended_type = 'evidence_report';
+      item.public_status_label = 'Evidence coverage item';
+      item.safety_notes.push('Only aggregate evidence/coverage information may be used externally.');
+    } else {
+      item.publishability = 'internal_only';
+      item.recommended_type = 'no_publish';
+      item.public_status_label = 'Internal only';
+      item.safety_notes.push('Individual evidence health and record quality findings stay internal.');
+    }
+    return;
+  }
+
+  if (recommendedAction.includes('canonical') || source.review_status === 'reviewed') {
+    item.publishability = 'publishable';
+    item.recommended_type = 'registry_update';
+    item.public_status_label = 'Reviewed HEI update';
+    item.safety_notes.push('Marked as reviewed/canonical by source data.');
+    return;
+  }
+
+  item.publishability = 'internal_only';
+  item.recommended_type = 'no_publish';
+  item.public_status_label = 'Internal only';
+}
+
+function toSafeSummary(value) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  if (!text) return 'Monitoring item requires review.';
+  let safe = text;
+  for (const term of FORBIDDEN_TERMS) {
+    const pattern = new RegExp(escapeRegExp(term), 'gi');
+    safe = safe.replace(pattern, 'requires review');
+  }
+  return safe;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function assignPublicationIds(items, datePart) {
+  return items.map((item, index) => ({
+    ...item,
+    publication_item_id: `pubitem_${datePart}_${String(index + 1).padStart(3, '0')}`,
+  }));
+}
+
+function determineRecommendedType(items) {
+  const publishable = items.filter((item) => item.publishability === 'publishable');
+  const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
+  const source = publishable[0] || reviewNeeded[0];
+  return source?.recommended_type || 'no_publish';
+}
+
+function buildDecision({ runId, monitoringDir, generatedAt, items, minPublishable }) {
+  const counts = {
+    publishable: items.filter((item) => item.publishability === 'publishable').length,
+    review_needed: items.filter((item) => item.publishability === 'review_needed').length,
+    internal_only: items.filter((item) => item.publishability === 'internal_only').length,
+    no_material: items.length === 0 ? 1 : 0,
+  };
+  const recommendedPublicationType = counts.publishable >= minPublishable
+    ? determineRecommendedType(items.filter((item) => item.publishability === 'publishable'))
+    : 'no_publish';
+  const shouldPublish = counts.publishable >= minPublishable;
+  const reasons = [];
+  const nextActions = [];
+
+  if (shouldPublish) {
+    reasons.push(`Found ${counts.publishable} publishable item(s) after safety filtering.`);
+    nextActions.push('Review generated draft before moving anything to content/updates.');
+  } else if (counts.review_needed > 0) {
+    reasons.push('No publishable items, but review-needed items exist.');
+    nextActions.push('Manually verify review-needed items and add source review before publication.');
+  } else {
+    reasons.push('No publishable material after safety filtering.');
+    nextActions.push('Do not publish this run.');
+  }
+
+  return {
+    run_id: runId,
+    source_monitoring_dir: monitoringDir,
+    generated_at: generatedAt,
+    should_publish: shouldPublish,
+    recommended_publication_type: recommendedPublicationType,
+    homepage_headliner_available: shouldPublish,
+    x_post_available: shouldPublish,
+    counts,
+    reasons,
+    next_actions: nextActions,
+  };
+}
+
+function buildInternalReview({ dateLabel, decision, items }) {
+  const publishable = items.filter((item) => item.publishability === 'publishable');
+  const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
+  const internalOnly = items.filter((item) => item.publishability === 'internal_only');
+  const lines = [];
+
+  lines.push(`# HEI Publishing Draft Review - ${dateLabel}`);
+  lines.push('');
+  lines.push('## Decision');
+  lines.push(`- should_publish: ${decision.should_publish}`);
+  lines.push(`- recommended type: ${decision.recommended_publication_type}`);
+  lines.push(`- publishable: ${decision.counts.publishable}`);
+  lines.push(`- review_needed: ${decision.counts.review_needed}`);
+  lines.push(`- internal_only: ${decision.counts.internal_only}`);
+  lines.push('');
+  lines.push('## Publishable items');
+  if (publishable.length === 0) lines.push('- None.');
+  for (const item of publishable) {
+    lines.push(`- ${item.title} — ${item.public_status_label}`);
+  }
+  lines.push('');
+  lines.push('## Review needed');
+  if (reviewNeeded.length === 0) lines.push('- None.');
+  for (const item of reviewNeeded.slice(0, 20)) {
+    lines.push(`- ${item.title} — ${item.public_status_label}; ${item.safe_summary}`);
+  }
+  if (reviewNeeded.length > 20) lines.push(`- ...and ${reviewNeeded.length - 20} more review-needed item(s).`);
+  lines.push('');
+  lines.push('## Internal only summary');
+  const byMonitor = countBy(internalOnly, (item) => item.source_monitor);
+  if (internalOnly.length === 0) lines.push('- None.');
+  for (const [monitor, count] of Object.entries(byMonitor)) {
+    lines.push(`- ${monitor}: ${count}`);
+  }
+  lines.push('');
+  lines.push('## Safety notes');
+  lines.push('- No raw monitoring output should be published.');
+  lines.push('- Active status checks are internal only.');
+  lines.push('- Review-needed items are not canonical HEI classifications.');
+  lines.push('');
+  lines.push('## Suggested next actions');
+  decision.next_actions.forEach((action, index) => lines.push(`${index + 1}. ${action}`));
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function buildHomepageHeadliner({ dateLabel, decision, items }) {
+  if (!decision.homepage_headliner_available) {
+    return `---\nsafe_to_publish: false\nreason: no_publishable_material\n---\n\nNo homepage headliner for this run.\n`;
+  }
+  const first = items.find((item) => item.publishability === 'publishable');
+  return `---\ntype: ${decision.recommended_publication_type}\ndate: ${dateLabel}\nsafe_to_publish: true\n---\n\n## Latest from HEI\n\n${first.title}\n\n${first.safe_summary}\n`;
+}
+
+function buildUpdatesArticleDraft({ dateLabel, decision, items }) {
+  const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
+  const publishable = items.filter((item) => item.publishability === 'publishable');
+  const safeToPublish = decision.should_publish ? 'false' : 'false';
+  const type = decision.recommended_publication_type;
+  const lines = [];
+
+  lines.push('---');
+  lines.push(`title: "HEI Publishing Draft - ${dateLabel}"`);
+  lines.push(`date: "${dateLabel}"`);
+  lines.push(`type: "${type}"`);
+  lines.push(`safe_to_publish: ${safeToPublish}`);
+  lines.push(`source_run_id: "${decision.run_id}"`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# HEI Publishing Draft - ${dateLabel}`);
+  lines.push('');
+  lines.push('## Publication decision');
+  lines.push(decision.should_publish
+    ? 'Publishable material was found, but this draft still requires manual review before publication.'
+    : 'No publishable material was found after safety filtering.');
+  lines.push('');
+  lines.push('## Publishable items');
+  if (publishable.length === 0) lines.push('- None.');
+  for (const item of publishable) {
+    lines.push(`- ${item.title} — ${item.safe_summary}`);
+  }
+  lines.push('');
+  lines.push('## Review-needed items');
+  if (reviewNeeded.length === 0) lines.push('- None.');
+  for (const item of reviewNeeded.slice(0, 20)) {
+    lines.push(`- ${item.title} — ${item.public_status_label}; ${item.safe_summary}`);
+  }
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('This draft is generated from internal monitoring output and is not public-ready.');
+  lines.push('Monitoring signals are not final HEI classifications.');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function buildXPostDrafts({ dateLabel, decision, items }) {
+  if (!decision.x_post_available) {
+    return `# X Post Drafts - ${dateLabel}\n\nNo X post draft generated for this run.\nReason: no publishable material after safety filtering.\n`;
+  }
+  const publishable = items.filter((item) => item.publishability === 'publishable').slice(0, 4);
+  const lines = [];
+  lines.push(`# X Post Drafts - ${dateLabel}`);
+  lines.push('');
+  lines.push('## Draft 1');
+  lines.push('');
+  lines.push(`HEI Publishing Update — ${dateLabel}`);
+  lines.push('');
+  lines.push('Reviewed HEI material is ready for editorial review:');
+  for (const item of publishable) {
+    lines.push(`- ${truncate(item.title, 70)}`);
+  }
+  lines.push('');
+  lines.push('Full update:');
+  lines.push('[URL]');
+  lines.push('');
+  lines.push('Note: Review before posting. Do not auto-post.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function buildSourceMap({ runId, items }) {
+  return {
+    run_id: runId,
+    items: items.map((item) => ({
+      publication_item_id: item.publication_item_id,
+      draft_files: [
+        'updates-article-draft.md',
+        ...(item.publishability === 'publishable' ? ['homepage-headliner.md', 'x-post-drafts.md'] : []),
+      ],
+      source_monitor: item.source_monitor,
+      source_file: item.source_file,
+      source_ids: item.source_ids,
+      source_urls: item.source_urls,
+    })),
+  };
+}
+
+function countBy(items, getKey) {
+  return items.reduce((acc, item) => {
+    const key = getKey(item) || 'unknown';
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function truncate(value, length) {
+  const text = String(value || '');
+  return text.length <= length ? text : `${text.slice(0, length - 1)}…`;
+}
+
+async function loadMonitoringRun(monitoringDir) {
+  const manifestPath = path.join(monitoringDir, 'manifest.json');
+  const manifest = await readJson(manifestPath, null);
+  if (!manifest) {
+    throw new Error(`Missing manifest.json in ${monitoringDir}`);
+  }
+
+  const summary = await readText(path.join(monitoringDir, 'summary.md'), '');
+  const entries = await fs.readdir(monitoringDir, { withFileTypes: true });
+  const jsonFiles = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => name.endsWith('.json') && name !== 'manifest.json')
+    .sort();
+
+  const monitorReports = [];
+  for (const fileName of jsonFiles) {
+    const filePath = path.join(monitoringDir, fileName);
+    const report = await readJson(filePath, null);
+    if (report && report.monitor) {
+      monitorReports.push({ fileName, filePath, report });
+    }
+  }
+
+  return { manifest, summary, monitorReports };
+}
+
+function collectPublicationItems(monitorReports) {
+  const items = [];
+  for (const { fileName, filePath, report } of monitorReports) {
+    const sourceMonitor = report.monitor;
+    for (const finding of report.findings || []) {
+      items.push(makePublicationItem({
+        sourceMonitor,
+        sourceFile: filePath,
+        sourceType: 'finding',
+        source: finding,
+      }));
+    }
+    for (const candidate of report.candidates || []) {
+      items.push(makePublicationItem({
+        sourceMonitor,
+        sourceFile: filePath,
+        sourceType: 'candidate',
+        source: candidate,
+      }));
+    }
+    if ((report.findings || []).length === 0 && (report.candidates || []).length === 0 && report.summary) {
+      // No item needed. The decision file records no_material when nothing is collected.
+    }
+  }
+
+  const datePart = new Date().toISOString().slice(0, 10).replaceAll('-', '');
+  return assignPublicationIds(items, datePart);
+}
+
+async function writeOutputs(outputDir, outputs) {
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, 'publication-decision.json'), `${JSON.stringify(outputs.decision, null, 2)}\n`);
+  await fs.writeFile(path.join(outputDir, 'publication-items.json'), `${JSON.stringify(outputs.items, null, 2)}\n`);
+  await fs.writeFile(path.join(outputDir, 'source-map.json'), `${JSON.stringify(outputs.sourceMap, null, 2)}\n`);
+  await fs.writeFile(path.join(outputDir, 'internal-review.md'), outputs.internalReview);
+  await fs.writeFile(path.join(outputDir, 'homepage-headliner.md'), outputs.homepageHeadliner);
+  await fs.writeFile(path.join(outputDir, 'updates-article-draft.md'), outputs.updatesArticleDraft);
+  await fs.writeFile(path.join(outputDir, 'x-post-drafts.md'), outputs.xPostDrafts);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const monitoringDir = normalizeMonitoringDir(args.monitoringDir) || await findLatestMonitoringDir();
+  const { manifest, monitorReports } = await loadMonitoringRun(monitoringDir);
+  const runId = manifest.run_id || path.basename(monitoringDir);
+  const generatedAt = new Date().toISOString();
+  const dateLabel = generatedAt.slice(0, 10);
+  const outputDir = path.join(OUTPUT_ROOT, runId);
+  const items = collectPublicationItems(monitorReports);
+  const decision = buildDecision({
+    runId,
+    monitoringDir,
+    generatedAt,
+    items,
+    minPublishable: args.minPublishable,
+  });
+
+  const outputs = {
+    decision,
+    items,
+    sourceMap: buildSourceMap({ runId, items }),
+    internalReview: buildInternalReview({ dateLabel, decision, items }),
+    homepageHeadliner: buildHomepageHeadliner({ dateLabel, decision, items }),
+    updatesArticleDraft: buildUpdatesArticleDraft({ dateLabel, decision, items }),
+    xPostDrafts: buildXPostDrafts({ dateLabel, decision, items }),
+  };
+
+  await writeOutputs(outputDir, outputs);
+  console.log(`HEI publishing draft generated: ${outputDir}`);
+  console.log(`should_publish: ${decision.should_publish}`);
+  console.log(`publishable: ${decision.counts.publishable}`);
+  console.log(`review_needed: ${decision.counts.review_needed}`);
+  console.log(`internal_only: ${decision.counts.internal_only}`);
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `publish:draft` npm script
- add initial `scripts/publishing/build-publishing-drafts.mjs`
- add publishing draft staging directory and safety policy
- generate no-publish decision output when no monitoring run exists

## What this does
- reads the latest `data-staging/monitoring/YYYYMMDD` directory when available
- classifies monitoring findings/candidates into `publishable`, `review_needed`, and `internal_only`
- writes draft files under `data-staging/publishing-drafts/<run_id>/`
- keeps public publishing gated behind manual review

## Safety
- does not modify canonical data
- does not write to `content/updates/**`
- does not change app pages
- does not auto-post to X
- treats active-status, site/SEO, monitoring-health, raw URL checks, and individual evidence health findings as internal-only by default

## Outputs
- `publication-decision.json`
- `publication-items.json`
- `internal-review.md`
- `homepage-headliner.md`
- `updates-article-draft.md`
- `x-post-drafts.md`
- `source-map.json`

## Validation
- Not run locally in this environment. Expected command after checkout:
  - `npm run publish:draft`

## Notes
This is Phase 1 only. `/updates`, homepage headliner rendering, X posting, and publishing workflow automation are intentionally not included.