### PR TITLE
Publish record bundles in registry views

### DIFF
--- a/src/lib/data/load-entities.ts
+++ b/src/lib/data/load-entities.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EntityRecord } from '../types/entity'
+import { loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -9,5 +10,11 @@ function readJsonFile<T>(relativePath: string): T {
 }
 
 export function loadEntities(): EntityRecord[] {
-  return readJsonFile<EntityRecord[]>('data/entities.json')
+  const entities = readJsonFile<EntityRecord[]>('data/entities.json')
+  const seenIds = new Set(entities.map((entity) => entity.id))
+  const bundleEntities = loadExchangeRecordBundles()
+    .map((bundle) => bundle.entity)
+    .filter((entity) => !seenIds.has(entity.id))
+
+  return [...entities, ...bundleEntities]
 }

--- a/src/lib/data/load-events.ts
+++ b/src/lib/data/load-events.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EventRecord } from '../types/event'
+import { loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -9,5 +10,11 @@ function readJsonFile<T>(relativePath: string): T {
 }
 
 export function loadEvents(): EventRecord[] {
-  return readJsonFile<EventRecord[]>('data/events.json')
+  const events = readJsonFile<EventRecord[]>('data/events.json')
+  const seenIds = new Set(events.map((event) => event.id))
+  const bundleEvents = loadExchangeRecordBundles()
+    .flatMap((bundle) => bundle.events)
+    .filter((event) => !seenIds.has(event.id))
+
+  return [...events, ...bundleEvents]
 }

--- a/src/lib/data/load-evidence.ts
+++ b/src/lib/data/load-evidence.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EvidenceRecord } from '../types/evidence'
+import { loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -9,5 +10,11 @@ function readJsonFile<T>(relativePath: string): T {
 }
 
 export function loadEvidence(): EvidenceRecord[] {
-  return readJsonFile<EvidenceRecord[]>('data/evidence.json')
+  const evidence = readJsonFile<EvidenceRecord[]>('data/evidence.json')
+  const seenIds = new Set(evidence.map((source) => source.id))
+  const bundleEvidence = loadExchangeRecordBundles()
+    .flatMap((bundle) => bundle.evidence)
+    .filter((source) => !seenIds.has(source.id))
+
+  return [...evidence, ...bundleEvidence]
 }

--- a/src/lib/data/load-record-bundles.ts
+++ b/src/lib/data/load-record-bundles.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { EntityRecord } from '../types/entity'
+import type { EventRecord } from '../types/event'
+import type { EvidenceRecord } from '../types/evidence'
+
+export interface ExchangeRecordBundle {
+  entity: EntityRecord
+  events: EventRecord[]
+  evidence: EvidenceRecord[]
+}
+
+function readJsonFile<T>(filePath: string): T {
+  const raw = fs.readFileSync(filePath, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+export function loadExchangeRecordBundles(): ExchangeRecordBundle[] {
+  const recordsDir = path.join(process.cwd(), 'records', 'exchanges')
+
+  if (!fs.existsSync(recordsDir)) {
+    return []
+  }
+
+  return fs
+    .readdirSync(recordsDir)
+    .filter((fileName) => fileName.endsWith('.json'))
+    .sort((a, b) => a.localeCompare(b))
+    .map((fileName) => readJsonFile<ExchangeRecordBundle>(path.join(recordsDir, fileName)))
+}


### PR DESCRIPTION
## Summary
- Load `records/exchanges/*.json` bundles in the public registry data loaders.
- Keep existing `data/*.json` as the base dataset.
- Skip bundle records whose IDs already exist in `data/*.json` to avoid duplicate display.

## Expected public count
- Current public `data/entities.json` count: 306
- Unpublished record bundles to surface: 14
- Expected public total after deploy: 320

## Checks
- npm run records:validate
- npm run build
- npm run check