### PR TITLE
Add Agni Finance record

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0043-0044-agni-finance.md
+++ b/docs/backlog/consumed/hei_unadded_0043-0044-agni-finance.md
@@ -1,0 +1,22 @@
+# Consumed backlog rows: hei_unadded_0043 / hei_unadded_0044
+
+Status: added
+
+## Candidate
+
+- backlog_id: `hei_unadded_0043`
+- backlog_id: `hei_unadded_0044`
+- backlog_name: `Agni Finance`
+- added_record_path: `records/exchanges/agni-finance.json`
+- added_entity_id: `hei_ex_000353`
+
+## Pre-add duplicate checks
+
+- repository search: no existing `Agni Finance` hit
+- domain search: no existing `agni.finance` hit
+- direct bundle check: `records/exchanges/agni-finance.json` not found
+- ID checks: `hei_ex_000353`, `hei_ev_000661`, `hei_src_001444`, `hei_src_001445`, and `hei_src_001446` unused before creation
+
+## Notes
+
+This is a low-confidence active DEX/protocol record from verified-unadded rows. Launch date remains null pending stronger date-specific evidence.

--- a/records/exchanges/agni-finance.json
+++ b/records/exchanges/agni-finance.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000353",
+    "slug": "agni-finance",
+    "canonical_name": "Agni Finance",
+    "aliases": ["Agni", "Agni DEX", "agni.finance"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Mantle ecosystem",
+    "summary": "Mantle ecosystem decentralized exchange candidate identified in the HEI verified-unadded backlog from CoinPaprika and CoinGecko source data and currently treated as an active DEX record.",
+    "official_url_original": "https://agni.finance/",
+    "official_domain_original": "agni.finance",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://agni.finance/",
+    "confidence": "low",
+    "last_verified_at": "2026-05-30",
+    "notes": "Added from verified-unadded backlog rows hei_unadded_0043 and hei_unadded_0044. Source evidence is limited to CoinPaprika and CoinGecko database references plus the official domain, so this record should be improved later if stronger official-history evidence is found."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000661",
+      "exchange_id": "hei_ex_000353",
+      "event_type": "listed_reference",
+      "event_date": "2026-05-30",
+      "title": "Agni Finance present in exchange source data",
+      "description": "Agni Finance appeared in the verified-unadded candidate generator from CoinPaprika and CoinGecko source data as an exchange-like DEX candidate not found in current HEI records.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "This is a database-reference event, not a verified launch event. Replace with a proper launch/history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001444",
+      "exchange_id": "hei_ex_000353",
+      "event_id": "hei_ev_000661",
+      "source_type": "official_statement",
+      "title": "Agni Finance official website",
+      "url": "https://agni.finance/",
+      "publisher": "Agni Finance",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://agni.finance/",
+      "accessed_at": "2026-05-30",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve the active Agni Finance identity."
+    },
+    {
+      "id": "hei_src_001445",
+      "exchange_id": "hei_ex_000353",
+      "event_id": "hei_ev_000661",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchanges reference for Agni Finance",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-05-30",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0043."
+    },
+    {
+      "id": "hei_src_001446",
+      "exchange_id": "hei_ex_000353",
+      "event_id": "hei_ev_000661",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchanges reference for Agni Finance",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-05-30",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0044, with domain agni.finance and source id agni-finance."
+    }
+  ]
+}


### PR DESCRIPTION
Add a low-confidence record bundle for Agni Finance from the verified-unadded candidate backlog and consume the source backlog rows.

Pre-add duplicate checks performed:
- Repository search: no existing `Agni Finance` hit
- Domain search: no existing `agni.finance` hit
- Direct bundle check: `records/exchanges/agni-finance.json` not found
- ID checks: `hei_ex_000353`, `hei_ev_000661`, `hei_src_001444`, `hei_src_001445`, and `hei_src_001446` unused before creation

Files:
- `records/exchanges/agni-finance.json`
- `docs/backlog/consumed/hei_unadded_0043-0044-agni-finance.md`