### PR TITLE
Add batch DEX protocol records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0052-0186-dex-batch.md
+++ b/docs/backlog/consumed/hei_unadded_0052-0186-dex-batch.md
@@ -1,0 +1,111 @@
+# Consumed backlog rows: DEX/protocol batch
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five event-backed or protocol-level DEX records under the revised HEI record-addition policy.
+
+This batch avoids creating thin one-row active records. Version/deployment duplicate rows are collapsed into one entity where appropriate.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000357` | Balancer | `records/exchanges/balancer.json` | `hei_unadded_0175`-`hei_unadded_0181` |
+| `hei_ex_000358` | Bancor | `records/exchanges/bancor.json` | `hei_unadded_0182`-`hei_unadded_0186` |
+| `hei_ex_000359` | Algofi Swap | `records/exchanges/algofi-swap.json` | `hei_unadded_0054` |
+| `hei_ex_000360` | ALEX | `records/exchanges/alex.json` | `hei_unadded_0052`, `hei_unadded_0053` |
+| `hei_ex_000361` | Astroport | `records/exchanges/astroport.json` | `hei_unadded_0137`-`hei_unadded_0141` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` and scan memos before creation:
+
+- `docs/backlog/scans/hei_unadded_0052-0100-scan.md`
+- `docs/backlog/scans/hei_unadded_0101-0150-scan.md`
+- `docs/backlog/scans/hei_unadded_0151-0200-scan.md`
+
+## Duplicate handling
+
+### Balancer
+
+Consumed rows:
+
+- `hei_unadded_0175` Balancer (Polygon)
+- `hei_unadded_0176` Balancer V1
+- `hei_unadded_0177` Balancer V2
+- `hei_unadded_0178` Balancer V2 (Arbitrum One)
+- `hei_unadded_0179` Balancer V2 (Avalanche)
+- `hei_unadded_0180` Balancer V3
+- `hei_unadded_0181` Balancer V3 (Plasma)
+
+Decision: create one `Balancer` protocol-level DEX record. Do not create separate version/deployment records for v0.
+
+### Bancor
+
+Consumed rows:
+
+- `hei_unadded_0182` Bancor (V2)
+- `hei_unadded_0183` Bancor (V3)
+- `hei_unadded_0184` Bancor Network
+- `hei_unadded_0185` Bancor V2.1
+- `hei_unadded_0186` Bancor V3
+
+Decision: create one `Bancor` protocol-level DEX record. Do not create separate version records for v0.
+
+### ALEX
+
+Consumed rows:
+
+- `hei_unadded_0052` ALEX / `alexgo` / `alexlab.co`
+- `hei_unadded_0053` ALEX / `alex`
+
+Decision: create one `ALEX` protocol-level DEX record.
+
+### Astroport
+
+Consumed rows:
+
+- `hei_unadded_0137` Astroport
+- `hei_unadded_0138` Astroport (Classic)
+- `hei_unadded_0139` Astroport (Neutron)
+- `hei_unadded_0140` Astroport (Terra 2.0)
+- `hei_unadded_0141` Astroport (Terra)
+
+Decision: create one `Astroport` protocol-level DEX record and treat chain/version rows as aliases or deployment context.
+
+## Pre-add duplicate checks
+
+Repository search before creation found no existing records for:
+
+- `Balancer`
+- `Bancor`
+- `Algofi`
+- `ALEX`
+- `Astroport`
+
+ID checks before creation found no hits for:
+
+- `hei_ex_000357`-`hei_ex_000361`
+- `hei_ev_000665`-`hei_ev_000669`
+- `hei_src_001454` onward
+
+## Public site / source notes
+
+- These records are not thin `listed_reference`-only entries.
+- Each record includes an entity-level official domain or documentation source.
+- Each record includes database references from the verified-unadded candidate source rows.
+- Event details should be strengthened later where official postmortems or launch announcements are available.
+
+## Next action
+
+After this batch, continue with research candidates from the scan pool, especially:
+
+- ApeSwap
+- ApolloX
+- Aster
+- Arbswap
+- ArcherSwap
+- ArthSwap
+- Backpack if active CEX seed policy is used

