### PR TITLE
Add second batch DEX records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0093-0197-dex-batch-2.md
+++ b/docs/backlog/consumed/hei_unadded_0093-0197-dex-batch-2.md
@@ -1,0 +1,94 @@
+# Consumed backlog rows: DEX/exchange batch 2
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five exchange / DEX records under the revised HEI record-addition policy.
+
+This batch continues the post-scan workflow and avoids one-row pending PRs. Duplicate or version-specific rows are collapsed into one entity where appropriate.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000362` | ApeSwap | `records/exchanges/apeswap.json` | `hei_unadded_0093`-`hei_unadded_0095` |
+| `hei_ex_000363` | ApolloX | `records/exchanges/apollox.json` | `hei_unadded_0099`, `hei_unadded_0100` |
+| `hei_ex_000364` | Backpack | `records/exchanges/backpack.json` | `hei_unadded_0170` |
+| `hei_ex_000365` | BakerySwap | `records/exchanges/bakeryswap.json` | `hei_unadded_0171`, `hei_unadded_0172` |
+| `hei_ex_000366` | BaseSwap | `records/exchanges/baseswap.json` | `hei_unadded_0194`-`hei_unadded_0197` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` and scan memos before creation:
+
+- `docs/backlog/scans/hei_unadded_0052-0100-scan.md`
+- `docs/backlog/scans/hei_unadded_0101-0150-scan.md`
+- `docs/backlog/scans/hei_unadded_0151-0200-scan.md`
+
+## Duplicate handling
+
+### ApeSwap
+
+Consumed rows:
+
+- `hei_unadded_0093` ApeSwap
+- `hei_unadded_0094` ApeSwap BSC
+- `hei_unadded_0095` ApeSwap AMM
+
+Decision: create one `ApeSwap` protocol-level DEX record.
+
+### ApolloX
+
+Consumed rows:
+
+- `hei_unadded_0099` ApolloX
+- `hei_unadded_0100` ApolloX DEX
+
+Decision: create one `ApolloX` hybrid exchange/protocol record unless future research proves separation is required.
+
+### Backpack
+
+Consumed row:
+
+- `hei_unadded_0170` Backpack
+
+Decision: create one active CEX seed record because an official exchange domain exists and the row comes from CCXT.
+
+### BakerySwap
+
+Consumed rows:
+
+- `hei_unadded_0171` BakerySwap
+- `hei_unadded_0172` BakerySwap
+
+Decision: create one `BakerySwap` protocol-level DEX record.
+
+### BaseSwap
+
+Consumed rows:
+
+- `hei_unadded_0194` BaseSwap V2
+- `hei_unadded_0195` BaseSwap V2
+- `hei_unadded_0196` BaseSwap V3
+- `hei_unadded_0197` BaseSwap V3
+
+Decision: create one `BaseSwap` protocol-level DEX record and avoid separate v2/v3 records in v0.
+
+## Notes
+
+- Aster was investigated in this pass but was excluded from the batch after repeated tool-side write blocking.
+- Aster remains a future research/add candidate.
+- Records in this batch should be improved later with stronger launch, incident, migration, licensing, or history evidence where available.
+
+## Next action
+
+Continue with remaining research candidates:
+
+- Aster
+- Arbswap
+- ArcherSwap
+- ArthSwap
+- Balanced / Balanced Exchange
+- Baryon Network
+- Azbit / B2BX where CEX scope is accepted

--- a/records/exchanges/apeswap.json
+++ b/records/exchanges/apeswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000362",
+    "slug": "apeswap",
+    "canonical_name": "ApeSwap",
+    "aliases": ["ApeSwap BSC", "ApeSwap AMM", "ApeSwap Finance", "apeswap.finance"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "BNB Chain ecosystem",
+    "summary": "Multi-chain DeFi and automated market maker protocol, originally known for BNB Chain DEX activity. HEI treats ApeSwap, ApeSwap BSC, and ApeSwap AMM rows as one protocol-level DEX entity.",
+    "official_url_original": "https://apeswap.finance/",
+    "official_domain_original": "apeswap.finance",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://apeswap.finance/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0093 through hei_unadded_0095 as one entity to avoid duplicate AMM / chain-specific records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000670",
+      "exchange_id": "hei_ex_000362",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "ApeSwap recorded as protocol-level DEX entity",
+      "description": "ApeSwap is recorded as a protocol-level AMM/DEX entity, with BSC and AMM candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch or migration event if a stronger primary source is added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001469",
+      "exchange_id": "hei_ex_000362",
+      "event_id": "hei_ev_000670",
+      "source_type": "official_statement",
+      "title": "ApeSwap official website",
+      "url": "https://apeswap.finance/",
+      "publisher": "ApeSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://apeswap.finance/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify current ApeSwap identity."
+    },
+    {
+      "id": "hei_src_001470",
+      "exchange_id": "hei_ex_000362",
+      "event_id": "hei_ev_000670",
+      "source_type": "official_statement",
+      "title": "ApeSwap documentation",
+      "url": "https://apeswap.gitbook.io/apeswap-finance/",
+      "publisher": "ApeSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://apeswap.gitbook.io/apeswap-finance/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official documentation used for protocol-level identity."
+    },
+    {
+      "id": "hei_src_001471",
+      "exchange_id": "hei_ex_000362",
+      "event_id": "hei_ev_000670",
+      "source_type": "database_reference",
+      "title": "CoinPaprika / CoinGecko / DefiLlama references for ApeSwap variants",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika / CoinGecko / DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0093-0095 contained ApeSwap and ApeSwap AMM references."
+    }
+  ]
+}

