### PR TITLE
Add record-bundle workflow for exchange additions

### DIFF
--- a/docs/data-record-workflow.md
+++ b/docs/data-record-workflow.md
@@ -1,0 +1,89 @@
+# HEI record-bundle workflow
+
+This workflow separates the editing source of truth from the generated site data.
+
+## Goal
+
+HEI can keep the existing public data files:
+
+- `data/entities.json`
+- `data/events.json`
+- `data/evidence.json`
+
+But new exchange records should be authored as one bundle per exchange:
+
+- `records/exchanges/<slug>.json`
+
+The bundle format is easier to review, easier to create through GitHub, and avoids editing three large JSON arrays by hand for every new exchange.
+
+## Bundle shape
+
+Each bundle must contain exactly one exchange entity, its events, and its evidence.
+
+```json
+{
+  "entity": {},
+  "events": [],
+  "evidence": []
+}
+```
+
+The filename must match `entity.slug`:
+
+```text
+records/exchanges/txbit.json
+```
+
+## Required checks
+
+Run:
+
+```bash
+npm run records:validate
+```
+
+The validator checks:
+
+- bundle JSON is valid
+- `entity`, `events`, and `evidence` are present
+- required fields exist
+- filename matches `entity.slug`
+- ids use HEI prefixes
+- event `exchange_id` matches the bundle entity
+- evidence `exchange_id` matches the bundle entity
+- evidence `event_id` points to an event in the same bundle or is `null`
+- event `source_count` equals the number of matching evidence rows
+- ids are unique across record bundles
+
+## Build generated data
+
+Run:
+
+```bash
+npm run records:build
+```
+
+This merges all bundle files into the existing generated files:
+
+- `data/entities.json`
+- `data/events.json`
+- `data/evidence.json`
+
+The build script refuses to overwrite existing ids already present in the generated data files.
+
+## Current migration stance
+
+This PR does not migrate all existing records.
+
+Current rule:
+
+- Existing `data/*.json` remains the public generated data.
+- New additions may be authored as record bundles.
+- After validation, `records:build` can generate updated `data/*.json`.
+- Existing legacy records can be migrated gradually later.
+
+## Why this exists
+
+The old append workflow requires editing three large JSON files for each exchange. That is workable at small scale, but it becomes risky when HEI grows to hundreds or thousands of records.
+
+The bundle workflow makes each new record reviewable as a single file while preserving the current public data format.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "monitor:dry": "HEI_MONITORING_MODE=manual node scripts/monitoring/run.mjs",
     "monitor:promote-candidate": "node scripts/monitoring/promote-candidate-to-staging.mjs",
     "monitor:smoke": "node scripts/monitoring/smoke-test.mjs",
-    "publish:draft": "node scripts/publishing/build-publishing-drafts.mjs"
+    "publish:draft": "node scripts/publishing/build-publishing-drafts.mjs",
+    "records:validate": "node scripts/validate-record-bundles.mjs",
+    "records:build": "node scripts/build-data-from-records.mjs"
   },
   "dependencies": {
     "next": "^15.2.8",

--- a/records/exchanges/.gitkeep
+++ b/records/exchanges/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for HEI record bundle files.

--- a/scripts/build-data-from-records.mjs
+++ b/scripts/build-data-from-records.mjs
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const RECORD_DIR = path.join(ROOT, 'records', 'exchanges');
+const DATA_DIR = path.join(ROOT, 'data');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function listRecordFiles() {
+  if (!fs.existsSync(RECORD_DIR)) return [];
+  return fs
+    .readdirSync(RECORD_DIR)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) => path.join(RECORD_DIR, name));
+}
+
+function idNumber(id) {
+  const match = String(id).match(/_(\d+)$/);
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
+}
+
+const entityPath = path.join(DATA_DIR, 'entities.json');
+const eventPath = path.join(DATA_DIR, 'events.json');
+const evidencePath = path.join(DATA_DIR, 'evidence.json');
+
+const entities = readJson(entityPath);
+const events = readJson(eventPath);
+const evidence = readJson(evidencePath);
+
+const entityById = new Map(entities.map((entity) => [entity.id, entity]));
+const eventById = new Map(events.map((event) => [event.id, event]));
+const evidenceById = new Map(evidence.map((source) => [source.id, source]));
+
+let bundleCount = 0;
+for (const filePath of listRecordFiles()) {
+  const bundle = readJson(filePath);
+  bundleCount += 1;
+
+  if (!bundle.entity || !Array.isArray(bundle.events) || !Array.isArray(bundle.evidence)) {
+    throw new Error(`${filePath}: expected { entity, events, evidence }`);
+  }
+
+  if (entityById.has(bundle.entity.id)) {
+    throw new Error(`${filePath}: entity id already exists in data/entities.json: ${bundle.entity.id}`);
+  }
+  entityById.set(bundle.entity.id, bundle.entity);
+
+  for (const event of bundle.events) {
+    if (eventById.has(event.id)) {
+      throw new Error(`${filePath}: event id already exists in data/events.json: ${event.id}`);
+    }
+    eventById.set(event.id, event);
+  }
+
+  for (const source of bundle.evidence) {
+    if (evidenceById.has(source.id)) {
+      throw new Error(`${filePath}: evidence id already exists in data/evidence.json: ${source.id}`);
+    }
+    evidenceById.set(source.id, source);
+  }
+}
+
+const nextEntities = [...entityById.values()].sort((a, b) => idNumber(a.id) - idNumber(b.id));
+const nextEvents = [...eventById.values()].sort((a, b) => idNumber(a.id) - idNumber(b.id));
+const nextEvidence = [...evidenceById.values()].sort((a, b) => idNumber(a.id) - idNumber(b.id));
+
+writeJson(entityPath, nextEntities);
+writeJson(eventPath, nextEvents);
+writeJson(evidencePath, nextEvidence);
+
+console.log(`built data from ${bundleCount} record bundle(s)`);
+console.log(`entities: ${entities.length} -> ${nextEntities.length}`);
+console.log(`events: ${events.length} -> ${nextEvents.length}`);
+console.log(`evidence: ${evidence.length} -> ${nextEvidence.length}`);

