### PR TITLE
Run duplicate check during record validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "monitor:promote-candidate": "node scripts/monitoring/promote-candidate-to-staging.mjs",
     "monitor:smoke": "node scripts/monitoring/smoke-test.mjs",
     "publish:draft": "node scripts/publishing/build-publishing-drafts.mjs",
-    "records:validate": "node scripts/validate-record-bundles.mjs",
+    "records:validate": "node scripts/validate-record-bundles.mjs && node scripts/check-record-duplicates.mjs",
     "records:build": "node scripts/build-data-from-records.mjs",
     "records:dedupe": "node scripts/check-record-duplicates.mjs"
   },


### PR DESCRIPTION
Update `records:validate` so it runs both record bundle schema validation and cross-dataset duplicate detection.

This makes `npm run records:validate` fail when a bundle duplicates an existing `data/entities.json` exchange by ID, slug, canonical name, alias, original domain, or original URL.