### PR TITLE
Fix record bundle duplicate display

### DIFF
--- a/src/lib/data/load-entities.ts
+++ b/src/lib/data/load-entities.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EntityRecord } from '../types/entity'
-import { loadExchangeRecordBundles } from './load-record-bundles'
+import { filterNewExchangeRecordBundles, loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -11,10 +11,9 @@ function readJsonFile<T>(relativePath: string): T {
 
 export function loadEntities(): EntityRecord[] {
   const entities = readJsonFile<EntityRecord[]>('data/entities.json')
-  const seenIds = new Set(entities.map((entity) => entity.id))
-  const bundleEntities = loadExchangeRecordBundles()
-    .map((bundle) => bundle.entity)
-    .filter((entity) => !seenIds.has(entity.id))
+  const bundleEntities = filterNewExchangeRecordBundles(loadExchangeRecordBundles(), entities).map(
+    (bundle) => bundle.entity,
+  )
 
   return [...entities, ...bundleEntities]
 }

--- a/src/lib/data/load-events.ts
+++ b/src/lib/data/load-events.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EventRecord } from '../types/event'
-import { loadExchangeRecordBundles } from './load-record-bundles'
+import type { EntityRecord } from '../types/entity'
+import { filterNewExchangeRecordBundles, loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -11,8 +12,9 @@ function readJsonFile<T>(relativePath: string): T {
 
 export function loadEvents(): EventRecord[] {
   const events = readJsonFile<EventRecord[]>('data/events.json')
+  const entities = readJsonFile<EntityRecord[]>('data/entities.json')
   const seenIds = new Set(events.map((event) => event.id))
-  const bundleEvents = loadExchangeRecordBundles()
+  const bundleEvents = filterNewExchangeRecordBundles(loadExchangeRecordBundles(), entities)
     .flatMap((bundle) => bundle.events)
     .filter((event) => !seenIds.has(event.id))
 

--- a/src/lib/data/load-evidence.ts
+++ b/src/lib/data/load-evidence.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EvidenceRecord } from '../types/evidence'
-import { loadExchangeRecordBundles } from './load-record-bundles'
+import type { EntityRecord } from '../types/entity'
+import { filterNewExchangeRecordBundles, loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -11,8 +12,9 @@ function readJsonFile<T>(relativePath: string): T {
 
 export function loadEvidence(): EvidenceRecord[] {
   const evidence = readJsonFile<EvidenceRecord[]>('data/evidence.json')
+  const entities = readJsonFile<EntityRecord[]>('data/entities.json')
   const seenIds = new Set(evidence.map((source) => source.id))
-  const bundleEvidence = loadExchangeRecordBundles()
+  const bundleEvidence = filterNewExchangeRecordBundles(loadExchangeRecordBundles(), entities)
     .flatMap((bundle) => bundle.evidence)
     .filter((source) => !seenIds.has(source.id))
 

--- a/src/lib/data/load-record-bundles.ts
+++ b/src/lib/data/load-record-bundles.ts
@@ -15,6 +15,39 @@ function readJsonFile<T>(filePath: string): T {
   return JSON.parse(raw) as T
 }
 
+function normalizeIdentity(value: string | null | undefined): string | null {
+  if (!value) return null
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/$/, '')
+
+  return normalized.length > 0 ? normalized : null
+}
+
+function addIdentityKey(keys: Set<string>, value: string | null | undefined): void {
+  const normalized = normalizeIdentity(value)
+  if (normalized) keys.add(normalized)
+}
+
+export function getEntityIdentityKeys(entity: EntityRecord): Set<string> {
+  const keys = new Set<string>()
+
+  addIdentityKey(keys, entity.id)
+  addIdentityKey(keys, entity.slug)
+  addIdentityKey(keys, entity.canonical_name)
+  addIdentityKey(keys, entity.official_domain_original)
+  addIdentityKey(keys, entity.official_url_original)
+
+  for (const alias of entity.aliases) {
+    addIdentityKey(keys, alias)
+  }
+
+  return keys
+}
+
 export function loadExchangeRecordBundles(): ExchangeRecordBundle[] {
   const recordsDir = path.join(process.cwd(), 'records', 'exchanges')
 
@@ -27,4 +60,36 @@ export function loadExchangeRecordBundles(): ExchangeRecordBundle[] {
     .filter((fileName) => fileName.endsWith('.json'))
     .sort((a, b) => a.localeCompare(b))
     .map((fileName) => readJsonFile<ExchangeRecordBundle>(path.join(recordsDir, fileName)))
+}
+
+export function filterNewExchangeRecordBundles(
+  bundles: ExchangeRecordBundle[],
+  baseEntities: EntityRecord[],
+): ExchangeRecordBundle[] {
+  const seenIdentityKeys = new Set<string>()
+
+  for (const entity of baseEntities) {
+    for (const key of getEntityIdentityKeys(entity)) {
+      seenIdentityKeys.add(key)
+    }
+  }
+
+  const acceptedBundles: ExchangeRecordBundle[] = []
+
+  for (const bundle of bundles) {
+    const bundleKeys = getEntityIdentityKeys(bundle.entity)
+    const hasExistingIdentity = [...bundleKeys].some((key) => seenIdentityKeys.has(key))
+
+    if (hasExistingIdentity) {
+      continue
+    }
+
+    acceptedBundles.push(bundle)
+
+    for (const key of bundleKeys) {
+      seenIdentityKeys.add(key)
+    }
+  }
+
+  return acceptedBundles
 }


### PR DESCRIPTION
Fix record-bundle duplicate display by filtering bundle entities with matching slug, name, domain, URL, or aliases against the base dataset, not ID only.

This addresses cases where the same exchange exists in data/entities.json and records/exchanges/*.json with different IDs.