### PR TITLE
Add ninth batch DEX records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0343-0357-dex-batch-9.md
+++ b/docs/backlog/consumed/hei_unadded_0343-0357-dex-batch-9.md
@@ -1,0 +1,87 @@
+# Consumed backlog rows: DEX / exchange batch 9
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five DEX/exchange-like records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with domain references and rows that can be consolidated cleanly by protocol/version.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000398` | Bitzy | `records/exchanges/bitzy.json` | `hei_unadded_0343` |
+| `hei_ex_000399` | Blackhole | `records/exchanges/blackhole.json` | `hei_unadded_0347`-`hei_unadded_0350` |
+| `hei_ex_000400` | BladeSwap | `records/exchanges/bladeswap.json` | `hei_unadded_0351`-`hei_unadded_0353` |
+| `hei_ex_000401` | BlasterSwap | `records/exchanges/blasterswap.json` | `hei_unadded_0354`-`hei_unadded_0356` |
+| `hei_ex_000402` | BlazeSwap (Flare) | `records/exchanges/blazeswap-flare.json` | `hei_unadded_0357` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### Bitzy
+
+Consumed row:
+
+- `hei_unadded_0343` Bitzy
+
+Decision: create one low-confidence exchange-like seed record.
+
+### Blackhole
+
+Consumed rows:
+
+- `hei_unadded_0347` Blackhole AMM
+- `hei_unadded_0348` Blackhole CLMM
+- `hei_unadded_0349` Blackhole V3
+- `hei_unadded_0350` Blackhole V3
+
+Decision: create one `Blackhole` protocol-level DEX record and treat AMM, CLMM, and V3 rows as variant/context rows for v0.
+
+### BladeSwap
+
+Consumed rows:
+
+- `hei_unadded_0351` BladeSwap
+- `hei_unadded_0352` BladeSwap AMM
+- `hei_unadded_0353` BladeSwap CL
+
+Decision: create one `BladeSwap` protocol-level DEX record and treat AMM/CL rows as variants.
+
+### BlasterSwap
+
+Consumed rows:
+
+- `hei_unadded_0354` BlasterSwap
+- `hei_unadded_0355` Blasterswap V2
+- `hei_unadded_0356` Blasterswap V3
+
+Decision: create one `BlasterSwap` protocol-level DEX record and treat V2/V3 rows as variants.
+
+### BlazeSwap (Flare)
+
+Consumed row:
+
+- `hei_unadded_0357` BlazeSwap (Flare)
+
+Decision: create one Flare ecosystem DEX record. Chain-specific naming is kept because the source row is explicitly chain-specific.
+
+## Notes
+
+- This batch intentionally avoids rows with no official domain or unclear identity.
+- Bitzy is lower confidence than the DEX protocol records and should be upgraded later with stronger official/operating evidence.
+- Records in this batch should be improved later with stronger launch, migration, rebrand, shutdown, or operating-history evidence where available.
+
+## Next action
+
+Continue with remaining candidates:
+
+- Blockchain.com / blockchaincom rows as a careful CEX/entity grouping
+- BL3P / Bittylicious if official-domain evidence is found
+- BLEX / derivatives rows if scope allows
+- BlueMove / Bluefin / other next-range protocol rows after source review

--- a/records/exchanges/bitzy.json
+++ b/records/exchanges/bitzy.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000398",
+    "slug": "bitzy",
+    "canonical_name": "Bitzy",
+    "aliases": ["bitzy.app"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Exchange-like crypto trading candidate with CoinGecko source data and a domain reference. HEI records Bitzy as an active exchange seed record pending stronger operating-history evidence.",
+    "official_url_original": "https://bitzy.app/",
+    "official_domain_original": "bitzy.app",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://bitzy.app/",
+    "confidence": "low",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded row hei_unadded_0343. This is a seed record and should be improved later with stronger official, launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000708",
+      "exchange_id": "hei_ex_000398",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "Bitzy recorded as exchange-like candidate",
+      "description": "Bitzy is recorded as an exchange-like entity based on its CoinGecko exchange source row and domain reference.",
+      "confidence": "low",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, licensing, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001567",
+      "exchange_id": "hei_ex_000398",
+      "event_id": "hei_ev_000708",
+      "source_type": "official_statement",
+      "title": "Bitzy domain reference",
+      "url": "https://bitzy.app/",
+      "publisher": "Bitzy",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bitzy.app/",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Domain reference from the verified-unadded candidate row."
+    },
+    {
+      "id": "hei_src_001568",
+      "exchange_id": "hei_ex_000398",
+      "event_id": "hei_ev_000708",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bitzy",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0343."
+    }
+  ]
+}

--- a/records/exchanges/blackhole.json
+++ b/records/exchanges/blackhole.json
@@ -1,0 +1,100 @@
+{
+  "entity": {
+    "id": "hei_ex_000399",
+    "slug": "blackhole",
+    "canonical_name": "Blackhole",
+    "aliases": ["Blackhole V3", "Blackhole AMM", "Blackhole CLMM", "blackhole.xyz"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Avalanche ecosystem",
+    "summary": "Avalanche ecosystem DEX/protocol candidate represented by CoinGecko, CoinPaprika, and DefiLlama rows. HEI treats Blackhole AMM, CLMM, and V3 rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://blackhole.xyz/",
+    "official_domain_original": "blackhole.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://blackhole.xyz/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded rows hei_unadded_0347 through hei_unadded_0350 as one entity to avoid AMM/CLMM/V3 duplication."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000709",
+      "exchange_id": "hei_ex_000399",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "Blackhole recorded as Avalanche ecosystem DEX",
+      "description": "Blackhole is recorded as an Avalanche ecosystem DEX/protocol entity, with AMM, CLMM, and V3 candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 4,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001569",
+      "exchange_id": "hei_ex_000399",
+      "event_id": "hei_ev_000709",
+      "source_type": "official_statement",
+      "title": "Blackhole official website",
+      "url": "https://blackhole.xyz/",
+      "publisher": "Blackhole",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blackhole.xyz/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Blackhole identity."
+    },
+    {
+      "id": "hei_src_001570",
+      "exchange_id": "hei_ex_000399",
+      "event_id": "hei_ev_000709",
+      "source_type": "database_reference",
+      "title": "DefiLlama references for Blackhole AMM and CLMM",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0347 and hei_unadded_0348 referenced Blackhole AMM and CLMM."
+    },
+    {
+      "id": "hei_src_001571",
+      "exchange_id": "hei_ex_000399",
+      "event_id": "hei_ev_000709",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Blackhole V3",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0349."
+    },
+    {
+      "id": "hei_src_001572",
+      "exchange_id": "hei_ex_000399",
+      "event_id": "hei_ev_000709",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Blackhole V3",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0350."
+    }
+  ]
+}

--- a/records/exchanges/bladeswap.json
+++ b/records/exchanges/bladeswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000400",
+    "slug": "bladeswap",
+    "canonical_name": "BladeSwap",
+    "aliases": ["BladeSwap AMM", "BladeSwap CL", "bladeswap.xyz"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Blast ecosystem",
+    "summary": "Blast ecosystem DEX/protocol candidate represented by CoinGecko and DefiLlama rows. HEI treats BladeSwap, BladeSwap AMM, and BladeSwap CL rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://bladeswap.xyz/",
+    "official_domain_original": "bladeswap.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bladeswap.xyz/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded rows hei_unadded_0351 through hei_unadded_0353 as one entity to avoid AMM/CL duplication."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000710",
+      "exchange_id": "hei_ex_000400",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "BladeSwap recorded as Blast ecosystem DEX",
+      "description": "BladeSwap is recorded as a Blast ecosystem DEX/protocol entity, with AMM and CL candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001573",
+      "exchange_id": "hei_ex_000400",
+      "event_id": "hei_ev_000710",
+      "source_type": "official_statement",
+      "title": "BladeSwap official website",
+      "url": "https://bladeswap.xyz/",
+      "publisher": "BladeSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bladeswap.xyz/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BladeSwap identity."
+    },
+    {
+      "id": "hei_src_001574",
+      "exchange_id": "hei_ex_000400",
+      "event_id": "hei_ev_000710",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BladeSwap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0351."
+    },
+    {
+      "id": "hei_src_001575",
+      "exchange_id": "hei_ex_000400",
+      "event_id": "hei_ev_000710",
+      "source_type": "database_reference",
+      "title": "DefiLlama references for BladeSwap AMM and CL",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0352 and hei_unadded_0353 referenced BladeSwap AMM and CL."
+    }
+  ]
+}

--- a/records/exchanges/blasterswap.json
+++ b/records/exchanges/blasterswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000401",
+    "slug": "blasterswap",
+    "canonical_name": "BlasterSwap",
+    "aliases": ["Blasterswap", "Blasterswap V2", "Blasterswap V3", "blasterswap.com"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Blast ecosystem",
+    "summary": "Blast ecosystem DEX/protocol candidate represented by CoinGecko and DefiLlama rows. HEI treats BlasterSwap, Blasterswap V2, and Blasterswap V3 rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://blasterswap.com/",
+    "official_domain_original": "blasterswap.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://blasterswap.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded rows hei_unadded_0354 through hei_unadded_0356 as one entity to avoid version duplication."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000711",
+      "exchange_id": "hei_ex_000401",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "BlasterSwap recorded as Blast ecosystem DEX",
+      "description": "BlasterSwap is recorded as a Blast ecosystem DEX/protocol entity, with V2 and V3 candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001576",
+      "exchange_id": "hei_ex_000401",
+      "event_id": "hei_ev_000711",
+      "source_type": "official_statement",
+      "title": "BlasterSwap official website",
+      "url": "https://blasterswap.com/",
+      "publisher": "BlasterSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blasterswap.com/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BlasterSwap identity."
+    },
+    {
+      "id": "hei_src_001577",
+      "exchange_id": "hei_ex_000401",
+      "event_id": "hei_ev_000711",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BlasterSwap",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0354."
+    },
+    {
+      "id": "hei_src_001578",
+      "exchange_id": "hei_ex_000401",
+      "event_id": "hei_ev_000711",
+      "source_type": "database_reference",
+      "title": "DefiLlama references for Blasterswap V2 and V3",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0355 and hei_unadded_0356 referenced Blasterswap V2 and V3."
+    }
+  ]
+}

--- a/records/exchanges/blazeswap-flare.json
+++ b/records/exchanges/blazeswap-flare.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000402",
+    "slug": "blazeswap-flare",
+    "canonical_name": "BlazeSwap (Flare)",
+    "aliases": ["BlazeSwap", "app.blazeswap.xyz"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Flare ecosystem",
+    "summary": "Flare ecosystem DEX/protocol candidate represented by a CoinGecko exchange row and official app domain. HEI records BlazeSwap (Flare) as a protocol-level DEX entity for v0.",
+    "official_url_original": "https://app.blazeswap.xyz/",
+    "official_domain_original": "app.blazeswap.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://app.blazeswap.xyz/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-02",
+    "notes": "Added from verified-unadded row hei_unadded_0357. Kept as BlazeSwap (Flare) because the source row is chain-specific."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000712",
+      "exchange_id": "hei_ex_000402",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-02",
+      "title": "BlazeSwap recorded as Flare ecosystem DEX",
+      "description": "BlazeSwap is recorded as a Flare ecosystem DEX/protocol entity based on its CoinGecko source row and official app domain.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001579",
+      "exchange_id": "hei_ex_000402",
+      "event_id": "hei_ev_000712",
+      "source_type": "official_statement",
+      "title": "BlazeSwap official app",
+      "url": "https://app.blazeswap.xyz/",
+      "publisher": "BlazeSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.blazeswap.xyz/",
+      "accessed_at": "2026-06-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official app domain used to verify BlazeSwap identity."
+    },
+    {
+      "id": "hei_src_001580",
+      "exchange_id": "hei_ex_000402",
+      "event_id": "hei_ev_000712",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BlazeSwap (Flare)",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-02",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0357."
+    }
+  ]
+}


### PR DESCRIPTION
Add five DEX / exchange-like records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000398` Bitzy — `records/exchanges/bitzy.json`
- `hei_ex_000399` Blackhole — `records/exchanges/blackhole.json`
- `hei_ex_000400` BladeSwap — `records/exchanges/bladeswap.json`
- `hei_ex_000401` BlasterSwap — `records/exchanges/blasterswap.json`
- `hei_ex_000402` BlazeSwap (Flare) — `records/exchanges/blazeswap-flare.json`

Consumed rows:
- Bitzy: `hei_unadded_0343`
- Blackhole: `hei_unadded_0347`-`hei_unadded_0350`
- BladeSwap: `hei_unadded_0351`-`hei_unadded_0353`
- BlasterSwap: `hei_unadded_0354`-`hei_unadded_0356`
- BlazeSwap (Flare): `hei_unadded_0357`

Files added:
- `records/exchanges/bitzy.json`
- `records/exchanges/blackhole.json`
- `records/exchanges/bladeswap.json`
- `records/exchanges/blasterswap.json`
- `records/exchanges/blazeswap-flare.json`
- `docs/backlog/consumed/hei_unadded_0343-0357-dex-batch-9.md`

Policy notes:
- This follows the revised batch policy.
- Version/variant rows are consolidated into one protocol-level entity where appropriate.
- Rows with no official domain or unclear identity are left unconsumed.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
