### PR TITLE
Add fourth batch DEX records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0102-0223-dex-batch-4.md
+++ b/docs/backlog/consumed/hei_unadded_0102-0223-dex-batch-4.md
@@ -1,0 +1,93 @@
+# Consumed backlog rows: DEX/exchange batch 4
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five exchange / DEX records under the revised HEI record-addition workflow.
+
+This batch continues the post-scan workflow. Duplicate or closely related candidate rows are collapsed into one entity where appropriate.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000372` | Aquarius | `records/exchanges/aquarius.json` | `hei_unadded_0102`, `hei_unadded_0103` |
+| `hei_ex_000373` | ArcherSwap | `records/exchanges/archerswap.json` | `hei_unadded_0112`, `hei_unadded_0113` |
+| `hei_ex_000374` | Baryon Network | `records/exchanges/baryon-network.json` | `hei_unadded_0190`, `hei_unadded_0191` |
+| `hei_ex_000375` | BeeZee DEX | `records/exchanges/beezee-dex.json` | `hei_unadded_0219` |
+| `hei_ex_000376` | Bequant | `records/exchanges/bequant.json` | `hei_unadded_0223` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` and scan memos before creation:
+
+- `docs/backlog/scans/hei_unadded_0101-0150-scan.md`
+- `docs/backlog/scans/hei_unadded_0151-0200-scan.md`
+
+Rows from `hei_unadded_0201` onward were also inspected from the verified-unadded JSONL source before selecting BeeZee DEX and Bequant.
+
+## Duplicate handling
+
+### Aquarius
+
+Consumed rows:
+
+- `hei_unadded_0102` Aquarius
+- `hei_unadded_0103` Aquarius Stellar
+
+Decision: create one `Aquarius` protocol-level DEX record.
+
+### ArcherSwap
+
+Consumed rows:
+
+- `hei_unadded_0112` ArcherSwap
+- `hei_unadded_0113` Archerswap
+
+Decision: create one `ArcherSwap` protocol-level DEX record.
+
+### Baryon Network
+
+Consumed rows:
+
+- `hei_unadded_0190` Baryon Network
+- `hei_unadded_0191` Baryon Network
+
+Decision: create one `Baryon Network` protocol-level DEX record.
+
+### BeeZee DEX
+
+Consumed row:
+
+- `hei_unadded_0219` BeeZee DEX
+
+Decision: create one `BeeZee DEX` record.
+
+### Bequant
+
+Consumed row:
+
+- `hei_unadded_0223` Bequant
+
+Decision: create one low-confidence CEX seed record. Official domain was not confirmed during this pass and should be improved later.
+
+## Notes
+
+- Beam Swap (`hei_unadded_0206`) was investigated but excluded after tool-side write blocking.
+- Aster remains a future candidate after prior write blocking.
+- Bequant is thinner than the other records in this batch and should be upgraded with official-domain or history evidence later.
+
+## Next action
+
+Continue with remaining research candidates:
+
+- Aster
+- Beam Swap
+- Azbit
+- B2BX
+- ATAIX
+- ATOMARS
+- AtomDax
+- BCEX
+- Beamex / Bean Exchange / other 0201-0250 rows after source review

--- a/records/exchanges/aquarius.json
+++ b/records/exchanges/aquarius.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000372",
+    "slug": "aquarius",
+    "canonical_name": "Aquarius",
+    "aliases": ["Aquarius Stellar", "Aqua", "aqua.network"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Stellar ecosystem",
+    "summary": "Stellar ecosystem liquidity and exchange protocol candidate. HEI treats Aquarius and Aquarius Stellar rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://aqua.network/",
+    "official_domain_original": "aqua.network",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://aqua.network/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0102 and hei_unadded_0103 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000680",
+      "exchange_id": "hei_ex_000372",
+      "event_type": "launched",
+      "event_date": null,
+      "title": "Aquarius recorded as Stellar ecosystem exchange protocol",
+      "description": "Aquarius is recorded as a Stellar ecosystem liquidity and DEX-related protocol, with Aquarius and Aquarius Stellar candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Replace with a precise launch event if stronger primary sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001497",
+      "exchange_id": "hei_ex_000372",
+      "event_id": "hei_ev_000680",
+      "source_type": "official_statement",
+      "title": "Aquarius official website",
+      "url": "https://aqua.network/",
+      "publisher": "Aquarius",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://aqua.network/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Aquarius identity."
+    },
+    {
+      "id": "hei_src_001498",
+      "exchange_id": "hei_ex_000372",
+      "event_id": "hei_ev_000680",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Aquarius",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0102."
+    },
+    {
+      "id": "hei_src_001499",
+      "exchange_id": "hei_ex_000372",
+      "event_id": "hei_ev_000680",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Aquarius Stellar",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0103."
+    }
+  ]
+}

