### PR TITLE
Polish publishing draft review output

### DIFF
--- a/.github/workflows/hei-publishing-draft.yml
+++ b/.github/workflows/hei-publishing-draft.yml
@@ -14,7 +14,7 @@ on:
       include_monitoring_output:
         description: "Commit generated monitoring output together with publishing drafts"
         type: boolean
-        default: true
+        default: false
       include_review_needed:
         description: "Include review-needed items in generated drafts"
         type: boolean
@@ -158,7 +158,7 @@ jobs:
       - name: Check publishing draft changes
         id: changes
         env:
-          INCLUDE_MONITORING_OUTPUT: ${{ github.event.inputs.include_monitoring_output || 'true' }}
+          INCLUDE_MONITORING_OUTPUT: ${{ github.event.inputs.include_monitoring_output || 'false' }}
         run: |
           CHECK_PATHS="data-staging/publishing-drafts"
           if [ "$INCLUDE_MONITORING_OUTPUT" = "true" ]; then
@@ -175,7 +175,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          INCLUDE_MONITORING_OUTPUT: ${{ github.event.inputs.include_monitoring_output || 'true' }}
+          INCLUDE_MONITORING_OUTPUT: ${{ github.event.inputs.include_monitoring_output || 'false' }}
           RESOLVED_MONITORING_DIR: ${{ steps.monitoring_dir.outputs.monitoring_dir }}
         run: |
           BRANCH="auto/publishing-draft/$(date -u +%Y%m%d-%H%M%S)"
@@ -208,6 +208,7 @@ jobs:
           echo "- Decision file: $DECISION_FILE" >> "$BODY_FILE"
           echo "- Internal review: $INTERNAL_REVIEW" >> "$BODY_FILE"
           echo "- X draft: $X_DRAFTS" >> "$BODY_FILE"
+          echo "- Monitoring output included: $INCLUDE_MONITORING_OUTPUT" >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"
           echo "Canonical data, public content, app, and components must not be changed by publishing draft PRs." >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"

--- a/scripts/publishing/build-publishing-drafts.mjs
+++ b/scripts/publishing/build-publishing-drafts.mjs
@@ -101,8 +101,22 @@ function normalizeMonitoringDir(input) {
   return input.replace(/\/$/, '');
 }
 
+function normalizeKey(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
 function getEntityKey(source) {
-  return String(source.canonical_name || source.affected_entity || source.title || source.headline || source.id || '').toLowerCase();
+  const canonicalName = source.canonical_name || source.affected_entity;
+  if (canonicalName) return normalizeKey(canonicalName);
+
+  const title = String(source.title || source.headline || source.id || '');
+  const newsCandidateMatch = title.match(/^News\/event candidate:\s*(.+)$/i);
+  if (newsCandidateMatch) return normalizeKey(newsCandidateMatch[1]);
+
+  return normalizeKey(title);
 }
 
 function shouldKeepExternalMotherlistItem(source) {
@@ -236,6 +250,7 @@ function applyPublishabilityRules(item, source) {
 
 function publicationPriority(item, source) {
   if (item.publishability === 'publishable') return 0;
+  if (item.source_monitor === 'news-and-event-watch' && item.source_type === 'candidate') return 4;
   if (item.source_monitor === 'news-and-event-watch' && item.candidate_class === 'A') return 5;
   if (item.source_monitor === 'news-and-event-watch') return 10;
   if (item.candidate_class === 'A') return 20;


### PR DESCRIPTION
## Summary
- dedupe news/event finding+candidate pairs by normalizing `News/event candidate: <name>` to the same entity key as canonical candidates
- prefer candidate records over generic finding records in review priority when both exist
- default `include_monitoring_output` to false so future publishing draft PRs contain draft outputs only unless explicitly requested

## Why
The latest harvest test after #186 worked: `review_needed` dropped to 2 and the only remaining external publishing signal was Tapp. The remaining problem is duplicate display: the same Tapp signal appears once as a finding and once as a candidate. Also, generated draft PRs are still large when monitoring output is included by default.

## Expected effect
Next `HEI Publishing Draft` run should produce:
- `review_needed: 1` for the Tapp signal, assuming the same source data
- smaller auto PRs by default because only `data-staging/publishing-drafts/**` is committed
- monitoring output can still be included by explicitly setting `include_monitoring_output=true`

## Safety
- no canonical data changes
- no `/updates` changes
- no X auto-posting