### PR TITLE
Defer Aldrin candidate

### DIFF
--- a/docs/backlog/pending/hei_unadded_0051-aldrin.md
+++ b/docs/backlog/pending/hei_unadded_0051-aldrin.md
@@ -1,0 +1,46 @@
+# Pending backlog row: hei_unadded_0051
+
+Status: pending
+
+## Candidate
+
+- backlog_id: `hei_unadded_0051`
+- backlog_name: `Aldrin`
+- candidate_slug: `aldrin`
+- source: `defillama_dexs`
+- source_url: `https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume`
+- source_id: `aldrin`
+
+## Source confirmation
+
+The source row was checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before this pending decision was created.
+
+Confirmed nearby mapping:
+
+- `hei_unadded_0050` = `Alcor Exchange`
+- `hei_unadded_0051` = `Aldrin`
+- `hei_unadded_0052` = `ALEX`
+
+## Pre-add checks
+
+- repository search: no existing `Aldrin` hit
+- slug search: no existing `aldrin` hit
+- direct bundle check: `records/exchanges/aldrin.json` not found
+- PR search: no existing Aldrin record PR identified
+- public site check: no existing public HEI entry found during the pre-add check
+- official/public website check: no reliable official domain or public website confirmed during this pass
+
+## Decision
+
+Do not create a record bundle yet.
+
+Reason:
+
+- the verified-unadded row has no domain
+- no reliable official/public site was confirmed during this pass
+- available evidence is limited to a database-style DefiLlama DEX reference
+- creating an active DEX record now would be weaker than the current public-ready threshold
+
+## Next action
+
+Revisit if a reliable official domain, archive, or stronger public source is found.


### PR DESCRIPTION
Defer `hei_unadded_0051` instead of creating a weak DEX record bundle.

Correction:
- The previous completion note incorrectly said the next row was Altcoin Trader.
- The verified-unadded list confirms the next row is `hei_unadded_0051` = Aldrin.

Backlog row:
- `hei_unadded_0051` = Aldrin

Nearby row check:
- `hei_unadded_0050` = Alcor Exchange
- `hei_unadded_0051` = Aldrin
- `hei_unadded_0052` = ALEX

Pre-add checks performed:
- Repository search: no existing `Aldrin` hit
- Slug search: no existing `aldrin` hit
- Direct bundle check: `records/exchanges/aldrin.json` not found
- PR search: no existing Aldrin record PR identified
- Public site check: no existing public HEI entry found during the pre-add check
- Official/public website check: no reliable official domain or public website confirmed during this pass

Decision:
- Do not create a record bundle yet.
- The verified-unadded row has no domain and available evidence is limited to a database-style DefiLlama DEX reference.
- Revisit if a reliable official domain, archive, or stronger public source is found.

Files added:
- `docs/backlog/pending/hei_unadded_0051-aldrin.md`

Validation target:
- backlog dedupe
- no canonical `data/*.json` changes
- no record bundle added