--- a/records/exchanges/alex.json
+++ b/records/exchanges/alex.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000360",
+    "slug": "alex",
+    "canonical_name": "ALEX",
+    "aliases": ["ALEX Lab", "ALEX Protocol", "ALEX DEX", "alexlab.co"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Stacks ecosystem",
+    "summary": "Stacks ecosystem DeFi and exchange protocol. HEI records ALEX as a protocol-level DEX entity and consolidates the CoinGecko and DefiLlama candidate rows into one record.",
+    "official_url_original": "https://alexlab.co/",
+    "official_domain_original": "alexlab.co",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://alexlab.co/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-31",
+    "notes": "Added from verified-unadded rows hei_unadded_0052 and hei_unadded_0053 as one entity. ALEX has event history beyond a thin database listing and should be improved later with stronger incident-specific sources."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000668",
+      "exchange_id": "hei_ex_000360",
+      "event_type": "exploit",
+      "event_date": "2024-05-14",
+      "title": "ALEX disclosed security incident / exploit context",
+      "description": "ALEX is included as an event-backed DEX/protocol record because the protocol has public security-incident history in addition to exchange database references.",
+      "confidence": "medium",
+      "impact_level": "high",
+      "event_status_effect": "limited",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Incident details should be refined later with the strongest official postmortem or recovery-plan source available."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001463",
+      "exchange_id": "hei_ex_000360",
+      "event_id": "hei_ev_000668",
+      "source_type": "official_statement",
+      "title": "ALEX official website",
+      "url": "https://alexlab.co/",
+      "publisher": "ALEX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://alexlab.co/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve ALEX identity."
+    },
+    {
+      "id": "hei_src_001464",
+      "exchange_id": "hei_ex_000360",
+      "event_id": "hei_ev_000668",
+      "source_type": "news_article",
+      "title": "ALEX Lab exploit / recovery coverage",
+      "url": "https://www.coindesk.com/tech/2024/05/15/bitcoin-layer-2-alex-lab-loses-43m-in-exploit/",
+      "publisher": "CoinDesk",
+      "published_at": "2024-05-15",
+      "archived_url": "https://web.archive.org/web/*/https://www.coindesk.com/tech/2024/05/15/bitcoin-layer-2-alex-lab-loses-43m-in-exploit/",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Secondary source used to support the public exploit/incident event."
+    },
+    {
+      "id": "hei_src_001465",
+      "exchange_id": "hei_ex_000360",
+      "event_id": "hei_ev_000668",
+      "source_type": "database_reference",
+      "title": "CoinGecko / DefiLlama references for ALEX",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko / DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0052 and hei_unadded_0053 referred to the same ALEX candidate."
+    }
+  ]
+}

--- a/records/exchanges/algofi-swap.json
+++ b/records/exchanges/algofi-swap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000359",
+    "slug": "algofi-swap",
+    "canonical_name": "Algofi Swap",
+    "aliases": ["Algofi", "Algofi Protocol", "Algofi DEX"],
+    "type": "dex",
+    "status": "dead",
+    "death_reason": "voluntary_shutdown",
+    "launch_date": null,
+    "death_date": "2023-07-31",
+    "country_or_origin": "Algorand ecosystem",
+    "summary": "Algorand ecosystem DeFi protocol with swap functionality. HEI records Algofi Swap as a DEX/protocol entity because the project announced that it would sunset, making it more suitable for HEI than thin active-only DEX rows.",
+    "official_url_original": "https://www.algofi.org/",
+    "official_domain_original": "algofi.org",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://www.algofi.org/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-31",
+    "notes": "Added from verified-unadded row hei_unadded_0054. Status is based on the public sunsetting / shutdown history rather than the DefiLlama database row alone."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000667",
+      "exchange_id": "hei_ex_000359",
+      "event_type": "shutdown_announced",
+      "event_date": "2023-07-31",
+      "title": "Algofi announced protocol sunsetting",
+      "description": "Algofi announced that the protocol would sunset, making Algofi Swap a dead or discontinued DEX/protocol record rather than a thin active listing.",
+      "confidence": "medium",
+      "impact_level": "high",
+      "event_status_effect": "dead",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "The exact shutdown wording/source should be strengthened later with an archived official announcement if needed."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001460",
+      "exchange_id": "hei_ex_000359",
+      "event_id": "hei_ev_000667",
+      "source_type": "official_statement",
+      "title": "Algofi official website",
+      "url": "https://www.algofi.org/",
+      "publisher": "Algofi",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.algofi.org/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve Algofi identity."
+    },
+    {
+      "id": "hei_src_001461",
+      "exchange_id": "hei_ex_000359",
+      "event_id": "hei_ev_000667",
+      "source_type": "news_article",
+      "title": "Algofi protocol sunsetting coverage",
+      "url": "https://www.coindesk.com/tech/2023/07/31/algorand-based-defi-protocol-algofi-to-shut-down/",
+      "publisher": "CoinDesk",
+      "published_at": "2023-07-31",
+      "archived_url": "https://web.archive.org/web/*/https://www.coindesk.com/tech/2023/07/31/algorand-based-defi-protocol-algofi-to-shut-down/",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Secondary source used to support the public shutdown/sunsetting event."
+    },
+    {
+      "id": "hei_src_001462",
+      "exchange_id": "hei_ex_000359",
+      "event_id": "hei_ev_000667",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Algofi Swap",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0054."
+    }
+  ]
+}