--- a/records/exchanges/archerswap.json
+++ b/records/exchanges/archerswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000373",
+    "slug": "archerswap",
+    "canonical_name": "ArcherSwap",
+    "aliases": ["Archerswap", "ArcherSwap Finance", "exchange.archerswap.finance"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Core ecosystem",
+    "summary": "Decentralized exchange and DeFi protocol candidate with CoinGecko and CoinPaprika source rows. HEI treats ArcherSwap and Archerswap rows as one protocol-level DEX entity.",
+    "official_url_original": "https://exchange.archerswap.finance/",
+    "official_domain_original": "exchange.archerswap.finance",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://exchange.archerswap.finance/",
+    "confidence": "low",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0112 and hei_unadded_0113 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000681",
+      "exchange_id": "hei_ex_000373",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "ArcherSwap recorded as DEX candidate",
+      "description": "ArcherSwap is recorded as a DEX entity, with duplicate ArcherSwap / Archerswap candidate rows consolidated into one HEI record.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001500",
+      "exchange_id": "hei_ex_000373",
+      "event_id": "hei_ev_000681",
+      "source_type": "official_statement",
+      "title": "ArcherSwap official exchange app",
+      "url": "https://exchange.archerswap.finance/",
+      "publisher": "ArcherSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://exchange.archerswap.finance/",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Official exchange app domain from the verified-unadded candidate row."
+    },
+    {
+      "id": "hei_src_001501",
+      "exchange_id": "hei_ex_000373",
+      "event_id": "hei_ev_000681",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for ArcherSwap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0112."
+    },
+    {
+      "id": "hei_src_001502",
+      "exchange_id": "hei_ex_000373",
+      "event_id": "hei_ev_000681",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Archerswap",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0113."
+    }
+  ]
+}

--- a/records/exchanges/baryon-network.json
+++ b/records/exchanges/baryon-network.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000374",
+    "slug": "baryon-network",
+    "canonical_name": "Baryon Network",
+    "aliases": ["Baryon", "baryon.network"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "multi-chain ecosystem",
+    "summary": "Decentralized exchange / DeFi protocol candidate represented by CoinGecko and DefiLlama source rows. HEI treats the Baryon Network rows as one protocol-level DEX entity.",
+    "official_url_original": "https://baryon.network/",
+    "official_domain_original": "baryon.network",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://baryon.network/",
+    "confidence": "low",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0190 and hei_unadded_0191 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000682",
+      "exchange_id": "hei_ex_000374",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Baryon Network recorded as DEX candidate",
+      "description": "Baryon Network is recorded as a DEX/protocol entity, with CoinGecko and DefiLlama candidate rows consolidated into one HEI record.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001503",
+      "exchange_id": "hei_ex_000374",
+      "event_id": "hei_ev_000682",
+      "source_type": "official_statement",
+      "title": "Baryon Network official website",
+      "url": "https://baryon.network/",
+      "publisher": "Baryon Network",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://baryon.network/",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Official domain from verified-unadded candidate rows."
+    },
+    {
+      "id": "hei_src_001504",
+      "exchange_id": "hei_ex_000374",
+      "event_id": "hei_ev_000682",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Baryon Network",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0190."
+    },
+    {
+      "id": "hei_src_001505",
+      "exchange_id": "hei_ex_000374",
+      "event_id": "hei_ev_000682",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Baryon Network",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0191."
+    }
+  ]
+}

