### PR TITLE
Add third batch DEX records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0110-0218-dex-batch-3.md
+++ b/docs/backlog/consumed/hei_unadded_0110-0218-dex-batch-3.md
@@ -1,0 +1,101 @@
+# Consumed backlog rows: DEX/exchange batch 3
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five DEX/protocol records under the revised HEI record-addition policy.
+
+This batch continues the post-scan workflow and avoids one-row pending PRs. Duplicate, branding, chain, and version-specific rows are collapsed into one entity where appropriate.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000367` | Balanced | `records/exchanges/balanced.json` | `hei_unadded_0173`, `hei_unadded_0174` |
+| `hei_ex_000368` | Arbswap | `records/exchanges/arbswap.json` | `hei_unadded_0110` |
+| `hei_ex_000369` | ArthSwap | `records/exchanges/arthswap.json` | `hei_unadded_0124`, `hei_unadded_0125` |
+| `hei_ex_000370` | Beamswap | `records/exchanges/beamswap.json` | `hei_unadded_0208`-`hei_unadded_0211` |
+| `hei_ex_000371` | Beets | `records/exchanges/beets.json` | `hei_unadded_0213`-`hei_unadded_0218` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` and scan memos before creation:
+
+- `docs/backlog/scans/hei_unadded_0101-0150-scan.md`
+- `docs/backlog/scans/hei_unadded_0151-0200-scan.md`
+- `docs/backlog/scans/hei_unadded_0052-0100-scan.md`
+
+Rows from `hei_unadded_0201` onward were also inspected from the verified-unadded JSONL source before selecting Beamswap and Beets.
+
+## Duplicate handling
+
+### Balanced
+
+Consumed rows:
+
+- `hei_unadded_0173` Balanced
+- `hei_unadded_0174` Balanced Exchange
+
+Decision: create one `Balanced` protocol-level DEX record.
+
+### Arbswap
+
+Consumed row:
+
+- `hei_unadded_0110` Arbswap
+
+Decision: create one `Arbswap` DEX record.
+
+### ArthSwap
+
+Consumed rows:
+
+- `hei_unadded_0124` ArthSwap
+- `hei_unadded_0125` ArthSwap V3
+
+Decision: create one `ArthSwap` protocol-level DEX record and avoid separate v3 records in v0.
+
+### Beamswap
+
+Consumed rows:
+
+- `hei_unadded_0208` Beamswap
+- `hei_unadded_0209` BeamSwap Classic
+- `hei_unadded_0210` BeamSwap Stable AMM
+- `hei_unadded_0211` BeamSwap V3
+
+Decision: create one `Beamswap` protocol-level DEX record and treat variant/version rows as aliases or deployment context.
+
+### Beets
+
+Consumed rows:
+
+- `hei_unadded_0213` Beethoven X (Optimism)
+- `hei_unadded_0214` Beethoven X (Optimism)
+- `hei_unadded_0215` Beets (Sonic)
+- `hei_unadded_0216` Beets (Sonic)
+- `hei_unadded_0217` Beets DEX
+- `hei_unadded_0218` Beets DEX V3
+
+Decision: create one `Beets` protocol-level DEX record and treat Beethoven X / Beets / chain/version rows as one consolidated entity for v0.
+
+## Notes
+
+- This batch intentionally avoids creating separate records for version, deployment, or chain-specific rows.
+- Aster remains a future candidate after prior write blocking.
+- Records in this batch should be improved later with stronger launch, migration, rebrand, or incident evidence where available.
+
+## Next action
+
+Continue with remaining research candidates:
+
+- Aster
+- ArcherSwap
+- Baryon Network
+- Azbit
+- B2BX
+- ATAIX
+- ATOMARS
+- AtomDax
+- Beam Swap if separate from Beamswap after research

--- a/records/exchanges/arbswap.json
+++ b/records/exchanges/arbswap.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000368",
+    "slug": "arbswap",
+    "canonical_name": "Arbswap",
+    "aliases": ["ArbSwap", "Arbswap DEX", "arbswap.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Arbitrum ecosystem",
+    "summary": "Arbitrum ecosystem decentralized exchange and AMM candidate with an official domain and CoinGecko exchange reference.",
+    "official_url_original": "https://arbswap.io/",
+    "official_domain_original": "arbswap.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://arbswap.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0110."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000676",
+      "exchange_id": "hei_ex_000368",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "Arbswap recorded as Arbitrum ecosystem DEX",
+      "description": "Arbswap is recorded as an Arbitrum ecosystem DEX entity based on its official domain and exchange source data.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001486",
+      "exchange_id": "hei_ex_000368",
+      "event_id": "hei_ev_000676",
+      "source_type": "official_statement",
+      "title": "Arbswap official website",
+      "url": "https://arbswap.io/",
+      "publisher": "Arbswap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://arbswap.io/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Arbswap identity."
+    },
+    {
+      "id": "hei_src_001487",
+      "exchange_id": "hei_ex_000368",
+      "event_id": "hei_ev_000676",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Arbswap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0110."
+    }
+  ]
+}

