### PR TITLE
Add 0x Protocol record

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0002-zero-x-protocol.md
+++ b/docs/backlog/consumed/hei_unadded_0002-zero-x-protocol.md
@@ -1,0 +1,23 @@
+# Consumed backlog row: hei_unadded_0002
+
+Status: added
+
+## Candidate
+
+- backlog_id: `hei_unadded_0002`
+- backlog_name: `0x`
+- backlog_slug: `0x`
+- added_record_path: `records/exchanges/zero-x-protocol.json`
+- added_entity_id: `hei_ex_000346`
+
+## Pre-add duplicate checks
+
+- public site search: no hit found for `0x` / `0x Protocol`
+- repository search: no existing `0x` hit
+- domain search: no existing `0x.org` hit
+- direct bundle check: `records/exchanges/0x.json` not found
+- ID checks: `hei_ex_000346`, `hei_ev_000654`, `hei_src_001424`, and `hei_src_001425` unused before creation
+
+## Notes
+
+The record file uses slug `zero-x-protocol` to avoid path ambiguity while preserving `0x Protocol` as canonical name and `0x` as an alias.

--- a/records/exchanges/zero-x-protocol.json
+++ b/records/exchanges/zero-x-protocol.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000346",
+    "slug": "zero-x-protocol",
+    "canonical_name": "0x Protocol",
+    "aliases": ["0x", "0x API", "0x Swap API", "0x Exchange Proxy"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Ethereum ecosystem",
+    "summary": "Decentralized exchange liquidity and swap infrastructure protocol that aggregates and routes token swaps across on-chain liquidity sources and remains active under the 0x brand.",
+    "official_url_original": "https://0x.org/",
+    "official_domain_original": "0x.org",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://0x.org/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-29",
+    "notes": "Added from verified-unadded backlog row hei_unadded_0002. Slug is normalized as zero-x-protocol to avoid path ambiguity while preserving 0x as canonical alias. Launch date is left null pending stronger date-specific evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000654",
+      "exchange_id": "hei_ex_000346",
+      "event_type": "listed_reference",
+      "event_date": "2026-05-29",
+      "title": "0x Protocol present in DEX aggregation source data",
+      "description": "0x Protocol appeared in the verified-unadded candidate generator from DefiLlama source data as a DEX aggregation and liquidity-routing protocol not found in current HEI records.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "This is a database-reference event, not a verified launch event. Replace with a proper launch/history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001424",
+      "exchange_id": "hei_ex_000346",
+      "event_id": "hei_ev_000654",
+      "source_type": "official_statement",
+      "title": "0x official website",
+      "url": "https://0x.org/",
+      "publisher": "0x",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://0x.org/",
+      "accessed_at": "2026-05-29",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official website used to preserve the active 0x identity and original domain."
+    },
+    {
+      "id": "hei_src_001425",
+      "exchange_id": "hei_ex_000346",
+      "event_id": "hei_ev_000654",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX overview reference for 0x",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-05-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0002, identifying 0x as a DEX aggregator across multiple chains."
+    }
+  ]
+}


### PR DESCRIPTION
Add a record bundle for 0x Protocol from the verified-unadded candidate backlog and consume the source backlog row.

Pre-add duplicate checks performed:
- Public site search: no hit found for `0x` / `0x Protocol`
- Repository search: no existing `0x` hit
- Domain search: no existing `0x.org` hit
- Direct bundle check: `records/exchanges/0x.json` not found
- ID checks: `hei_ex_000346`, `hei_ev_000654`, `hei_src_001424`, and `hei_src_001425` unused before creation

Files:
- `records/exchanges/zero-x-protocol.json`
- `docs/backlog/consumed/hei_unadded_0002-zero-x-protocol.md`