### PR TITLE
Add 9inch record

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0018-0019-nine-inch.md
+++ b/docs/backlog/consumed/hei_unadded_0018-0019-nine-inch.md
@@ -1,0 +1,22 @@
+# Consumed backlog rows: hei_unadded_0018 / hei_unadded_0019
+
+Status: added
+
+## Candidate
+
+- backlog_id: `hei_unadded_0018`
+- backlog_id: `hei_unadded_0019`
+- backlog_name: `9inch`
+- added_record_path: `records/exchanges/nine-inch.json`
+- added_entity_id: `hei_ex_000350`
+
+## Pre-add duplicate checks
+
+- repository search: no existing `9inch` hit
+- domain search: no existing `app.9inch.io` hit
+- direct bundle check: `records/exchanges/9inch.json` not found
+- ID checks: `hei_ex_000350`, `hei_ev_000658`, `hei_src_001435`, and `hei_src_001436` unused before creation
+
+## Notes
+
+This is a low-confidence active DEX/protocol record from verified-unadded rows. File slug is normalized as `nine-inch` while preserving `9inch` as canonical name.

--- a/records/exchanges/nine-inch.json
+++ b/records/exchanges/nine-inch.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000350",
+    "slug": "nine-inch",
+    "canonical_name": "9inch",
+    "aliases": ["9inch Exchange", "9inch DEX", "app.9inch.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "PulseChain ecosystem",
+    "summary": "Decentralized exchange candidate identified in the HEI verified-unadded backlog from CoinPaprika and CoinGecko source data and currently treated as an active DEX record.",
+    "official_url_original": "https://app.9inch.io/",
+    "official_domain_original": "app.9inch.io",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://app.9inch.io/",
+    "confidence": "low",
+    "last_verified_at": "2026-05-30",
+    "notes": "Added from verified-unadded backlog rows hei_unadded_0018 and hei_unadded_0019. Source evidence is limited to CoinPaprika and CoinGecko database references, so this record should be improved later if stronger official-history evidence is found. File slug is normalized as nine-inch while preserving 9inch as canonical_name."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000658",
+      "exchange_id": "hei_ex_000350",
+      "event_type": "listed_reference",
+      "event_date": "2026-05-30",
+      "title": "9inch present in exchange source data",
+      "description": "9inch appeared in the verified-unadded candidate generator from CoinPaprika and CoinGecko source data as an exchange-like DEX candidate not found in current HEI records.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "This is a database-reference event, not a verified launch event. Replace with a proper launch/history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001435",
+      "exchange_id": "hei_ex_000350",
+      "event_id": "hei_ev_000658",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchanges reference for 9inch",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-05-30",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0018, identifying 9inch as an exchange-like source candidate."
+    },
+    {
+      "id": "hei_src_001436",
+      "exchange_id": "hei_ex_000350",
+      "event_id": "hei_ev_000658",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchanges reference for 9inch",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-05-30",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0019, with domain app.9inch.io and source id 9inch."
+    }
+  ]
+}


### PR DESCRIPTION
Add a low-confidence record bundle for 9inch from the verified-unadded candidate backlog and consume the source backlog rows.

Pre-add duplicate checks performed:
- Repository search: no existing `9inch` hit
- Domain search: no existing `app.9inch.io` hit
- Direct bundle check: `records/exchanges/9inch.json` not found
- ID checks: `hei_ex_000350`, `hei_ev_000658`, `hei_src_001435`, and `hei_src_001436` unused before creation

Files:
- `records/exchanges/nine-inch.json`
- `docs/backlog/consumed/hei_unadded_0018-0019-nine-inch.md`