### PR TITLE
Add 1DEX record

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0008-0009-one-dex.md
+++ b/docs/backlog/consumed/hei_unadded_0008-0009-one-dex.md
@@ -1,0 +1,22 @@
+# Consumed backlog rows: hei_unadded_0008 / hei_unadded_0009
+
+Status: added
+
+## Candidate
+
+- backlog_id: `hei_unadded_0008`
+- backlog_id: `hei_unadded_0009`
+- backlog_name: `1DEX`
+- added_record_path: `records/exchanges/one-dex.json`
+- added_entity_id: `hei_ex_000349`
+
+## Pre-add duplicate checks
+
+- repository search: no existing `1DEX` hit
+- domain search: no existing `1dex.com` hit
+- direct bundle check: `records/exchanges/1dex.json` not found
+- ID checks: `hei_ex_000349`, `hei_ev_000657`, `hei_src_001433`, and `hei_src_001434` unused before creation
+
+## Notes
+
+This is a low-confidence active DEX/protocol record from verified-unadded rows. Launch date remains null pending stronger date-specific evidence.

--- a/docs/backlog/pending/hei_unadded_0032-aequinox.md
+++ b/docs/backlog/pending/hei_unadded_0032-aequinox.md
@@ -1,0 +1,25 @@
+# Pending backlog row: hei_unadded_0032
+
+Status: pending_research
+
+## Candidate
+
+- backlog_id: `hei_unadded_0032`
+- backlog_name: `Aequinox`
+- backlog_slug: `aequinox`
+
+## Reason
+
+The candidate row only has a DefiLlama source entry and does not include a verified official URL or domain. It is not added as a record yet.
+
+## Pre-add checks performed
+
+- repository search: no existing `Aequinox` hit
+- direct bundle check: `records/exchanges/aequinox.json` not found
+- source status: insufficient for record creation
+
+## Required before record PR
+
+- confirm official URL/domain
+- confirm entity scope as exchange/DEX rather than generic protocol/noise
+- add at least one stronger source beyond the generated source row

--- a/records/exchanges/one-dex.json
+++ b/records/exchanges/one-dex.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000349",
+    "slug": "one-dex",
+    "canonical_name": "1DEX",
+    "aliases": ["1DEX Exchange", "1DEX Vaulta", "one_dex", "1dex.com"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Vaulta / EOS ecosystem",
+    "summary": "Decentralized exchange candidate identified in the HEI verified-unadded backlog from CoinGecko and DefiLlama source data and currently treated as an active DEX record.",
+    "official_url_original": "https://1dex.com/",
+    "official_domain_original": "1dex.com",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://1dex.com/",
+    "confidence": "low",
+    "last_verified_at": "2026-05-29",
+    "notes": "Added from verified-unadded backlog rows hei_unadded_0008 and hei_unadded_0009. Source evidence is limited to CoinGecko and DefiLlama database references, so this record should be improved later if stronger official-history evidence is found."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000657",
+      "exchange_id": "hei_ex_000349",
+      "event_type": "listed_reference",
+      "event_date": "2026-05-29",
+      "title": "1DEX present in exchange and DEX source data",
+      "description": "1DEX appeared in the verified-unadded candidate generator from CoinGecko and DefiLlama source data as an exchange-like DEX candidate not found in current HEI records.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "This is a database-reference event, not a verified launch event. Replace with a proper launch/history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001433",
+      "exchange_id": "hei_ex_000349",
+      "event_id": "hei_ev_000657",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchanges reference for 1DEX",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-05-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0008, with domain 1dex.com and source id one_dex."
+    },
+    {
+      "id": "hei_src_001434",
+      "exchange_id": "hei_ex_000349",
+      "event_id": "hei_ev_000657",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX overview reference for 1DEX",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-05-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0009, identifying 1DEX as a Vaulta DEX candidate."
+    }
+  ]
+}


### PR DESCRIPTION
Add a low-confidence record bundle for 1DEX from the verified-unadded candidate backlog and consume the source backlog rows. Also mark Aequinox as pending research instead of adding it because the generated row lacks a verified official URL/domain.

Pre-add duplicate checks performed for 1DEX:
- Repository search: no existing `1DEX` hit
- Domain search: no existing `1dex.com` hit
- Direct bundle check: `records/exchanges/1dex.json` not found
- ID checks: `hei_ex_000349`, `hei_ev_000657`, `hei_src_001433`, and `hei_src_001434` unused before creation

Files:
- `records/exchanges/one-dex.json`
- `docs/backlog/consumed/hei_unadded_0008-0009-one-dex.md`
- `docs/backlog/pending/hei_unadded_0032-aequinox.md`