### PR TITLE
Add sixth batch exchange records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0250-0278-exchange-batch-6.md
+++ b/docs/backlog/consumed/hei_unadded_0250-0278-exchange-batch-6.md
@@ -1,0 +1,89 @@
+# Consumed backlog rows: exchange batch 6
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five centralized exchange records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with official domains and duplicate rows that can be consolidated cleanly. Binance US is handled separately from other Binance derivatives and market-specific rows.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000382` | Bitbaby | `records/exchanges/bitbaby.json` | `hei_unadded_0269` |
+| `hei_ex_000383` | Bitbns | `records/exchanges/bitbns.json` | `hei_unadded_0271`, `hei_unadded_0272` |
+| `hei_ex_000384` | bitcastle | `records/exchanges/bitcastle.json` | `hei_unadded_0274` |
+| `hei_ex_000385` | Bitcointry | `records/exchanges/bitcointry.json` | `hei_unadded_0277`, `hei_unadded_0278` |
+| `hei_ex_000386` | Binance US | `records/exchanges/binance-us.json` | `hei_unadded_0250`, `hei_unadded_0251`, `hei_unadded_0253` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### Bitbaby
+
+Consumed row:
+
+- `hei_unadded_0269` Bitbaby
+
+Decision: create one `Bitbaby` centralized exchange record.
+
+### Bitbns
+
+Consumed rows:
+
+- `hei_unadded_0271` Bitbns
+- `hei_unadded_0272` BitBNS
+
+Decision: create one `Bitbns` centralized exchange record.
+
+### bitcastle
+
+Consumed row:
+
+- `hei_unadded_0274` bitcastle
+
+Decision: create one `bitcastle` centralized exchange record.
+
+### Bitcointry
+
+Consumed rows:
+
+- `hei_unadded_0277` Bitcointry
+- `hei_unadded_0278` Bitcointry Exchange
+
+Decision: create one `Bitcointry` centralized exchange record.
+
+### Binance US
+
+Consumed rows:
+
+- `hei_unadded_0250` Binance US
+- `hei_unadded_0251` Binance US
+- `hei_unadded_0253` binanceus
+
+Decision: create one `Binance US` centralized exchange record. Other Binance market-specific or derivatives rows are intentionally left for a later scope pass.
+
+## Notes
+
+- This batch intentionally avoids merging Binance US with Binance DEX, Binance Futures, Binance JEX, or CCXT market-specific derivatives rows.
+- Records in this batch should be improved later with stronger launch, licensing, regulatory, or operating-history evidence where available.
+- Rows with no official domain or unclear identity remain unconsumed.
+
+## Next action
+
+Continue with remaining candidates:
+
+- Bilaxy
+- BCEX
+- BHEX
+- Bibox
+- Bidesk
+- BitcoinVN
+- BITCOIVA
+- Bit.com Futures / Bit.com Spot
+- Binance DEX / Binance Futures / Binance JEX rows as a separate careful grouping task

--- a/records/exchanges/binance-us.json
+++ b/records/exchanges/binance-us.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000386",
+    "slug": "binance-us",
+    "canonical_name": "Binance US",
+    "aliases": ["Binance.US", "binance.us", "binanceus"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "United States",
+    "summary": "United States crypto exchange entity associated with the Binance brand. HEI records Binance US as a separate entity from other Binance derivatives or CCXT market-specific rows.",
+    "official_url_original": "https://www.binance.us/",
+    "official_domain_original": "binance.us",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.binance.us/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0250, hei_unadded_0251, and hei_unadded_0253 as one Binance US entity. Other Binance derivatives rows are intentionally left for later careful grouping."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000694",
+      "exchange_id": "hei_ex_000386",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Binance US recorded as separate US exchange entity",
+      "description": "Binance US is recorded as a separate US exchange entity, consolidating Binance US / Binance.US / binanceus source rows without merging other Binance derivatives rows.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with launch, regulatory, or operating-history events if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001533",
+      "exchange_id": "hei_ex_000386",
+      "event_id": "hei_ev_000694",
+      "source_type": "official_statement",
+      "title": "Binance US official website",
+      "url": "https://www.binance.us/",
+      "publisher": "Binance US",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.binance.us/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Binance US identity."
+    },
+    {
+      "id": "hei_src_001534",
+      "exchange_id": "hei_ex_000386",
+      "event_id": "hei_ev_000694",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Binance US",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0251."
+    },
+    {
+      "id": "hei_src_001535",
+      "exchange_id": "hei_ex_000386",
+      "event_id": "hei_ev_000694",
+      "source_type": "database_reference",
+      "title": "CoinPaprika / CCXT references for Binance US naming variants",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika / CCXT",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0250 and hei_unadded_0253 refer to Binance US naming variants."
+    }
+  ]
+}

--- a/records/exchanges/bitbaby.json
+++ b/records/exchanges/bitbaby.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000382",
+    "slug": "bitbaby",
+    "canonical_name": "Bitbaby",
+    "aliases": ["Bitbaby Exchange", "bitbaby.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records Bitbaby as an active CEX seed record.",
+    "official_url_original": "https://bitbaby.com/",
+    "official_domain_original": "bitbaby.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitbaby.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0269. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000690",
+      "exchange_id": "hei_ex_000382",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bitbaby recorded as centralized exchange",
+      "description": "Bitbaby is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001523",
+      "exchange_id": "hei_ex_000382",
+      "event_id": "hei_ev_000690",
+      "source_type": "official_statement",
+      "title": "Bitbaby official website",
+      "url": "https://bitbaby.com/",
+      "publisher": "Bitbaby",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitbaby.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bitbaby identity."
+    },
+    {
+      "id": "hei_src_001524",
+      "exchange_id": "hei_ex_000382",
+      "event_id": "hei_ev_000690",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitbaby",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0269."
+    }
+  ]
+}

--- a/records/exchanges/bitbns.json
+++ b/records/exchanges/bitbns.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000383",
+    "slug": "bitbns",
+    "canonical_name": "Bitbns",
+    "aliases": ["BitBNS", "bitbns.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "India",
+    "summary": "India-based centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats Bitbns and BitBNS rows as one entity.",
+    "official_url_original": "https://bitbns.com/",
+    "official_domain_original": "bitbns.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitbns.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0271 and hei_unadded_0272 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000691",
+      "exchange_id": "hei_ex_000383",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bitbns recorded as centralized exchange",
+      "description": "Bitbns is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, incident, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001525",
+      "exchange_id": "hei_ex_000383",
+      "event_id": "hei_ev_000691",
+      "source_type": "official_statement",
+      "title": "Bitbns official website",
+      "url": "https://bitbns.com/",
+      "publisher": "Bitbns",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitbns.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bitbns identity."
+    },
+    {
+      "id": "hei_src_001526",
+      "exchange_id": "hei_ex_000383",
+      "event_id": "hei_ev_000691",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Bitbns",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0271."
+    },
+    {
+      "id": "hei_src_001527",
+      "exchange_id": "hei_ex_000383",
+      "event_id": "hei_ev_000691",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitBNS",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0272."
+    }
+  ]
+}

--- a/records/exchanges/bitcastle.json
+++ b/records/exchanges/bitcastle.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000384",
+    "slug": "bitcastle",
+    "canonical_name": "bitcastle",
+    "aliases": ["Bitcastle", "bitcastle.io"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records bitcastle as an active CEX seed record.",
+    "official_url_original": "https://bitcastle.io/",
+    "official_domain_original": "bitcastle.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitcastle.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0274. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000692",
+      "exchange_id": "hei_ex_000384",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "bitcastle recorded as centralized exchange",
+      "description": "bitcastle is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001528",
+      "exchange_id": "hei_ex_000384",
+      "event_id": "hei_ev_000692",
+      "source_type": "official_statement",
+      "title": "bitcastle official website",
+      "url": "https://bitcastle.io/",
+      "publisher": "bitcastle",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitcastle.io/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify bitcastle identity."
+    },
+    {
+      "id": "hei_src_001529",
+      "exchange_id": "hei_ex_000384",
+      "event_id": "hei_ev_000692",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for bitcastle",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0274."
+    }
+  ]
+}

--- a/records/exchanges/bitcointry.json
+++ b/records/exchanges/bitcointry.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000385",
+    "slug": "bitcointry",
+    "canonical_name": "Bitcointry",
+    "aliases": ["Bitcointry Exchange", "bitcointry.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats Bitcointry and Bitcointry Exchange rows as one entity.",
+    "official_url_original": "https://bitcointry.com/",
+    "official_domain_original": "bitcointry.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitcointry.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0277 and hei_unadded_0278 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000693",
+      "exchange_id": "hei_ex_000385",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bitcointry recorded as centralized exchange",
+      "description": "Bitcointry is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001530",
+      "exchange_id": "hei_ex_000385",
+      "event_id": "hei_ev_000693",
+      "source_type": "official_statement",
+      "title": "Bitcointry official website",
+      "url": "https://bitcointry.com/",
+      "publisher": "Bitcointry",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitcointry.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bitcointry identity."
+    },
+    {
+      "id": "hei_src_001531",
+      "exchange_id": "hei_ex_000385",
+      "event_id": "hei_ev_000693",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Bitcointry",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0277."
+    },
+    {
+      "id": "hei_src_001532",
+      "exchange_id": "hei_ex_000385",
+      "event_id": "hei_ev_000693",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitcointry Exchange",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0278."
+    }
+  ]
+}


### PR DESCRIPTION
Add five centralized exchange records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000382` Bitbaby — `records/exchanges/bitbaby.json`
- `hei_ex_000383` Bitbns — `records/exchanges/bitbns.json`
- `hei_ex_000384` bitcastle — `records/exchanges/bitcastle.json`
- `hei_ex_000385` Bitcointry — `records/exchanges/bitcointry.json`
- `hei_ex_000386` Binance US — `records/exchanges/binance-us.json`

Consumed rows:
- Bitbaby: `hei_unadded_0269`
- Bitbns: `hei_unadded_0271`, `hei_unadded_0272`
- bitcastle: `hei_unadded_0274`
- Bitcointry: `hei_unadded_0277`, `hei_unadded_0278`
- Binance US: `hei_unadded_0250`, `hei_unadded_0251`, `hei_unadded_0253`

Files added:
- `records/exchanges/bitbaby.json`
- `records/exchanges/bitbns.json`
- `records/exchanges/bitcastle.json`
- `records/exchanges/bitcointry.json`
- `records/exchanges/binance-us.json`
- `docs/backlog/consumed/hei_unadded_0250-0278-exchange-batch-6.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are consolidated into one entity where appropriate.
- Binance US is kept separate from Binance DEX, Binance Futures, Binance JEX, and market-specific derivatives rows.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