--- a/scripts/validate-record-bundles.mjs
+++ b/scripts/validate-record-bundles.mjs
@@ -1,0 +1,157 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const RECORD_DIR = path.join(ROOT, 'records', 'exchanges');
+
+const REQUIRED_ENTITY_FIELDS = [
+  'id',
+  'slug',
+  'canonical_name',
+  'aliases',
+  'type',
+  'status',
+  'death_reason',
+  'launch_date',
+  'death_date',
+  'country_or_origin',
+  'summary',
+  'official_url_original',
+  'official_domain_original',
+  'official_url_status',
+  'archived_url',
+  'confidence',
+  'last_verified_at',
+  'notes',
+];
+
+const REQUIRED_EVENT_FIELDS = [
+  'id',
+  'exchange_id',
+  'event_type',
+  'event_date',
+  'title',
+  'description',
+  'confidence',
+  'impact_level',
+  'event_status_effect',
+  'source_count',
+  'sort_order',
+  'notes',
+];
+
+const REQUIRED_EVIDENCE_FIELDS = [
+  'id',
+  'exchange_id',
+  'event_id',
+  'source_type',
+  'title',
+  'url',
+  'publisher',
+  'published_at',
+  'archived_url',
+  'accessed_at',
+  'reliability',
+  'claim_scope',
+  'notes',
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`${filePath}: invalid JSON: ${error.message}`);
+  }
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`${label}: expected object`);
+  }
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    fail(`${label}: expected array`);
+  }
+}
+
+function requireFields(value, fields, label) {
+  for (const field of fields) {
+    if (!(field in value)) {
+      fail(`${label}: missing required field ${field}`);
+    }
+  }
+}
+
+function requireId(value, prefix, label) {
+  if (typeof value !== 'string' || !value.startsWith(prefix)) {
+    fail(`${label}: expected id starting with ${prefix}`);
+  }
+}
+
+function listRecordFiles() {
+  if (!fs.existsSync(RECORD_DIR)) return [];
+  return fs
+    .readdirSync(RECORD_DIR)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) => path.join(RECORD_DIR, name));
+}
+
+const files = listRecordFiles();
+const allIds = new Set();
+let checked = 0;
+
+for (const filePath of files) {
+  const bundle = readJson(filePath);
+  requireObject(bundle, filePath);
+  requireObject(bundle.entity, `${filePath}.entity`);
+  requireArray(bundle.events, `${filePath}.events`);
+  requireArray(bundle.evidence, `${filePath}.evidence`);
+
+  const { entity, events, evidence } = bundle;
+  requireFields(entity, REQUIRED_ENTITY_FIELDS, `${filePath}.entity`);
+  requireId(entity.id, 'hei_ex_', `${filePath}.entity.id`);
+
+  const expectedFileName = `${entity.slug}.json`;
+  if (path.basename(filePath) !== expectedFileName) {
+    fail(`${filePath}: filename must match entity.slug (${expectedFileName})`);
+  }
+
+  for (const id of [entity.id, ...events.map((event) => event.id), ...evidence.map((source) => source.id)]) {
+    if (allIds.has(id)) fail(`${filePath}: duplicate id in record bundles: ${id}`);
+    allIds.add(id);
+  }
+
+  const eventIds = new Set(events.map((event) => event.id));
+
+  events.forEach((event, index) => {
+    const label = `${filePath}.events[${index}]`;
+    requireFields(event, REQUIRED_EVENT_FIELDS, label);
+    requireId(event.id, 'hei_ev_', `${label}.id`);
+    if (event.exchange_id !== entity.id) fail(`${label}: exchange_id must be ${entity.id}`);
+    const actualSourceCount = evidence.filter((source) => source.event_id === event.id).length;
+    if (event.source_count !== actualSourceCount) {
+      fail(`${label}: source_count ${event.source_count} != actual evidence count ${actualSourceCount}`);
+    }
+  });
+
+  evidence.forEach((source, index) => {
+    const label = `${filePath}.evidence[${index}]`;
+    requireFields(source, REQUIRED_EVIDENCE_FIELDS, label);
+    requireId(source.id, 'hei_src_', `${label}.id`);
+    if (source.exchange_id !== entity.id) fail(`${label}: exchange_id must be ${entity.id}`);
+    if (source.event_id !== null && !eventIds.has(source.event_id)) {
+      fail(`${label}: event_id does not exist in this bundle: ${source.event_id}`);
+    }
+  });
+
+  checked += 1;
+}
+
+console.log(`record bundle validation passed: ${checked} bundle(s)`);


### PR DESCRIPTION
## Summary
- add `records/exchanges/` as the future one-exchange-one-file authoring area
- add `records:validate` to validate record bundles before build
- add `records:build` to merge record bundles into existing `data/*.json`
- document the workflow in `docs/data-record-workflow.md`

## Scope
- no changes to existing `data/entities.json`, `data/events.json`, or `data/evidence.json`
- no site runtime changes
- no migration of existing records yet

## Why
The current append workflow requires editing three large JSON arrays for each exchange. That is risky at scale and makes GitHub/API-based additions harder to review. This PR keeps the current public data format while introducing a safer authoring workflow for new records.