--- a/records/exchanges/apollox.json
+++ b/records/exchanges/apollox.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000363",
+    "slug": "apollox",
+    "canonical_name": "ApolloX",
+    "aliases": ["ApolloX DEX", "ApolloX Exchange", "apollox.com"],
+    "type": "hybrid",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Crypto derivatives and DEX-associated trading platform. HEI treats ApolloX and ApolloX DEX candidate rows as one hybrid exchange/protocol entity unless later research proves that separate v0 records are required.",
+    "official_url_original": "https://www.apollox.com/",
+    "official_domain_original": "apollox.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.apollox.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0099 and hei_unadded_0100 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000671",
+      "exchange_id": "hei_ex_000363",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "ApolloX recorded as hybrid exchange/protocol entity",
+      "description": "ApolloX is recorded as one HEI entity consolidating ApolloX and ApolloX DEX candidate rows, reflecting its exchange and DEX-associated trading identity.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch, incident, or migration event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001472",
+      "exchange_id": "hei_ex_000363",
+      "event_id": "hei_ev_000671",
+      "source_type": "official_statement",
+      "title": "ApolloX official website",
+      "url": "https://www.apollox.com/",
+      "publisher": "ApolloX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.apollox.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to preserve ApolloX identity."
+    },
+    {
+      "id": "hei_src_001473",
+      "exchange_id": "hei_ex_000363",
+      "event_id": "hei_ev_000671",
+      "source_type": "official_statement",
+      "title": "ApolloX support / official information center",
+      "url": "https://apollox-finance.zendesk.com/",
+      "publisher": "ApolloX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://apollox-finance.zendesk.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Official support/help center used as additional identity evidence."
+    },
+    {
+      "id": "hei_src_001474",
+      "exchange_id": "hei_ex_000363",
+      "event_id": "hei_ev_000671",
+      "source_type": "database_reference",
+      "title": "CoinPaprika references for ApolloX / ApolloX DEX",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0099 and hei_unadded_0100 referred to ApolloX / ApolloX DEX."
+    }
+  ]
+}

--- a/records/exchanges/backpack.json
+++ b/records/exchanges/backpack.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000364",
+    "slug": "backpack",
+    "canonical_name": "Backpack",
+    "aliases": ["Backpack Exchange", "Backpack EU", "backpack.exchange"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Crypto exchange candidate from the CCXT-supported exchange list and official Backpack Exchange domain. HEI records it as an active centralized exchange seed because it has an official trading-domain identity beyond a single database row.",
+    "official_url_original": "https://backpack.exchange/",
+    "official_domain_original": "backpack.exchange",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://backpack.exchange/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0170. This is an active CEX seed record and should be improved later with stronger launch and licensing evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000672",
+      "exchange_id": "hei_ex_000364",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Backpack present in exchange source data",
+      "description": "Backpack appeared in the verified-unadded candidate pool via CCXT and has a current official exchange domain.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch or licensing event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001475",
+      "exchange_id": "hei_ex_000364",
+      "event_id": "hei_ev_000672",
+      "source_type": "official_statement",
+      "title": "Backpack Exchange official website",
+      "url": "https://backpack.exchange/",
+      "publisher": "Backpack",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://backpack.exchange/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Backpack exchange identity."
+    },
+    {
+      "id": "hei_src_001476",
+      "exchange_id": "hei_ex_000364",
+      "event_id": "hei_ev_000672",
+      "source_type": "database_reference",
+      "title": "CCXT reference for Backpack",
+      "url": "https://raw.githubusercontent.com/ccxt/ccxt/master/js/ccxt.js",
+      "publisher": "CCXT",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://raw.githubusercontent.com/ccxt/ccxt/master/js/ccxt.js",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0170."
+    }
+  ]
+}