--- a/records/exchanges/arthswap.json
+++ b/records/exchanges/arthswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000369",
+    "slug": "arthswap",
+    "canonical_name": "ArthSwap",
+    "aliases": ["ArthSwap V3", "app.arthswap.org"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Astar ecosystem",
+    "summary": "Astar ecosystem decentralized exchange and AMM protocol. HEI treats ArthSwap and ArthSwap V3 candidate rows as one protocol-level DEX entity.",
+    "official_url_original": "https://app.arthswap.org/",
+    "official_domain_original": "app.arthswap.org",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://app.arthswap.org/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0124 and hei_unadded_0125 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000677",
+      "exchange_id": "hei_ex_000369",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "ArthSwap recorded as Astar ecosystem DEX",
+      "description": "ArthSwap is recorded as an Astar ecosystem AMM/DEX entity, with duplicate ArthSwap rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch or version migration event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001488",
+      "exchange_id": "hei_ex_000369",
+      "event_id": "hei_ev_000677",
+      "source_type": "official_statement",
+      "title": "ArthSwap official app",
+      "url": "https://app.arthswap.org/",
+      "publisher": "ArthSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.arthswap.org/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official app domain used to verify ArthSwap identity."
+    },
+    {
+      "id": "hei_src_001489",
+      "exchange_id": "hei_ex_000369",
+      "event_id": "hei_ev_000677",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for ArthSwap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0124."
+    },
+    {
+      "id": "hei_src_001490",
+      "exchange_id": "hei_ex_000369",
+      "event_id": "hei_ev_000677",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for ArthSwap V3",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0125."
+    }
+  ]
+}

--- a/records/exchanges/balanced.json
+++ b/records/exchanges/balanced.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000367",
+    "slug": "balanced",
+    "canonical_name": "Balanced",
+    "aliases": ["Balanced Exchange", "Balanced Network", "balanced.network"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "ICON / cross-chain ecosystem",
+    "summary": "Cross-chain DeFi platform with swap and exchange functionality. HEI treats Balanced and Balanced Exchange candidate rows as one protocol-level DEX entity.",
+    "official_url_original": "https://balanced.network/",
+    "official_domain_original": "balanced.network",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://balanced.network/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0173 and hei_unadded_0174 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000675",
+      "exchange_id": "hei_ex_000367",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "Balanced recorded as cross-chain DEX entity",
+      "description": "Balanced is recorded as a cross-chain DeFi and exchange entity, with Balanced and Balanced Exchange rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch event if stronger primary sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001483",
+      "exchange_id": "hei_ex_000367",
+      "event_id": "hei_ev_000675",
+      "source_type": "official_statement",
+      "title": "Balanced official website",
+      "url": "https://balanced.network/",
+      "publisher": "Balanced",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://balanced.network/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official website describes Balanced as cross-chain DeFi with swap/exchange functionality."
+    },
+    {
+      "id": "hei_src_001484",
+      "exchange_id": "hei_ex_000367",
+      "event_id": "hei_ev_000675",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Balanced",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0173."
+    },
+    {
+      "id": "hei_src_001485",
+      "exchange_id": "hei_ex_000367",
+      "event_id": "hei_ev_000675",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Balanced Exchange",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0174."
+    }
+  ]
+}