--- a/records/exchanges/astroport.json
+++ b/records/exchanges/astroport.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000361",
+    "slug": "astroport",
+    "canonical_name": "Astroport",
+    "aliases": ["Astroport Classic", "Astroport Neutron", "Astroport Terra", "Astroport Terra 2.0", "astroport.fi"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2021-12-14",
+    "death_date": null,
+    "country_or_origin": "Terra / Cosmos ecosystem",
+    "summary": "Cosmos/Terra ecosystem automated market maker and decentralized exchange protocol. HEI treats Astroport as one protocol-level DEX entity and records Terra/Neutron/Terra 2.0 rows as deployments or variants rather than separate v0 entities.",
+    "official_url_original": "https://astroport.fi/",
+    "official_domain_original": "astroport.fi",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://astroport.fi/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-31",
+    "notes": "Added from verified-unadded rows hei_unadded_0137 through hei_unadded_0141 as one entity to avoid chain/version duplication."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000669",
+      "exchange_id": "hei_ex_000361",
+      "event_type": "launched",
+      "event_date": "2021-12-14",
+      "title": "Astroport launch treated as DEX start",
+      "description": "Astroport is recorded as a protocol-level AMM/DEX entity with multiple deployment and version rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Launch date and Terra history should be refined later with stronger primary launch and migration sources."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001466",
+      "exchange_id": "hei_ex_000361",
+      "event_id": "hei_ev_000669",
+      "source_type": "official_statement",
+      "title": "Astroport official website",
+      "url": "https://astroport.fi/",
+      "publisher": "Astroport",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://astroport.fi/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve current Astroport identity."
+    },
+    {
+      "id": "hei_src_001467",
+      "exchange_id": "hei_ex_000361",
+      "event_id": "hei_ev_000669",
+      "source_type": "official_statement",
+      "title": "Astroport documentation",
+      "url": "https://docs.astroport.fi/",
+      "publisher": "Astroport",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.astroport.fi/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official documentation used for protocol-level identity."
+    },
+    {
+      "id": "hei_src_001468",
+      "exchange_id": "hei_ex_000361",
+      "event_id": "hei_ev_000669",
+      "source_type": "database_reference",
+      "title": "DefiLlama / CoinGecko / CoinPaprika references for Astroport variants",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama / CoinGecko / CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0137-0141 contained Astroport deployment/version references."
+    }
+  ]
+}

--- a/records/exchanges/balancer.json
+++ b/records/exchanges/balancer.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000357",
+    "slug": "balancer",
+    "canonical_name": "Balancer",
+    "aliases": ["Balancer Protocol", "Balancer V1", "Balancer V2", "Balancer V3", "balancer.fi"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2020-03-31",
+    "death_date": null,
+    "country_or_origin": "Ethereum ecosystem",
+    "summary": "Automated market maker and decentralized exchange protocol launched on Ethereum and later expanded across multiple chains. HEI treats Balancer as one protocol-level DEX entity rather than separate records for each version or deployment.",
+    "official_url_original": "https://balancer.fi/",
+    "official_domain_original": "balancer.fi",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://balancer.fi/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-31",
+    "notes": "Added from verified-unadded rows hei_unadded_0175 through hei_unadded_0181 as one entity to avoid version/deployment duplication."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000665",
+      "exchange_id": "hei_ex_000357",
+      "event_type": "launched",
+      "event_date": "2020-03-31",
+      "title": "Balancer protocol launch treated as DEX start",
+      "description": "Balancer is recorded as an Ethereum ecosystem AMM and DEX protocol. Version and deployment rows are consolidated into one protocol-level HEI entity.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Launch date should be upgraded later if a stronger primary launch announcement is added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001454",
+      "exchange_id": "hei_ex_000357",
+      "event_id": "hei_ev_000665",
+      "source_type": "official_statement",
+      "title": "Balancer official website",
+      "url": "https://balancer.fi/",
+      "publisher": "Balancer",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://balancer.fi/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify current Balancer identity."
+    },
+    {
+      "id": "hei_src_001455",
+      "exchange_id": "hei_ex_000357",
+      "event_id": "hei_ev_000665",
+      "source_type": "official_statement",
+      "title": "Balancer documentation",
+      "url": "https://docs.balancer.fi/",
+      "publisher": "Balancer",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.balancer.fi/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official documentation used for protocol-level identity."
+    },
+    {
+      "id": "hei_src_001456",
+      "exchange_id": "hei_ex_000357",
+      "event_id": "hei_ev_000665",
+      "source_type": "database_reference",
+      "title": "CoinPaprika / DefiLlama references for Balancer variants",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika / DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0175-0181 contained Balancer deployment/version references."
+    }
+  ]
+}

