### PR TITLE
Add Aerodrome record

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0033-0037-aerodrome.md
+++ b/docs/backlog/consumed/hei_unadded_0033-0037-aerodrome.md
@@ -1,0 +1,26 @@
+# Consumed backlog rows: hei_unadded_0033 / hei_unadded_0034 / hei_unadded_0035 / hei_unadded_0036 / hei_unadded_0037
+
+Status: added
+
+## Candidate
+
+- backlog_id: `hei_unadded_0033`
+- backlog_id: `hei_unadded_0034`
+- backlog_id: `hei_unadded_0035`
+- backlog_id: `hei_unadded_0036`
+- backlog_id: `hei_unadded_0037`
+- backlog_name: `Aerodrome`
+- added_record_path: `records/exchanges/aerodrome.json`
+- added_entity_id: `hei_ex_000348`
+
+## Pre-add duplicate checks
+
+- public site search: no hit found for `Aerodrome`
+- repository search: no existing `Aerodrome` hit
+- domain search: no existing `aerodrome.finance` hit
+- direct bundle check: `records/exchanges/aerodrome.json` not found
+- ID checks: `hei_ex_000348`, `hei_ev_000656`, `hei_src_001429`, `hei_src_001430`, `hei_src_001431`, and `hei_src_001432` unused before creation
+
+## Notes
+
+This is an active DEX/protocol record from verified-unadded rows, not a shutdown record. Launch date remains null pending stronger date-specific evidence.

--- a/records/exchanges/aerodrome.json
+++ b/records/exchanges/aerodrome.json
@@ -1,0 +1,100 @@
+{
+  "entity": {
+    "id": "hei_ex_000348",
+    "slug": "aerodrome",
+    "canonical_name": "Aerodrome",
+    "aliases": ["Aerodrome Finance", "Aerodrome SlipStream", "Aerodrome V1", "Aerodrome V3"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Base ecosystem",
+    "summary": "Base-network decentralized exchange and liquidity marketplace identified in the HEI verified-unadded backlog from CoinPaprika, CoinGecko, and DefiLlama source data and currently treated as an active DEX record.",
+    "official_url_original": "https://aerodrome.finance/",
+    "official_domain_original": "aerodrome.finance",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://aerodrome.finance/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-29",
+    "notes": "Added from verified-unadded backlog rows hei_unadded_0033, hei_unadded_0034, hei_unadded_0035, hei_unadded_0036, and hei_unadded_0037. This is an active DEX/protocol record, not a shutdown record. Launch date is left null pending stronger date-specific evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000656",
+      "exchange_id": "hei_ex_000348",
+      "event_type": "listed_reference",
+      "event_date": "2026-05-29",
+      "title": "Aerodrome present in DEX source data",
+      "description": "Aerodrome appeared in the verified-unadded candidate generator from CoinPaprika, CoinGecko, and DefiLlama source data as an exchange-like DEX candidate not found in current HEI records.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 4,
+      "sort_order": 1,
+      "notes": "This is a database-reference event, not a verified launch event. Replace with a proper launch/history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001429",
+      "exchange_id": "hei_ex_000348",
+      "event_id": "hei_ev_000656",
+      "source_type": "official_statement",
+      "title": "Aerodrome official website",
+      "url": "https://aerodrome.finance/",
+      "publisher": "Aerodrome",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://aerodrome.finance/",
+      "accessed_at": "2026-05-29",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve the active Aerodrome identity."
+    },
+    {
+      "id": "hei_src_001430",
+      "exchange_id": "hei_ex_000348",
+      "event_id": "hei_ev_000656",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchanges reference for Aerodrome",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-05-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0033, identifying Aerodrome as an exchange-like source candidate."
+    },
+    {
+      "id": "hei_src_001431",
+      "exchange_id": "hei_ex_000348",
+      "event_id": "hei_ev_000656",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchanges reference for Aerodrome SlipStream",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-05-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0035, with domain aerodrome.finance and source id aerodrome-slipstream."
+    },
+    {
+      "id": "hei_src_001432",
+      "exchange_id": "hei_ex_000348",
+      "event_id": "hei_ev_000656",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX overview reference for Aerodrome",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-05-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog rows for Aerodrome versions, identifying Aerodrome as a Base-chain DEX candidate."
+    }
+  ]
+}


### PR DESCRIPTION
Add a record bundle for Aerodrome from the verified-unadded candidate backlog and consume the source backlog rows.

Pre-add duplicate checks performed:
- Public site search: no hit found for `Aerodrome`
- Repository search: no existing `Aerodrome` hit
- Domain search: no existing `aerodrome.finance` hit
- Direct bundle check: `records/exchanges/aerodrome.json` not found
- ID checks: `hei_ex_000348`, `hei_ev_000656`, and `hei_src_001429` through `hei_src_001432` unused before creation

Files:
- `records/exchanges/aerodrome.json`
- `docs/backlog/consumed/hei_unadded_0033-0037-aerodrome.md`