--- a/records/exchanges/beezee-dex.json
+++ b/records/exchanges/beezee-dex.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000375",
+    "slug": "beezee-dex",
+    "canonical_name": "BeeZee DEX",
+    "aliases": ["BeeZee", "BZE DEX", "dex.getbze.com"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "BeeZee ecosystem",
+    "summary": "BeeZee ecosystem decentralized exchange candidate with a CoinGecko exchange row and official DEX domain.",
+    "official_url_original": "https://dex.getbze.com/",
+    "official_domain_original": "dex.getbze.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://dex.getbze.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0219."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000683",
+      "exchange_id": "hei_ex_000375",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "BeeZee DEX recorded as DEX candidate",
+      "description": "BeeZee DEX is recorded as a DEX candidate based on its official DEX domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001506",
+      "exchange_id": "hei_ex_000375",
+      "event_id": "hei_ev_000683",
+      "source_type": "official_statement",
+      "title": "BeeZee DEX official website",
+      "url": "https://dex.getbze.com/",
+      "publisher": "BeeZee",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://dex.getbze.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official DEX domain used to verify BeeZee DEX identity."
+    },
+    {
+      "id": "hei_src_001507",
+      "exchange_id": "hei_ex_000375",
+      "event_id": "hei_ev_000683",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BeeZee DEX",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0219."
+    }
+  ]
+}

--- a/records/exchanges/bequant.json
+++ b/records/exchanges/bequant.json
@@ -1,0 +1,55 @@
+{
+  "entity": {
+    "id": "hei_ex_000376",
+    "slug": "bequant",
+    "canonical_name": "Bequant",
+    "aliases": ["BEQUANT", "BeQuant"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized exchange / brokerage candidate from CoinPaprika exchange data. HEI records Bequant as a low-confidence active CEX seed until stronger operating-history or shutdown evidence is added.",
+    "official_url_original": null,
+    "official_domain_original": null,
+    "official_url_status": "unknown",
+    "archived_url": null,
+    "confidence": "low",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0223. Official domain was not confirmed in this pass, so this record should be improved with stronger source evidence later."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000684",
+      "exchange_id": "hei_ex_000376",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bequant present in exchange source data",
+      "description": "Bequant appeared in the verified-unadded candidate pool through CoinPaprika exchange data and is recorded as a low-confidence exchange seed.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "Upgrade with official domain, launch, operating, or closure evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001508",
+      "exchange_id": "hei_ex_000376",
+      "event_id": "hei_ev_000684",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Bequant",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0223."
+    }
+  ]
+}


### PR DESCRIPTION
Add five exchange / DEX records from the scanned verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000372` Aquarius — `records/exchanges/aquarius.json`
- `hei_ex_000373` ArcherSwap — `records/exchanges/archerswap.json`
- `hei_ex_000374` Baryon Network — `records/exchanges/baryon-network.json`
- `hei_ex_000375` BeeZee DEX — `records/exchanges/beezee-dex.json`
- `hei_ex_000376` Bequant — `records/exchanges/bequant.json`

Consumed rows:
- Aquarius: `hei_unadded_0102`, `hei_unadded_0103`
- ArcherSwap: `hei_unadded_0112`, `hei_unadded_0113`
- Baryon Network: `hei_unadded_0190`, `hei_unadded_0191`
- BeeZee DEX: `hei_unadded_0219`
- Bequant: `hei_unadded_0223`

Files added:
- `records/exchanges/aquarius.json`
- `records/exchanges/archerswap.json`
- `records/exchanges/baryon-network.json`
- `records/exchanges/beezee-dex.json`
- `records/exchanges/bequant.json`
- `docs/backlog/consumed/hei_unadded_0102-0223-dex-batch-4.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are collapsed into one entity where appropriate.
- Beam Swap and Aster remain future candidates after tool-side write blocking.
- Bequant is a low-confidence CEX seed that should be upgraded later with stronger source evidence.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