--- a/records/exchanges/bakeryswap.json
+++ b/records/exchanges/bakeryswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000365",
+    "slug": "bakeryswap",
+    "canonical_name": "BakerySwap",
+    "aliases": ["Bakeryswap", "BakerySwap AMM", "bakeryswap.org"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "BNB Chain ecosystem",
+    "summary": "BNB Chain ecosystem automated market maker and DeFi trading protocol. HEI treats CoinPaprika and CoinGecko BakerySwap candidate rows as one protocol-level DEX entity.",
+    "official_url_original": "https://www.bakeryswap.org/",
+    "official_domain_original": "bakeryswap.org",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bakeryswap.org/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0171 and hei_unadded_0172 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000673",
+      "exchange_id": "hei_ex_000365",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "BakerySwap recorded as protocol-level DEX entity",
+      "description": "BakerySwap is recorded as a BNB Chain ecosystem AMM/DEX entity, with duplicate candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001477",
+      "exchange_id": "hei_ex_000365",
+      "event_id": "hei_ev_000673",
+      "source_type": "official_statement",
+      "title": "BakerySwap official website",
+      "url": "https://www.bakeryswap.org/",
+      "publisher": "BakerySwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bakeryswap.org/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BakerySwap identity."
+    },
+    {
+      "id": "hei_src_001478",
+      "exchange_id": "hei_ex_000365",
+      "event_id": "hei_ev_000673",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for BakerySwap",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0171."
+    },
+    {
+      "id": "hei_src_001479",
+      "exchange_id": "hei_ex_000365",
+      "event_id": "hei_ev_000673",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BakerySwap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0172."
+    }
+  ]
+}

--- a/records/exchanges/baseswap.json
+++ b/records/exchanges/baseswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000366",
+    "slug": "baseswap",
+    "canonical_name": "BaseSwap",
+    "aliases": ["BaseSwap V2", "BaseSwap V3", "baseswap.fi"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Base ecosystem",
+    "summary": "Base ecosystem automated market maker and decentralized exchange protocol. HEI treats BaseSwap V2 and V3 candidate rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://baseswap.fi/",
+    "official_domain_original": "baseswap.fi",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://baseswap.fi/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0194 through hei_unadded_0197 as one entity to avoid duplicate version records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000674",
+      "exchange_id": "hei_ex_000366",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "BaseSwap recorded as protocol-level DEX entity",
+      "description": "BaseSwap is recorded as a Base ecosystem AMM/DEX entity, with V2 and V3 candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch or version migration event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001480",
+      "exchange_id": "hei_ex_000366",
+      "event_id": "hei_ev_000674",
+      "source_type": "official_statement",
+      "title": "BaseSwap official website",
+      "url": "https://baseswap.fi/",
+      "publisher": "BaseSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://baseswap.fi/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BaseSwap identity."
+    },
+    {
+      "id": "hei_src_001481",
+      "exchange_id": "hei_ex_000366",
+      "event_id": "hei_ev_000674",
+      "source_type": "database_reference",
+      "title": "CoinPaprika / DefiLlama references for BaseSwap V2/V3",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika / DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0194-0196 referenced BaseSwap V2/V3."
+    },
+    {
+      "id": "hei_src_001482",
+      "exchange_id": "hei_ex_000366",
+      "event_id": "hei_ev_000674",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BaseSwap V3",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0197."
+    }
+  ]
+}


### PR DESCRIPTION
Add five exchange / DEX records from the scanned verified-unadded backlog pool and consume their source rows in a single batch memo.

PR URL will be available after creation.

Records added:
- `hei_ex_000362` ApeSwap — `records/exchanges/apeswap.json`
- `hei_ex_000363` ApolloX — `records/exchanges/apollox.json`
- `hei_ex_000364` Backpack — `records/exchanges/backpack.json`
- `hei_ex_000365` BakerySwap — `records/exchanges/bakeryswap.json`
- `hei_ex_000366` BaseSwap — `records/exchanges/baseswap.json`

Consumed rows:
- ApeSwap: `hei_unadded_0093`-`hei_unadded_0095`
- ApolloX: `hei_unadded_0099`, `hei_unadded_0100`
- Backpack: `hei_unadded_0170`
- BakerySwap: `hei_unadded_0171`, `hei_unadded_0172`
- BaseSwap: `hei_unadded_0194`-`hei_unadded_0197`

Files added:
- `records/exchanges/apeswap.json`
- `records/exchanges/apollox.json`
- `records/exchanges/backpack.json`
- `records/exchanges/bakeryswap.json`
- `records/exchanges/baseswap.json`
- `docs/backlog/consumed/hei_unadded_0093-0197-dex-batch-2.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate/version rows are collapsed into one protocol-level entity where appropriate.
- Aster was excluded after tool-side write blocking and remains a future candidate.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- no canonical `data/*.json` direct edits
