### PR TITLE
Add eighth batch exchange records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0310-0336-exchange-batch-8.md
+++ b/docs/backlog/consumed/hei_unadded_0310-0336-exchange-batch-8.md
@@ -1,0 +1,88 @@
+# Consumed backlog rows: exchange batch 8
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five centralized exchange records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with official domains and duplicate rows that can be consolidated cleanly.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000392` | Bitlo | `records/exchanges/bitlo.json` | `hei_unadded_0310` |
+| `hei_ex_000393` | BitMart | `records/exchanges/bitmart.json` | `hei_unadded_0311`, `hei_unadded_0312` |
+| `hei_ex_000394` | BitStorage | `records/exchanges/bitstorage.json` | `hei_unadded_0329`, `hei_unadded_0330` |
+| `hei_ex_000395` | Bittime | `records/exchanges/bittime.json` | `hei_unadded_0334` |
+| `hei_ex_000396` | BitTrade | `records/exchanges/bittrade.json` | `hei_unadded_0335`, `hei_unadded_0336` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### Bitlo
+
+Consumed row:
+
+- `hei_unadded_0310` Bitlo
+
+Decision: create one `Bitlo` centralized exchange record.
+
+### BitMart
+
+Consumed rows:
+
+- `hei_unadded_0311` BitMart
+- `hei_unadded_0312` BitMart
+
+Decision: create one `BitMart` centralized exchange record.
+
+Public-site check before this PR showed `bitmar` matched `BitMarket` and `BitMarket.eu`, not `BitMart`, so this was not treated as an existing public duplicate.
+
+### BitStorage
+
+Consumed rows:
+
+- `hei_unadded_0329` BitStorage
+- `hei_unadded_0330` BitStorage
+
+Decision: create one `BitStorage` centralized exchange record.
+
+### Bittime
+
+Consumed row:
+
+- `hei_unadded_0334` Bittime
+
+Decision: create one `Bittime` centralized exchange record.
+
+### BitTrade
+
+Consumed rows:
+
+- `hei_unadded_0335` bittrade
+- `hei_unadded_0336` BitTrade / Huobi Japan
+
+Decision: create one `BitTrade` centralized exchange record and treat the Huobi Japan source row as an alias/context row for v0.
+
+## Notes
+
+- Bittrex is intentionally not included in this batch because it has major closure/bankruptcy/regulatory history and should be handled as a thicker standalone or carefully researched record.
+- Records in this batch should be improved later with stronger launch, licensing, regulatory, rebrand, hack, shutdown, or operating-history evidence where available.
+- Rows with no official domain or unclear identity remain unconsumed.
+
+## Next action
+
+Continue with remaining candidates:
+
+- Bittrex as a thicker event-backed record
+- BitGlobal
+- Bithumb Singapore
+- Bitinka
+- BitMEX / BitMEX derivatives rows if not already present
+- BitMart Futures if scoped separately
+- Bitrue / Bitrue Futures

--- a/records/exchanges/bitlo.json
+++ b/records/exchanges/bitlo.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000392",
+    "slug": "bitlo",
+    "canonical_name": "Bitlo",
+    "aliases": ["bitlo.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Turkey",
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records Bitlo as an active CEX seed record.",
+    "official_url_original": "https://www.bitlo.com/",
+    "official_domain_original": "bitlo.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bitlo.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded row hei_unadded_0310. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000700",
+      "exchange_id": "hei_ex_000392",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "Bitlo recorded as centralized exchange",
+      "description": "Bitlo is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001549",
+      "exchange_id": "hei_ex_000392",
+      "event_id": "hei_ev_000700",
+      "source_type": "official_statement",
+      "title": "Bitlo official website",
+      "url": "https://www.bitlo.com/",
+      "publisher": "Bitlo",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bitlo.com/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bitlo identity."
+    },
+    {
+      "id": "hei_src_001550",
+      "exchange_id": "hei_ex_000392",
+      "event_id": "hei_ev_000700",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitlo",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0310."
+    }
+  ]
+}

--- a/records/exchanges/bitmart.json
+++ b/records/exchanges/bitmart.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000393",
+    "slug": "bitmart",
+    "canonical_name": "BitMart",
+    "aliases": ["bitmart.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange represented by CoinPaprika and CoinGecko source rows. HEI treats BitMart duplicate rows as one entity.",
+    "official_url_original": "https://www.bitmart.com/",
+    "official_domain_original": "bitmart.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bitmart.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded rows hei_unadded_0311 and hei_unadded_0312 as one entity. This record should be improved later with incident, launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000701",
+      "exchange_id": "hei_ex_000393",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "BitMart recorded as centralized exchange",
+      "description": "BitMart is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, hack, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001551",
+      "exchange_id": "hei_ex_000393",
+      "event_id": "hei_ev_000701",
+      "source_type": "official_statement",
+      "title": "BitMart official website",
+      "url": "https://www.bitmart.com/",
+      "publisher": "BitMart",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bitmart.com/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BitMart identity."
+    },
+    {
+      "id": "hei_src_001552",
+      "exchange_id": "hei_ex_000393",
+      "event_id": "hei_ev_000701",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for BitMart",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0311."
+    },
+    {
+      "id": "hei_src_001553",
+      "exchange_id": "hei_ex_000393",
+      "event_id": "hei_ev_000701",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitMart",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0312."
+    }
+  ]
+}

--- a/records/exchanges/bitstorage.json
+++ b/records/exchanges/bitstorage.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000394",
+    "slug": "bitstorage",
+    "canonical_name": "BitStorage",
+    "aliases": ["bitstorage.finance"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats BitStorage duplicate rows as one entity.",
+    "official_url_original": "https://bitstorage.finance/",
+    "official_domain_original": "bitstorage.finance",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bitstorage.finance/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded rows hei_unadded_0329 and hei_unadded_0330 as one entity. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000702",
+      "exchange_id": "hei_ex_000394",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "BitStorage recorded as centralized exchange",
+      "description": "BitStorage is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001554",
+      "exchange_id": "hei_ex_000394",
+      "event_id": "hei_ev_000702",
+      "source_type": "official_statement",
+      "title": "BitStorage official website",
+      "url": "https://bitstorage.finance/",
+      "publisher": "BitStorage",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitstorage.finance/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BitStorage identity."
+    },
+    {
+      "id": "hei_src_001555",
+      "exchange_id": "hei_ex_000394",
+      "event_id": "hei_ev_000702",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for BitStorage",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0329."
+    },
+    {
+      "id": "hei_src_001556",
+      "exchange_id": "hei_ex_000394",
+      "event_id": "hei_ev_000702",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitStorage",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0330."
+    }
+  ]
+}

--- a/records/exchanges/bittime.json
+++ b/records/exchanges/bittime.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000395",
+    "slug": "bittime",
+    "canonical_name": "Bittime",
+    "aliases": ["bittime.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Indonesia",
+    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records Bittime as an active CEX seed record.",
+    "official_url_original": "https://www.bittime.com/",
+    "official_domain_original": "bittime.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bittime.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded row hei_unadded_0334. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000703",
+      "exchange_id": "hei_ex_000395",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "Bittime recorded as centralized exchange",
+      "description": "Bittime is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001557",
+      "exchange_id": "hei_ex_000395",
+      "event_id": "hei_ev_000703",
+      "source_type": "official_statement",
+      "title": "Bittime official website",
+      "url": "https://www.bittime.com/",
+      "publisher": "Bittime",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bittime.com/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bittime identity."
+    },
+    {
+      "id": "hei_src_001558",
+      "exchange_id": "hei_ex_000395",
+      "event_id": "hei_ev_000703",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bittime",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0334."
+    }
+  ]
+}

--- a/records/exchanges/bittrade.json
+++ b/records/exchanges/bittrade.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000396",
+    "slug": "bittrade",
+    "canonical_name": "BitTrade",
+    "aliases": ["Huobi Japan", "bittrade.co.jp", "bittrade"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Japan",
+    "summary": "Japan-based centralized crypto exchange candidate represented by CCXT and CoinGecko source rows. HEI treats bittrade / Huobi Japan / BitTrade rows as one entity for v0.",
+    "official_url_original": "https://www.bittrade.co.jp/",
+    "official_domain_original": "bittrade.co.jp",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bittrade.co.jp/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded rows hei_unadded_0335 and hei_unadded_0336 as one entity. This record should be improved later with stronger rebrand, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000704",
+      "exchange_id": "hei_ex_000396",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "BitTrade recorded as centralized exchange",
+      "description": "BitTrade is recorded as a Japan-based centralized exchange entity, with bittrade and Huobi Japan candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with a precise rebrand, licensing, or operating-history event if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001559",
+      "exchange_id": "hei_ex_000396",
+      "event_id": "hei_ev_000704",
+      "source_type": "official_statement",
+      "title": "BitTrade official website",
+      "url": "https://www.bittrade.co.jp/",
+      "publisher": "BitTrade",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bittrade.co.jp/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BitTrade identity."
+    },
+    {
+      "id": "hei_src_001560",
+      "exchange_id": "hei_ex_000396",
+      "event_id": "hei_ev_000704",
+      "source_type": "database_reference",
+      "title": "CCXT reference for bittrade",
+      "url": "https://raw.githubusercontent.com/ccxt/ccxt/master/js/ccxt.js",
+      "publisher": "CCXT",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://raw.githubusercontent.com/ccxt/ccxt/master/js/ccxt.js",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0335."
+    },
+    {
+      "id": "hei_src_001561",
+      "exchange_id": "hei_ex_000396",
+      "event_id": "hei_ev_000704",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BitTrade / Huobi Japan",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0336."
+    }
+  ]
+}


### PR DESCRIPTION
Add five centralized exchange records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000392` Bitlo — `records/exchanges/bitlo.json`
- `hei_ex_000393` BitMart — `records/exchanges/bitmart.json`
- `hei_ex_000394` BitStorage — `records/exchanges/bitstorage.json`
- `hei_ex_000395` Bittime — `records/exchanges/bittime.json`
- `hei_ex_000396` BitTrade — `records/exchanges/bittrade.json`

Consumed rows:
- Bitlo: `hei_unadded_0310`
- BitMart: `hei_unadded_0311`, `hei_unadded_0312`
- BitStorage: `hei_unadded_0329`, `hei_unadded_0330`
- Bittime: `hei_unadded_0334`
- BitTrade: `hei_unadded_0335`, `hei_unadded_0336`

Files added:
- `records/exchanges/bitlo.json`
- `records/exchanges/bitmart.json`
- `records/exchanges/bitstorage.json`
- `records/exchanges/bittime.json`
- `records/exchanges/bittrade.json`
- `docs/backlog/consumed/hei_unadded_0310-0336-exchange-batch-8.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are consolidated into one entity where appropriate.
- Public-site check before this PR showed `bitmar` matched `BitMarket` and `BitMarket.eu`, not `BitMart`.
- Bittrex is intentionally left for a separate, thicker event-backed record.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
