### PR TITLE
Add seventh batch exchange records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0283-0307-exchange-batch-7.md
+++ b/docs/backlog/consumed/hei_unadded_0283-0307-exchange-batch-7.md
@@ -1,0 +1,86 @@
+# Consumed backlog rows: exchange / DEX batch 7
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five exchange / DEX records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with official domains and duplicate rows that can be consolidated cleanly.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000387` | BitDelta | `records/exchanges/bitdelta.json` | `hei_unadded_0283` |
+| `hei_ex_000388` | Bitexlive | `records/exchanges/bitexlive.json` | `hei_unadded_0290`, `hei_unadded_0291` |
+| `hei_ex_000389` | Bitflow | `records/exchanges/bitflow.json` | `hei_unadded_0296`, `hei_unadded_0297` |
+| `hei_ex_000390` | BitGenie | `records/exchanges/bitgenie.json` | `hei_unadded_0299`, `hei_unadded_0300` |
+| `hei_ex_000391` | BitKan | `records/exchanges/bitkan.json` | `hei_unadded_0307` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### BitDelta
+
+Consumed row:
+
+- `hei_unadded_0283` BitDelta
+
+Decision: create one `BitDelta` centralized exchange record.
+
+### Bitexlive
+
+Consumed rows:
+
+- `hei_unadded_0290` Bitexlive
+- `hei_unadded_0291` Bitexlive
+
+Decision: create one `Bitexlive` centralized exchange record.
+
+### Bitflow
+
+Consumed rows:
+
+- `hei_unadded_0296` Bitflow
+- `hei_unadded_0297` Bitflow
+
+Decision: create one `Bitflow` protocol-level DEX record.
+
+### BitGenie
+
+Consumed rows:
+
+- `hei_unadded_0299` BitGenie
+- `hei_unadded_0300` BitGenie AMM
+
+Decision: create one `BitGenie` protocol-level DEX record.
+
+### BitKan
+
+Consumed row:
+
+- `hei_unadded_0307` BitKan
+
+Decision: create one `BitKan` centralized exchange record.
+
+## Notes
+
+- This batch intentionally avoids thin rows with no official domain where possible.
+- Records in this batch should be improved later with stronger launch, licensing, regulatory, rebrand, or operating-history evidence where available.
+- Rows with no official domain or unclear identity remain unconsumed.
+
+## Next action
+
+Continue with remaining candidates:
+
+- BITCOIVA
+- BitGlobal
+- Bithumb Singapore
+- Bitinka
+- BitMEX / BitMEX derivatives rows if not already present
+- BitMart / BitMart Futures if not already present
+- Bitrue / Bitrue Futures if not already present

--- a/records/exchanges/bitdelta.json
+++ b/records/exchanges/bitdelta.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000387",
+    "slug": "bitdelta",
+    "canonical_name": "BitDelta",
+    "aliases": ["bitdelta.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records BitDelta as an active CEX seed record.",
+    "official_url_original": "https://bitdelta.com/",
+    "official_domain_original": "bitdelta.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitdelta.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0283. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000695",
+      "exchange_id": "hei_ex_000387",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "BitDelta recorded as centralized exchange",
+      "description": "BitDelta is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001536",
+      "exchange_id": "hei_ex_000387",
+      "event_id": "hei_ev_000695",
+      "source_type": "official_statement",
+      "title": "BitDelta official website",
+      "url": "https://bitdelta.com/",
+      "publisher": "BitDelta",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitdelta.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BitDelta identity."
+    },
+    {
+      "id": "hei_src_001537",
+      "exchange_id": "hei_ex_000387",
+      "event_id": "hei_ev_000695",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitDelta",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0283."
+    }
+  ]
+}

--- a/records/exchanges/bitexlive.json
+++ b/records/exchanges/bitexlive.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000388",
+    "slug": "bitexlive",
+    "canonical_name": "Bitexlive",
+    "aliases": ["bitexlive.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats Bitexlive duplicate rows as one entity.",
+    "official_url_original": "https://bitexlive.com/",
+    "official_domain_original": "bitexlive.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitexlive.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0290 and hei_unadded_0291 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000696",
+      "exchange_id": "hei_ex_000388",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bitexlive recorded as centralized exchange",
+      "description": "Bitexlive is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001538",
+      "exchange_id": "hei_ex_000388",
+      "event_id": "hei_ev_000696",
+      "source_type": "official_statement",
+      "title": "Bitexlive official website",
+      "url": "https://bitexlive.com/",
+      "publisher": "Bitexlive",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitexlive.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bitexlive identity."
+    },
+    {
+      "id": "hei_src_001539",
+      "exchange_id": "hei_ex_000388",
+      "event_id": "hei_ev_000696",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Bitexlive",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0290."
+    },
+    {
+      "id": "hei_src_001540",
+      "exchange_id": "hei_ex_000388",
+      "event_id": "hei_ev_000696",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitexlive",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0291."
+    }
+  ]
+}

--- a/records/exchanges/bitflow.json
+++ b/records/exchanges/bitflow.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000389",
+    "slug": "bitflow",
+    "canonical_name": "Bitflow",
+    "aliases": ["Bitflow Finance", "bitflow.finance"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Stacks ecosystem",
+    "summary": "Stacks ecosystem decentralized exchange candidate represented by CoinGecko and DefiLlama source rows. HEI treats Bitflow rows as one protocol-level DEX entity.",
+    "official_url_original": "https://bitflow.finance/",
+    "official_domain_original": "bitflow.finance",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitflow.finance/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0296 and hei_unadded_0297 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000697",
+      "exchange_id": "hei_ex_000389",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "Bitflow recorded as Stacks ecosystem DEX",
+      "description": "Bitflow is recorded as a Stacks ecosystem DEX entity, with CoinGecko and DefiLlama candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001541",
+      "exchange_id": "hei_ex_000389",
+      "event_id": "hei_ev_000697",
+      "source_type": "official_statement",
+      "title": "Bitflow official website",
+      "url": "https://bitflow.finance/",
+      "publisher": "Bitflow",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitflow.finance/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bitflow identity."
+    },
+    {
+      "id": "hei_src_001542",
+      "exchange_id": "hei_ex_000389",
+      "event_id": "hei_ev_000697",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitflow",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0296."
+    },
+    {
+      "id": "hei_src_001543",
+      "exchange_id": "hei_ex_000389",
+      "event_id": "hei_ev_000697",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Bitflow",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0297."
+    }
+  ]
+}

--- a/records/exchanges/bitgenie.json
+++ b/records/exchanges/bitgenie.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000390",
+    "slug": "bitgenie",
+    "canonical_name": "BitGenie",
+    "aliases": ["BitGenie AMM", "BitGenie Merlin Chain", "bitgenie.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Merlin ecosystem",
+    "summary": "Merlin ecosystem DEX/AMM candidate represented by CoinGecko and DefiLlama source rows. HEI treats BitGenie and BitGenie AMM rows as one protocol-level DEX entity.",
+    "official_url_original": "https://bitgenie.io/",
+    "official_domain_original": "bitgenie.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitgenie.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded rows hei_unadded_0299 and hei_unadded_0300 as one entity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000698",
+      "exchange_id": "hei_ex_000390",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "BitGenie recorded as Merlin ecosystem DEX",
+      "description": "BitGenie is recorded as a Merlin ecosystem DEX/AMM entity, with CoinGecko and DefiLlama candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001544",
+      "exchange_id": "hei_ex_000390",
+      "event_id": "hei_ev_000698",
+      "source_type": "official_statement",
+      "title": "BitGenie official website",
+      "url": "https://bitgenie.io/",
+      "publisher": "BitGenie",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitgenie.io/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BitGenie identity."
+    },
+    {
+      "id": "hei_src_001545",
+      "exchange_id": "hei_ex_000390",
+      "event_id": "hei_ev_000698",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitGenie",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0299."
+    },
+    {
+      "id": "hei_src_001546",
+      "exchange_id": "hei_ex_000390",
+      "event_id": "hei_ev_000698",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for BitGenie AMM",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0300."
+    }
+  ]
+}

--- a/records/exchanges/bitkan.json
+++ b/records/exchanges/bitkan.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000391",
+    "slug": "bitkan",
+    "canonical_name": "BitKan",
+    "aliases": ["bitkan.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records BitKan as an active CEX seed record.",
+    "official_url_original": "https://bitkan.com/",
+    "official_domain_original": "bitkan.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitkan.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-01",
+    "notes": "Added from verified-unadded row hei_unadded_0307. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000699",
+      "exchange_id": "hei_ex_000391",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-01",
+      "title": "BitKan recorded as centralized exchange",
+      "description": "BitKan is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001547",
+      "exchange_id": "hei_ex_000391",
+      "event_id": "hei_ev_000699",
+      "source_type": "official_statement",
+      "title": "BitKan official website",
+      "url": "https://bitkan.com/",
+      "publisher": "BitKan",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitkan.com/",
+      "accessed_at": "2026-06-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BitKan identity."
+    },
+    {
+      "id": "hei_src_001548",
+      "exchange_id": "hei_ex_000391",
+      "event_id": "hei_ev_000699",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitKan",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-01",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0307."
+    }
+  ]
+}


### PR DESCRIPTION
Add five exchange / DEX records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000387` BitDelta — `records/exchanges/bitdelta.json`
- `hei_ex_000388` Bitexlive — `records/exchanges/bitexlive.json`
- `hei_ex_000389` Bitflow — `records/exchanges/bitflow.json`
- `hei_ex_000390` BitGenie — `records/exchanges/bitgenie.json`
- `hei_ex_000391` BitKan — `records/exchanges/bitkan.json`

Consumed rows:
- BitDelta: `hei_unadded_0283`
- Bitexlive: `hei_unadded_0290`, `hei_unadded_0291`
- Bitflow: `hei_unadded_0296`, `hei_unadded_0297`
- BitGenie: `hei_unadded_0299`, `hei_unadded_0300`
- BitKan: `hei_unadded_0307`

Files added:
- `records/exchanges/bitdelta.json`
- `records/exchanges/bitexlive.json`
- `records/exchanges/bitflow.json`
- `records/exchanges/bitgenie.json`
- `records/exchanges/bitkan.json`
- `docs/backlog/consumed/hei_unadded_0283-0307-exchange-batch-7.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are consolidated into one entity where appropriate.
- Rows with no official domain or unclear identity are left unconsumed.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