--- a/records/exchanges/bancor.json
+++ b/records/exchanges/bancor.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000358",
+    "slug": "bancor",
+    "canonical_name": "Bancor",
+    "aliases": ["Bancor Network", "Bancor V2", "Bancor V2.1", "Bancor V3", "bancor.network"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2017-06-12",
+    "death_date": null,
+    "country_or_origin": "Ethereum ecosystem",
+    "summary": "Early automated market maker and decentralized liquidity protocol. HEI treats Bancor as one protocol-level DEX entity rather than separate records for each version row.",
+    "official_url_original": "https://bancor.network/",
+    "official_domain_original": "bancor.network",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bancor.network/",
+    "confidence": "medium",
+    "last_verified_at": "2026-05-31",
+    "notes": "Added from verified-unadded rows hei_unadded_0182 through hei_unadded_0186 as one entity to avoid duplicate Bancor version records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000666",
+      "exchange_id": "hei_ex_000358",
+      "event_type": "launched",
+      "event_date": "2017-06-12",
+      "title": "Bancor protocol launch treated as DEX start",
+      "description": "Bancor is recorded as an early Ethereum ecosystem AMM and decentralized liquidity protocol. Version rows are consolidated into one HEI entity.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Launch date uses the public Bancor token generation / protocol launch period and should be refined if a stronger primary source is added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001457",
+      "exchange_id": "hei_ex_000358",
+      "event_id": "hei_ev_000666",
+      "source_type": "official_statement",
+      "title": "Bancor official website",
+      "url": "https://bancor.network/",
+      "publisher": "Bancor",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bancor.network/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify current Bancor identity."
+    },
+    {
+      "id": "hei_src_001458",
+      "exchange_id": "hei_ex_000358",
+      "event_id": "hei_ev_000666",
+      "source_type": "official_statement",
+      "title": "Bancor documentation",
+      "url": "https://docs.bancor.network/",
+      "publisher": "Bancor",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.bancor.network/",
+      "accessed_at": "2026-05-31",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official documentation used for protocol-level identity."
+    },
+    {
+      "id": "hei_src_001459",
+      "exchange_id": "hei_ex_000358",
+      "event_id": "hei_ev_000666",
+      "source_type": "database_reference",
+      "title": "CoinGecko / CoinPaprika / DefiLlama references for Bancor variants",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko / CoinPaprika / DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-05-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0182-0186 contained Bancor deployment/version references."
+    }
+  ]
+}


### PR DESCRIPTION
Add five protocol-level DEX records from the scanned verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000357` Balancer — `records/exchanges/balancer.json`
- `hei_ex_000358` Bancor — `records/exchanges/bancor.json`
- `hei_ex_000359` Algofi Swap — `records/exchanges/algofi-swap.json`
- `hei_ex_000360` ALEX — `records/exchanges/alex.json`
- `hei_ex_000361` Astroport — `records/exchanges/astroport.json`

Consumed rows:
- ALEX: `hei_unadded_0052`, `hei_unadded_0053`
- Algofi Swap: `hei_unadded_0054`
- Astroport: `hei_unadded_0137`-`hei_unadded_0141`
- Balancer: `hei_unadded_0175`-`hei_unadded_0181`
- Bancor: `hei_unadded_0182`-`hei_unadded_0186`

Files added:
- `records/exchanges/balancer.json`
- `records/exchanges/bancor.json`
- `records/exchanges/algofi-swap.json`
- `records/exchanges/alex.json`
- `records/exchanges/astroport.json`
- `docs/backlog/consumed/hei_unadded_0052-0186-dex-batch.md`

Policy notes:
- This follows the revised batch policy.
- Version/deployment duplicate rows are collapsed into one protocol-level entity.
- This avoids thin one-row active records.
- Each record includes official/domain evidence plus source database references.

Pre-add checks:
- Repository name searches found no existing records for Balancer, Bancor, Algofi, ALEX, or Astroport.
- ID searches found no existing hits for `hei_ex_000357`, `hei_ev_000665`, or `hei_src_001454` before creation.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- no canonical `data/*.json` direct edits
