### PR TITLE
Add Aivora Exchange record

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0046-aivora-exchange.md
+++ b/docs/backlog/consumed/hei_unadded_0046-aivora-exchange.md
@@ -1,0 +1,35 @@
+# Consumed backlog row: hei_unadded_0046
+
+Status: added
+
+## Candidate
+
+- backlog_id: `hei_unadded_0046`
+- backlog_name: `Aivora Exchange`
+- added_record_path: `records/exchanges/aivora-exchange.json`
+- added_entity_id: `hei_ex_000355`
+
+## Source confirmation
+
+The source row was checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before this record was created.
+
+Confirmed nearby mapping:
+
+- `hei_unadded_0045` = `AirSwap`
+- `hei_unadded_0046` = `Aivora Exchange`
+- `hei_unadded_0047` = `AjuBit`
+
+## Pre-add duplicate checks
+
+- repository search: no existing `Aivora Exchange` hit
+- slug search: no existing `aivora-exchange` hit
+- domain search: no existing `aivora.com` hit
+- direct bundle check: `records/exchanges/aivora-exchange.json` not found
+- PR search: no existing `Aivora Exchange` / `aivora-exchange` PR hit
+- public site check: no existing public HEI entry found during the pre-add check
+- official/public website check: `aivora.com` displayed an exchange-like public site during the pre-add check
+- ID checks: `hei_ex_000355`, `hei_ev_000663`, `hei_src_001449`, and `hei_src_001450` unused before creation
+
+## Notes
+
+This is a low-confidence active exchange record added from CoinGecko source data. It should be improved later with stronger public history, launch, and operational evidence if available.

--- a/records/exchanges/aivora-exchange.json
+++ b/records/exchanges/aivora-exchange.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000355",
+    "slug": "aivora-exchange",
+    "canonical_name": "Aivora Exchange",
+    "aliases": ["Aivora", "aivora.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized exchange candidate identified in the HEI verified-unadded backlog from CoinGecko source data and currently treated as an active exchange record.",
+    "official_url_original": "https://www.aivora.com/",
+    "official_domain_original": "aivora.com",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://www.aivora.com/",
+    "confidence": "low",
+    "last_verified_at": "2026-05-31",
+    "notes": "Added from verified-unadded backlog row hei_unadded_0046. Evidence is limited to CoinGecko and the official domain, so this record should be improved later if stronger historical or operational sources are found."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000663",
+      "exchange_id": "hei_ex_000355",
+      "event_type": "listed_reference",
+      "event_date": "2026-05-31",
+      "title": "Aivora Exchange present in exchange source data",
+      "description": "Aivora Exchange appeared in the verified-unadded candidate generator from CoinGecko source data as an exchange-like candidate not found in current HEI records.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Database-reference event. Replace with a proper launch or history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001449",
+      "exchange_id": "hei_ex_000355",
+      "event_id": "hei_ev_000663",
+      "source_type": "official_statement",
+      "title": "Aivora Exchange official website",
+      "url": "https://www.aivora.com/",
+      "publisher": "Aivora Exchange",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.aivora.com/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve the active Aivora Exchange identity."
+    },
+    {
+      "id": "hei_src_001450",
+      "exchange_id": "hei_ex_000355",
+      "event_id": "hei_ev_000663",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchanges reference for Aivora Exchange",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0046 with source id aivora-exchange."
+    }
+  ]
+}


### PR DESCRIPTION
Add a low-confidence record bundle for Aivora Exchange from the verified-unadded candidate backlog and consume the source backlog row.

Backlog row:
- `hei_unadded_0046` = Aivora Exchange

Nearby row check:
- `hei_unadded_0045` = AirSwap
- `hei_unadded_0046` = Aivora Exchange
- `hei_unadded_0047` = AjuBit

Pre-add duplicate checks performed:
- Repository search: no existing `Aivora Exchange` hit
- Slug search: no existing `aivora-exchange` hit
- Domain search: no existing `aivora.com` hit
- Direct bundle check: `records/exchanges/aivora-exchange.json` not found
- PR search: no existing `Aivora Exchange` / `aivora-exchange` PR hit
- Public site check: no existing public HEI entry found during the pre-add check
- Official/public website check: `aivora.com` displayed an exchange-like public site during the pre-add check
- ID checks: `hei_ex_000355`, `hei_ev_000663`, `hei_src_001449`, and `hei_src_001450` unused before creation

Files added:
- `records/exchanges/aivora-exchange.json`
- `docs/backlog/consumed/hei_unadded_0046-aivora-exchange.md`

Record:
- `hei_ex_000355` Aivora Exchange
- status: `active`
- type: `cex`
- death_reason: `null`
- confidence: `low`

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- no canonical `data/*.json` changes
