### PR TITLE
Add fifth batch exchange records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0230-0268-exchange-batch-5.md
+++ b/docs/backlog/consumed/hei_unadded_0230-0268-exchange-batch-5.md
@@ -1,0 +1,87 @@
+# Consumed backlog rows: exchange / DEX batch 5
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five exchange / DEX records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with official domains and duplicate rows that can be consolidated cleanly.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000377` | BEX | `records/exchanges/bex.json` | `hei_unadded_0230`, `hei_unadded_0231` |
+| `hei_ex_000378` | Bifrost Swap | `records/exchanges/bifrost-swap.json` | `hei_unadded_0237`, `hei_unadded_0238` |
+| `hei_ex_000379` | Biswap | `records/exchanges/biswap.json` | `hei_unadded_0258`-`hei_unadded_0260` |
+| `hei_ex_000380` | Bit2C | `records/exchanges/bit2c.json` | `hei_unadded_0265`, `hei_unadded_0266` |
+| `hei_ex_000381` | Bitazza | `records/exchanges/bitazza.json` | `hei_unadded_0268` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### BEX
+
+Consumed rows:
+
+- `hei_unadded_0230` BEX
+- `hei_unadded_0231` BEX
+
+Decision: create one `BEX` Berachain ecosystem DEX record.
+
+### Bifrost Swap
+
+Consumed rows:
+
+- `hei_unadded_0237` Bifrost DEX
+- `hei_unadded_0238` Bifrost Swap
+
+Decision: create one `Bifrost Swap` DEX record.
+
+### Biswap
+
+Consumed rows:
+
+- `hei_unadded_0258` Biswap
+- `hei_unadded_0259` Biswap
+- `hei_unadded_0260` Biswap V2
+
+Decision: create one `Biswap` protocol-level DEX record.
+
+### Bit2C
+
+Consumed rows:
+
+- `hei_unadded_0265` Bit2c
+- `hei_unadded_0266` Bit2C
+
+Decision: create one `Bit2C` centralized exchange record.
+
+### Bitazza
+
+Consumed row:
+
+- `hei_unadded_0268` Bitazza
+
+Decision: create one `Bitazza` centralized exchange record.
+
+## Notes
+
+- This batch intentionally avoids thin rows with no official domain where possible.
+- BEX, Bifrost Swap, Biswap, Bit2C, and Bitazza should be improved later with more precise launch, licensing, rebrand, or operating-history events where available.
+- Binance-related rows in this range should be handled separately because they require more careful grouping and existing-major-exchange scope decisions.
+
+## Next action
+
+Continue with remaining candidates:
+
+- Binance US / Binance derivatives rows, if scope allows and duplicate handling is planned carefully
+- Bilaxy
+- Bitbns
+- bitcastle
+- Bitcointry
+- BCEX / BHEX / Bibox / Bidesk after source review

--- a/records/exchanges/bex.json
+++ b/records/exchanges/bex.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000377",
+    "slug": "bex",
+    "canonical_name": "BEX",
+    "aliases": ["Berachain BEX", "BEX Berachain", "hub.berachain.com"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Berachain ecosystem",
+    "summary": "Berachain ecosystem decentralized exchange candidate represented by CoinGecko and DefiLlama source rows. HEI treats BEX rows as one ecosystem-level DEX entity.",
+    "official_url_original": "https://hub.berachain.com/",
+    "official_domain_original": "hub.berachain.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://hub.berachain.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0230 and hei_unadded_0231 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000685",
+      "exchange_id": "hei_ex_000377",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "BEX recorded as Berachain ecosystem DEX",
+      "description": "BEX is recorded as a Berachain ecosystem DEX candidate with CoinGecko and DefiLlama rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001509",
+      "exchange_id": "hei_ex_000377",
+      "event_id": "hei_ev_000685",
+      "source_type": "official_statement",
+      "title": "Berachain hub official site",
+      "url": "https://hub.berachain.com/",
+      "publisher": "Berachain",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://hub.berachain.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official app domain used to verify BEX identity."
+    },
+    {
+      "id": "hei_src_001510",
+      "exchange_id": "hei_ex_000377",
+      "event_id": "hei_ev_000685",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BEX",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0230."
+    },
+    {
+      "id": "hei_src_001511",
+      "exchange_id": "hei_ex_000377",
+      "event_id": "hei_ev_000685",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for BEX",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0231."
+    }
+  ]
+}

--- a/records/exchanges/bifrost-swap.json
+++ b/records/exchanges/bifrost-swap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000378",
+    "slug": "bifrost-swap",
+    "canonical_name": "Bifrost Swap",
+    "aliases": ["Bifrost DEX", "bifrost.app"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Bifrost ecosystem",
+    "summary": "Bifrost ecosystem DEX candidate represented by CoinGecko and DefiLlama source rows. HEI treats Bifrost Swap and Bifrost DEX rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://bifrost.app/",
+    "official_domain_original": "bifrost.app",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bifrost.app/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0237 and hei_unadded_0238 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000686",
+      "exchange_id": "hei_ex_000378",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bifrost Swap recorded as Bifrost ecosystem DEX",
+      "description": "Bifrost Swap is recorded as a Bifrost ecosystem DEX candidate with CoinGecko and DefiLlama rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001512",
+      "exchange_id": "hei_ex_000378",
+      "event_id": "hei_ev_000686",
+      "source_type": "official_statement",
+      "title": "Bifrost official website",
+      "url": "https://bifrost.app/",
+      "publisher": "Bifrost",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bifrost.app/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bifrost Swap identity."
+    },
+    {
+      "id": "hei_src_001513",
+      "exchange_id": "hei_ex_000378",
+      "event_id": "hei_ev_000686",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bifrost Swap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0238."
+    },
+    {
+      "id": "hei_src_001514",
+      "exchange_id": "hei_ex_000378",
+      "event_id": "hei_ev_000686",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Bifrost DEX",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0237."
+    }
+  ]
+}

--- a/records/exchanges/biswap.json
+++ b/records/exchanges/biswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000379",
+    "slug": "biswap",
+    "canonical_name": "Biswap",
+    "aliases": ["Biswap V2", "biswap.org"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "BNB Chain ecosystem",
+    "summary": "BNB Chain ecosystem decentralized exchange and AMM protocol. HEI treats Biswap and Biswap V2 candidate rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://biswap.org/",
+    "official_domain_original": "biswap.org",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://biswap.org/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0258 through hei_unadded_0260 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000687",
+      "exchange_id": "hei_ex_000379",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Biswap recorded as BNB Chain ecosystem DEX",
+      "description": "Biswap is recorded as a BNB Chain ecosystem AMM/DEX entity, with Biswap and Biswap V2 rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001515",
+      "exchange_id": "hei_ex_000379",
+      "event_id": "hei_ev_000687",
+      "source_type": "official_statement",
+      "title": "Biswap official website",
+      "url": "https://biswap.org/",
+      "publisher": "Biswap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://biswap.org/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Biswap identity."
+    },
+    {
+      "id": "hei_src_001516",
+      "exchange_id": "hei_ex_000379",
+      "event_id": "hei_ev_000687",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Biswap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0259."
+    },
+    {
+      "id": "hei_src_001517",
+      "exchange_id": "hei_ex_000379",
+      "event_id": "hei_ev_000687",
+      "source_type": "database_reference",
+      "title": "CoinPaprika / DefiLlama references for Biswap variants",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika / DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0258 and hei_unadded_0260 referenced Biswap and Biswap V2."
+    }
+  ]
+}

--- a/records/exchanges/bit2c.json
+++ b/records/exchanges/bit2c.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000380",
+    "slug": "bit2c",
+    "canonical_name": "Bit2C",
+    "aliases": ["Bit2c", "bit2c.co.il"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Israel",
+    "summary": "Israel-based centralized crypto exchange candidate represented by CoinGecko and CoinPaprika exchange rows. HEI treats Bit2c and Bit2C rows as one entity.",
+    "official_url_original": "https://www.bit2c.co.il/",
+    "official_domain_original": "bit2c.co.il",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bit2c.co.il/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0265 and hei_unadded_0266 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000688",
+      "exchange_id": "hei_ex_000380",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bit2C recorded as centralized exchange",
+      "description": "Bit2C is recorded as a centralized exchange entity, with CoinGecko and CoinPaprika candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001518",
+      "exchange_id": "hei_ex_000380",
+      "event_id": "hei_ev_000688",
+      "source_type": "official_statement",
+      "title": "Bit2C official website",
+      "url": "https://www.bit2c.co.il/",
+      "publisher": "Bit2C",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bit2c.co.il/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bit2C identity."
+    },
+    {
+      "id": "hei_src_001519",
+      "exchange_id": "hei_ex_000380",
+      "event_id": "hei_ev_000688",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bit2C",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0265."
+    },
+    {
+      "id": "hei_src_001520",
+      "exchange_id": "hei_ex_000380",
+      "event_id": "hei_ev_000688",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Bit2C",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0266."
+    }
+  ]
+}

--- a/records/exchanges/bitazza.json
+++ b/records/exchanges/bitazza.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000381",
+    "slug": "bitazza",
+    "canonical_name": "Bitazza",
+    "aliases": ["trade.bitazza.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Thailand",
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official trading domain. HEI records Bitazza as an active CEX seed record.",
+    "official_url_original": "https://trade.bitazza.com/",
+    "official_domain_original": "trade.bitazza.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://trade.bitazza.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0268. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000689",
+      "exchange_id": "hei_ex_000381",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bitazza recorded as centralized exchange",
+      "description": "Bitazza is recorded as a centralized exchange entity based on its official trading domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001521",
+      "exchange_id": "hei_ex_000381",
+      "event_id": "hei_ev_000689",
+      "source_type": "official_statement",
+      "title": "Bitazza official trading website",
+      "url": "https://trade.bitazza.com/",
+      "publisher": "Bitazza",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://trade.bitazza.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official trading domain used to verify Bitazza identity."
+    },
+    {
+      "id": "hei_src_001522",
+      "exchange_id": "hei_ex_000381",
+      "event_id": "hei_ev_000689",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitazza",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0268."
+    }
+  ]
+}


### PR DESCRIPTION
Add five exchange / DEX records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000377` BEX — `records/exchanges/bex.json`
- `hei_ex_000378` Bifrost Swap — `records/exchanges/bifrost-swap.json`
- `hei_ex_000379` Biswap — `records/exchanges/biswap.json`
- `hei_ex_000380` Bit2C — `records/exchanges/bit2c.json`
- `hei_ex_000381` Bitazza — `records/exchanges/bitazza.json`

Consumed rows:
- BEX: `hei_unadded_0230`, `hei_unadded_0231`
- Bifrost Swap: `hei_unadded_0237`, `hei_unadded_0238`
- Biswap: `hei_unadded_0258`-`hei_unadded_0260`
- Bit2C: `hei_unadded_0265`, `hei_unadded_0266`
- Bitazza: `hei_unadded_0268`

Files added:
- `records/exchanges/bex.json`
- `records/exchanges/bifrost-swap.json`
- `records/exchanges/biswap.json`
- `records/exchanges/bit2c.json`
- `records/exchanges/bitazza.json`
- `docs/backlog/consumed/hei_unadded_0230-0268-exchange-batch-5.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are consolidated into one entity where appropriate.
- Binance-related rows are intentionally left for a later, more careful pass.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
