### PR TITLE
Tighten candidate discovery and publishing draft priority

### DIFF
--- a/scripts/monitoring/sources/external-lists.mjs
+++ b/scripts/monitoring/sources/external-lists.mjs
@@ -21,12 +21,16 @@ export const EXTERNAL_LIST_SOURCES = [
     type: 'remote_json',
     enabled: ENABLE_REMOTE_LISTS,
     url: 'https://api.llama.fi/protocols',
-    description: 'Optional remote adapter for DEX-like protocol discovery. Disabled by default to avoid noisy scheduled runs.',
-    category: 'active_motherlist',
-    item_limit: 100,
+    description: 'Optional remote adapter for DEX / derivatives / trading-venue discovery. Disabled by default and deliberately excludes staking, lending, vault, and yield products.',
+    category: 'active_trading_venue_motherlist',
+    item_limit: 75,
     transform: 'defillama_protocols_dexlike',
   },
 ];
+
+const DEFINITELY_TRADING_VENUE_RE = /\b(dex|derivatives?|options?|synthetics?)\b/i;
+const TRADING_NAME_RE = /\b(dex|swap|exchange|perp|perps|perpetual|trade|trading|market|markets)\b/i;
+const NON_EXCHANGE_PROTOCOL_RE = /\b(liquid\s+staking|staking|staked|lst\b|lsd\b|restaking|validator|yield|vault|vaults|earn|lending|borrow|borrowing|cdp|rwa|bridge|wallet|nft|index|privacy|oracle)\b/i;
 
 function withSource(item, source) {
   return {
@@ -59,24 +63,41 @@ async function fetchJson(url) {
   }
 }
 
+function isDefillamaTradingVenueCandidate(item) {
+  const category = String(item.category || '');
+  const name = String(item.name || '');
+  const descriptionText = `${name} ${category} ${(item.chains || []).join(' ')}`;
+  const hasTradingCategory = DEFINITELY_TRADING_VENUE_RE.test(category);
+  const hasTradingName = TRADING_NAME_RE.test(name);
+  const looksLikeNonExchangeProduct = NON_EXCHANGE_PROTOCOL_RE.test(descriptionText);
+
+  if (looksLikeNonExchangeProduct && !hasTradingCategory) return false;
+  if (hasTradingCategory) return true;
+  if (hasTradingName && !looksLikeNonExchangeProduct) return true;
+  return false;
+}
+
+function inferDefillamaType(item) {
+  const category = String(item.category || '');
+  const name = String(item.name || '');
+  if (/\b(dex|derivatives?|options?|synthetics?)\b/i.test(`${category} ${name}`)) return 'dex';
+  return 'hybrid';
+}
+
 function transformDefillamaProtocolsDexlike(json, source) {
   const protocols = Array.isArray(json) ? json : [];
-  const dexLike = protocols.filter((item) => {
-    const text = `${item.name || ''} ${item.category || ''} ${(item.chains || []).join(' ')}`.toLowerCase();
-    return /\b(dex|derivatives|options|synthetics|yield aggregator|liquid staking)\b/.test(text)
-      && !/\b(lending|wallet|nft|bridge)\b/.test(text);
-  });
+  const dexLike = protocols.filter(isDefillamaTradingVenueCandidate);
 
-  return dexLike.slice(0, source.item_limit || 100).map((item) => withSource({
+  return dexLike.slice(0, source.item_limit || 75).map((item) => withSource({
     canonical_name: item.name,
     aliases: [],
-    likely_type: /dex|derivatives|options|synthetics/i.test(item.category || '') ? 'dex' : 'hybrid',
+    likely_type: inferDefillamaType(item),
     likely_status: 'active',
-    headline: `${item.name} appears in a remote protocol directory`,
+    headline: `${item.name} appears in a remote trading-venue directory`,
     description: `${item.name} category=${item.category || 'unknown'} chains=${(item.chains || []).slice(0, 8).join(', ')}`,
     source_urls: [item.url || `https://defillama.com/protocol/${item.slug}`].filter(Boolean),
     source_quality: 'medium',
-    signals: ['external list diff', 'active motherlist candidate', item.category || 'unknown'],
+    signals: ['external list diff', 'active trading venue candidate', item.category || 'unknown'],
     url: item.url || null,
     official_url: item.url || null,
   }, source));

--- a/scripts/publishing/build-publishing-drafts.mjs
+++ b/scripts/publishing/build-publishing-drafts.mjs
@@ -106,7 +106,7 @@ function makePublicationItem({ sourceMonitor, sourceFile, sourceType, source }) 
   const title = source.title || source.headline || source.canonical_name || `${sourceMonitor} item`;
   const summary = source.summary || source.hei_relevance || source.description || 'Monitoring item requires review.';
   const sourceUrls = Array.isArray(source.source_urls) ? source.source_urls.filter(Boolean) : [];
-  const category = source.category || source.record_shape || source.candidate_class || 'unknown';
+  const category = source.category || source.source_category || source.record_shape || source.candidate_class || 'unknown';
   const candidateClass = source.candidate_class || null;
   const severity = source.severity || null;
 
@@ -127,9 +127,11 @@ function makePublicationItem({ sourceMonitor, sourceFile, sourceType, source }) 
     source_urls: sourceUrls,
     safety_notes: [],
     recommended_action: source.recommended_action || source.next_action || 'review',
+    priority: 100,
   };
 
   applyPublishabilityRules(item, source);
+  item.priority = publicationPriority(item, source);
   return item;
 }
 
@@ -157,10 +159,15 @@ function applyPublishabilityRules(item, source) {
   }
 
   if (monitor === 'candidate-discovery') {
-    if (candidateClass === 'A' || candidateClass === 'B') {
+    if (candidateClass === 'A') {
       item.publishability = 'review_needed';
       item.recommended_type = 'research_note';
-      item.public_status_label = 'Not canonical yet';
+      item.public_status_label = 'A candidate / not canonical yet';
+      item.safety_notes.push('Candidate discovery requires manual source review before publication.');
+    } else if (candidateClass === 'B') {
+      item.publishability = 'review_needed';
+      item.recommended_type = 'research_note';
+      item.public_status_label = 'B candidate / not canonical yet';
       item.safety_notes.push('Candidate discovery requires manual source review before publication.');
     } else {
       item.publishability = 'internal_only';
@@ -174,7 +181,7 @@ function applyPublishabilityRules(item, source) {
     if (sourceUrls.length > 0) {
       item.publishability = source.review_status === 'reviewed' ? 'publishable' : 'review_needed';
       item.recommended_type = 'weekly_watch';
-      item.public_status_label = source.review_status === 'reviewed' ? 'Reviewed item' : 'Monitoring signal only';
+      item.public_status_label = source.review_status === 'reviewed' ? 'Reviewed item' : 'News/event monitoring signal';
       item.safety_notes.push('News/event item should not be treated as a final HEI classification before review.');
     } else {
       item.publishability = 'internal_only';
@@ -213,6 +220,23 @@ function applyPublishabilityRules(item, source) {
   item.public_status_label = 'Internal only';
 }
 
+function publicationPriority(item, source) {
+  if (item.publishability === 'publishable') return 0;
+  if (item.source_monitor === 'news-and-event-watch' && item.candidate_class === 'A') return 5;
+  if (item.source_monitor === 'news-and-event-watch') return 10;
+  if (item.candidate_class === 'A') return 20;
+  if (item.candidate_class === 'B') return 40;
+  if (source?.historical_dead_strength === 'medium') return 45;
+  return 100;
+}
+
+function sortPublicationItems(items) {
+  return [...items].sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+    return String(a.title).localeCompare(String(b.title));
+  });
+}
+
 function toSafeSummary(value) {
   const text = String(value || '').replace(/\s+/g, ' ').trim();
   if (!text) return 'Monitoring item requires review.';
@@ -236,8 +260,8 @@ function assignPublicationIds(items, datePart) {
 }
 
 function determineRecommendedType(items) {
-  const publishable = items.filter((item) => item.publishability === 'publishable');
-  const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
+  const publishable = sortPublicationItems(items.filter((item) => item.publishability === 'publishable'));
+  const reviewNeeded = sortPublicationItems(items.filter((item) => item.publishability === 'review_needed'));
   const source = publishable[0] || reviewNeeded[0];
   return source?.recommended_type || 'no_publish';
 }
@@ -285,8 +309,8 @@ function buildDecision({ runId, monitoringDir, generatedAt, items, minPublishabl
 }
 
 function buildInternalReview({ dateLabel, decision, items }) {
-  const publishable = items.filter((item) => item.publishability === 'publishable');
-  const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
+  const publishable = sortPublicationItems(items.filter((item) => item.publishability === 'publishable'));
+  const reviewNeeded = sortPublicationItems(items.filter((item) => item.publishability === 'review_needed'));
   const internalOnly = items.filter((item) => item.publishability === 'internal_only');
   const lines = [];
 
@@ -335,13 +359,13 @@ function buildHomepageHeadliner({ dateLabel, decision, items }) {
   if (!decision.homepage_headliner_available) {
     return `---\nsafe_to_publish: false\nreason: no_publishable_material\n---\n\nNo homepage headliner for this run.\n`;
   }
-  const first = items.find((item) => item.publishability === 'publishable');
+  const first = sortPublicationItems(items).find((item) => item.publishability === 'publishable');
   return `---\ntype: ${decision.recommended_publication_type}\ndate: ${dateLabel}\nsafe_to_publish: true\n---\n\n## Latest from HEI\n\n${first.title}\n\n${first.safe_summary}\n`;
 }
 
 function buildUpdatesArticleDraft({ dateLabel, decision, items }) {
-  const reviewNeeded = items.filter((item) => item.publishability === 'review_needed');
-  const publishable = items.filter((item) => item.publishability === 'publishable');
+  const reviewNeeded = sortPublicationItems(items.filter((item) => item.publishability === 'review_needed'));
+  const publishable = sortPublicationItems(items.filter((item) => item.publishability === 'publishable'));
   const safeToPublish = 'false';
   const type = decision.recommended_publication_type;
   const lines = [];
@@ -385,7 +409,7 @@ function buildXPostDrafts({ dateLabel, decision, items }) {
   if (!decision.x_post_available) {
     return `# X Post Drafts - ${dateLabel}\n\nNo X post draft generated for this run.\nReason: no publishable material after safety filtering.\n`;
   }
-  const publishable = items.filter((item) => item.publishability === 'publishable').slice(0, 4);
+  const publishable = sortPublicationItems(items.filter((item) => item.publishability === 'publishable')).slice(0, 4);
   const lines = [];
   lines.push(`# X Post Drafts - ${dateLabel}`);
   lines.push('');
@@ -501,7 +525,7 @@ function collectPublicationItems(monitorReports) {
   }
 
   const datePart = new Date().toISOString().slice(0, 10).replaceAll('-', '');
-  return assignPublicationIds(items, datePart);
+  return assignPublicationIds(sortPublicationItems(items), datePart);
 }
 
 async function writeOutputs(outputDir, outputs) {


### PR DESCRIPTION
## Summary
- tighten the DefiLlama remote candidate adapter so it focuses on DEX / derivatives / trading-venue candidates
- exclude liquid staking, staking, LST/LSD, yield, vault, lending, bridge, wallet, NFT, oracle, and similar non-exchange protocol products unless they have a clear trading-venue category
- lower the remote item limit from 100 to 75
- rename the remote source category from broad `active_motherlist` to `active_trading_venue_motherlist`
- prioritize news/event candidates above remote active-motherlist candidates in publishing draft review output

## Why
The second harvest test produced 102 review-needed items, but most were noisy DeFi protocol / staking / vault / yield products. The useful external publishing signal was the news/event candidate `Tapp`, but it was buried below remote protocol-directory candidates. This PR makes the next harvest test more useful by reducing candidate-discovery noise and surfacing news/event candidates first.

## Not included
- Does not promote anything to `/updates`
- Does not auto-post to X
- Does not change canonical data
- Does not resolve the existing canonical enum high alerts yet

## Expected validation after merge
Run `HEI Publishing Draft` with:
- `enable_external_lists=true`
- `enable_news_rss=true`
- `enable_regulatory_watch=true`
- domain/evidence/site checks still false

Expected outcome:
- fewer review_needed items from DefiLlama remote discovery
- news/event shutdown candidates appear at the top of `internal-review.md`
- still `should_publish=false` until manual source review is added