--- a/records/exchanges/beamswap.json
+++ b/records/exchanges/beamswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000370",
+    "slug": "beamswap",
+    "canonical_name": "Beamswap",
+    "aliases": ["BeamSwap", "BeamSwap Classic", "BeamSwap Stable AMM", "BeamSwap V3", "app.beamswap.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Moonbeam ecosystem",
+    "summary": "Moonbeam ecosystem decentralized exchange and AMM protocol. HEI treats Beamswap, BeamSwap Classic, Stable AMM, and V3 rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://app.beamswap.io/",
+    "official_domain_original": "app.beamswap.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://app.beamswap.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0208 through hei_unadded_0211 as one entity to avoid duplicate version records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000678",
+      "exchange_id": "hei_ex_000370",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "Beamswap recorded as Moonbeam ecosystem DEX",
+      "description": "Beamswap is recorded as a Moonbeam ecosystem AMM/DEX entity, with classic, stable AMM, and V3 rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch or version migration event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001491",
+      "exchange_id": "hei_ex_000370",
+      "event_id": "hei_ev_000678",
+      "source_type": "official_statement",
+      "title": "Beamswap official app",
+      "url": "https://app.beamswap.io/",
+      "publisher": "Beamswap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.beamswap.io/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official app domain used to verify Beamswap identity."
+    },
+    {
+      "id": "hei_src_001492",
+      "exchange_id": "hei_ex_000370",
+      "event_id": "hei_ev_000678",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Beamswap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0208."
+    },
+    {
+      "id": "hei_src_001493",
+      "exchange_id": "hei_ex_000370",
+      "event_id": "hei_ev_000678",
+      "source_type": "database_reference",
+      "title": "DefiLlama references for Beamswap variants",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0209-0211 referred to Beamswap variant rows."
+    }
+  ]
+}

--- a/records/exchanges/beets.json
+++ b/records/exchanges/beets.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000371",
+    "slug": "beets",
+    "canonical_name": "Beets",
+    "aliases": ["Beethoven X", "Beethoven X Optimism", "Beets Sonic", "Beets DEX", "Beets DEX V3", "beets.fi"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Fantom / Optimism / Sonic ecosystem",
+    "summary": "Multi-chain AMM and DEX protocol historically associated with Beethoven X and later Beets branding. HEI treats Beethoven X, Beets, and Beets DEX variant rows as one protocol-level entity for v0.",
+    "official_url_original": "https://beets.fi/",
+    "official_domain_original": "beets.fi",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://beets.fi/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0213 through hei_unadded_0218 as one entity to avoid duplicate branding, chain, and version records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000679",
+      "exchange_id": "hei_ex_000371",
+      "event_type": "rebrand",
+      "event_date": null,
+      "title": "Beethoven X / Beets rows consolidated under Beets",
+      "description": "Beets is recorded as the consolidated protocol-level entity for Beethoven X, Beets, and Beets DEX candidate rows.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise rebrand or migration event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001494",
+      "exchange_id": "hei_ex_000371",
+      "event_id": "hei_ev_000679",
+      "source_type": "official_statement",
+      "title": "Beets official website",
+      "url": "https://beets.fi/",
+      "publisher": "Beets",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://beets.fi/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify current Beets identity."
+    },
+    {
+      "id": "hei_src_001495",
+      "exchange_id": "hei_ex_000371",
+      "event_id": "hei_ev_000679",
+      "source_type": "database_reference",
+      "title": "CoinGecko / CoinPaprika references for Beethoven X and Beets",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko / CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0213-0216 referred to Beethoven X and Beets chain rows."
+    },
+    {
+      "id": "hei_src_001496",
+      "exchange_id": "hei_ex_000371",
+      "event_id": "hei_ev_000679",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX references for Beets variants",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0217 and hei_unadded_0218 referred to Beets DEX variants."
+    }
+  ]
+}


### PR DESCRIPTION
Add five DEX/protocol records from the scanned verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000367` Balanced — `records/exchanges/balanced.json`
- `hei_ex_000368` Arbswap — `records/exchanges/arbswap.json`
- `hei_ex_000369` ArthSwap — `records/exchanges/arthswap.json`
- `hei_ex_000370` Beamswap — `records/exchanges/beamswap.json`
- `hei_ex_000371` Beets — `records/exchanges/beets.json`

Consumed rows:
- Balanced: `hei_unadded_0173`, `hei_unadded_0174`
- Arbswap: `hei_unadded_0110`
- ArthSwap: `hei_unadded_0124`, `hei_unadded_0125`
- Beamswap: `hei_unadded_0208`-`hei_unadded_0211`
- Beets: `hei_unadded_0213`-`hei_unadded_0218`

Files added:
- `records/exchanges/balanced.json`
- `records/exchanges/arbswap.json`
- `records/exchanges/arthswap.json`
- `records/exchanges/beamswap.json`
- `records/exchanges/beets.json`
- `docs/backlog/consumed/hei_unadded_0110-0218-dex-batch-3.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate, branding, chain, and version rows are collapsed into one protocol-level entity where appropriate.
- No canonical `data/*.json` files are edited directly.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
