### PR TITLE
Defer AjuBit candidate

### DIFF
--- a/docs/backlog/pending/hei_unadded_0047-ajubit.md
+++ b/docs/backlog/pending/hei_unadded_0047-ajubit.md
@@ -1,0 +1,46 @@
+# Pending backlog row: hei_unadded_0047
+
+Status: pending
+
+## Candidate
+
+- backlog_id: `hei_unadded_0047`
+- backlog_name: `AjuBit`
+- candidate_slug: `ajubit`
+- source: `coinpaprika_exchanges`
+- source_url: `https://api.coinpaprika.com/v1/exchanges`
+- source_id: `ajubit`
+
+## Source confirmation
+
+The source row was checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before this pending decision was created.
+
+Confirmed nearby mapping:
+
+- `hei_unadded_0046` = `Aivora Exchange`
+- `hei_unadded_0047` = `AjuBit`
+- `hei_unadded_0048` = `Aktionariat`
+
+## Pre-add checks
+
+- repository search: no existing `AjuBit` hit
+- slug search: no existing `ajubit` hit
+- direct bundle check: `records/exchanges/ajubit.json` not found
+- PR search: only nearby-row references found, no existing AjuBit record PR identified
+- public site check: no existing public HEI entry found during the pre-add check
+- official/public website check: no reliable official domain or public website confirmed during this pass
+
+## Decision
+
+Do not create a record bundle yet.
+
+Reason:
+
+- the verified-unadded row has no domain
+- no official/public site was confirmed during this pass
+- available evidence is limited to a database-style CoinPaprika source reference
+- creating an active exchange record now would be weaker than the current public-ready threshold
+
+## Next action
+
+Revisit if a reliable official domain, archive, or stronger public source is found.


### PR DESCRIPTION
Defer `hei_unadded_0047` instead of creating a weak record bundle.

Backlog row:
- `hei_unadded_0047` = AjuBit

Nearby row check:
- `hei_unadded_0046` = Aivora Exchange
- `hei_unadded_0047` = AjuBit
- `hei_unadded_0048` = Aktionariat

Pre-add checks performed:
- Repository search: no existing `AjuBit` hit
- Slug search: no existing `ajubit` hit
- Direct bundle check: `records/exchanges/ajubit.json` not found
- PR search: only nearby-row references found, no existing AjuBit record PR identified
- Public site check: no existing public HEI entry found during the pre-add check
- Official/public website check: no reliable official domain or public website confirmed during this pass

Decision:
- Do not create a record bundle yet.
- The verified-unadded row has no domain and currently only has a database-style CoinPaprika reference.
- Revisit if a reliable official domain, archive, or stronger public source is found.

Files added:
- `docs/backlog/pending/hei_unadded_0047-ajubit.md`

Validation target:
- backlog dedupe
- no canonical `data/*.json` changes
- no record bundle added
