### PR TITLE
Add tenth batch exchange records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0364-0390-exchange-batch-10.md
+++ b/docs/backlog/consumed/hei_unadded_0364-0390-exchange-batch-10.md
@@ -1,0 +1,92 @@
+# Consumed backlog rows: exchange / DEX batch 10
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five exchange / DEX records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with official domains and rows that can be consolidated cleanly by entity or protocol.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000403` | Blockchain.com | `records/exchanges/blockchain-com.json` | `hei_unadded_0364`, `hei_unadded_0366` |
+| `hei_ex_000404` | Bluefin | `records/exchanges/bluefin.json` | `hei_unadded_0372`-`hei_unadded_0374` |
+| `hei_ex_000405` | BlueMove | `records/exchanges/bluemove.json` | `hei_unadded_0375`-`hei_unadded_0377` |
+| `hei_ex_000406` | Blueprint | `records/exchanges/blueprint.json` | `hei_unadded_0378` |
+| `hei_ex_000407` | BounceBit Swap V3 | `records/exchanges/bouncebit-swap-v3.json` | `hei_unadded_0390` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### Blockchain.com
+
+Consumed rows:
+
+- `hei_unadded_0364` Blockchain.com
+- `hei_unadded_0366` blockchaincom
+
+Decision: create one `Blockchain.com` exchange entity and treat the CCXT `blockchaincom` row as an alias/source row.
+
+Not consumed:
+
+- `hei_unadded_0365` Blockchain.io
+
+Decision: leave Blockchain.io unconsumed because it is a separate candidate and should not be merged into Blockchain.com without stronger evidence.
+
+### Bluefin
+
+Consumed rows:
+
+- `hei_unadded_0372` Bluefin
+- `hei_unadded_0373` Bluefin
+- `hei_unadded_0374` Bluefin Spot
+
+Decision: create one `Bluefin` protocol-level trading / DEX record and treat Bluefin Spot as a product/context row for v0.
+
+### BlueMove
+
+Consumed rows:
+
+- `hei_unadded_0375` BlueMove
+- `hei_unadded_0376` BlueMove
+- `hei_unadded_0377` BlueMove DEX
+
+Decision: create one `BlueMove` protocol-level DEX record.
+
+### Blueprint
+
+Consumed row:
+
+- `hei_unadded_0378` Blueprint
+
+Decision: create one `Blueprint` protocol seed record.
+
+### BounceBit Swap V3
+
+Consumed row:
+
+- `hei_unadded_0390` BounceBit Swap V3
+
+Decision: create one chain/version-specific DEX record because the source row is explicitly BounceBit-specific.
+
+## Notes
+
+- This batch intentionally avoids rows with no official domain or unclear identity.
+- Blockchain.io is intentionally left unconsumed.
+- Records in this batch should be improved later with stronger launch, licensing, migration, rebrand, shutdown, or operating-history evidence where available.
+
+## Next action
+
+Continue with remaining candidates:
+
+- Blockchain.io after source review
+- BL3P / Bittylicious if official-domain evidence is found
+- Braziliex as inactive/dead if closure evidence is found
+- Blue Planet / BLEX / BMX Classic AMM if scope and source quality are acceptable
+- Next-range protocol rows after source review

--- a/records/exchanges/blockchain-com.json
+++ b/records/exchanges/blockchain-com.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000403",
+    "slug": "blockchain-com",
+    "canonical_name": "Blockchain.com",
+    "aliases": ["blockchaincom", "blockchain.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Crypto wallet and exchange/trading platform represented by CoinGecko and CCXT source rows. HEI treats Blockchain.com and blockchaincom rows as one exchange entity for v0, while leaving Blockchain.io as a separate unconsumed candidate.",
+    "official_url_original": "https://www.blockchain.com/",
+    "official_domain_original": "blockchain.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.blockchain.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0364 and hei_unadded_0366 as one entity. Blockchain.io / hei_unadded_0365 is not consumed here."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000713",
+      "exchange_id": "hei_ex_000403",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "Blockchain.com recorded as exchange entity",
+      "description": "Blockchain.com is recorded as an exchange/trading-platform entity, with Blockchain.com and blockchaincom candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise exchange launch, licensing, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001581",
+      "exchange_id": "hei_ex_000403",
+      "event_id": "hei_ev_000713",
+      "source_type": "official_statement",
+      "title": "Blockchain.com official website",
+      "url": "https://www.blockchain.com/",
+      "publisher": "Blockchain.com",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.blockchain.com/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Blockchain.com identity."
+    },
+    {
+      "id": "hei_src_001582",
+      "exchange_id": "hei_ex_000403",
+      "event_id": "hei_ev_000713",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Blockchain.com",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0364."
+    },
+    {
+      "id": "hei_src_001583",
+      "exchange_id": "hei_ex_000403",
+      "event_id": "hei_ev_000713",
+      "source_type": "database_reference",
+      "title": "CCXT reference for blockchaincom",
+      "url": "https://raw.githubusercontent.com/ccxt/ccxt/master/js/ccxt.js",
+      "publisher": "CCXT",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://raw.githubusercontent.com/ccxt/ccxt/master/js/ccxt.js",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0366."
+    }
+  ]
+}

--- a/records/exchanges/bluefin.json
+++ b/records/exchanges/bluefin.json
@@ -1,0 +1,100 @@
+{
+  "entity": {
+    "id": "hei_ex_000404",
+    "slug": "bluefin",
+    "canonical_name": "Bluefin",
+    "aliases": ["Bluefin Spot", "trade.bluefin.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Sui ecosystem",
+    "summary": "Sui ecosystem trading platform / DEX candidate represented by CoinPaprika, CoinGecko, and DefiLlama rows. HEI treats Bluefin and Bluefin Spot rows as one protocol-level entity for v0.",
+    "official_url_original": "https://trade.bluefin.io/",
+    "official_domain_original": "trade.bluefin.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://trade.bluefin.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0372 through hei_unadded_0374 as one entity to avoid duplicate Bluefin / Bluefin Spot records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000714",
+      "exchange_id": "hei_ex_000404",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "Bluefin recorded as Sui ecosystem trading protocol",
+      "description": "Bluefin is recorded as a Sui ecosystem trading protocol / DEX entity, with Bluefin and Bluefin Spot candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 4,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, product migration, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001584",
+      "exchange_id": "hei_ex_000404",
+      "event_id": "hei_ev_000714",
+      "source_type": "official_statement",
+      "title": "Bluefin official trading app",
+      "url": "https://trade.bluefin.io/",
+      "publisher": "Bluefin",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://trade.bluefin.io/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official trading app domain used to verify Bluefin identity."
+    },
+    {
+      "id": "hei_src_001585",
+      "exchange_id": "hei_ex_000404",
+      "event_id": "hei_ev_000714",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for Bluefin",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0372."
+    },
+    {
+      "id": "hei_src_001586",
+      "exchange_id": "hei_ex_000404",
+      "event_id": "hei_ev_000714",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bluefin",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0373."
+    },
+    {
+      "id": "hei_src_001587",
+      "exchange_id": "hei_ex_000404",
+      "event_id": "hei_ev_000714",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Bluefin Spot",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0374."
+    }
+  ]
+}

--- a/records/exchanges/bluemove.json
+++ b/records/exchanges/bluemove.json
@@ -1,0 +1,100 @@
+{
+  "entity": {
+    "id": "hei_ex_000405",
+    "slug": "bluemove",
+    "canonical_name": "BlueMove",
+    "aliases": ["BlueMove DEX", "dex.bluemove.net"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Aptos / Sui ecosystem",
+    "summary": "Aptos and Sui ecosystem DEX candidate represented by CoinPaprika, CoinGecko, and DefiLlama rows. HEI treats BlueMove and BlueMove DEX rows as one protocol-level entity for v0.",
+    "official_url_original": "https://dex.bluemove.net/",
+    "official_domain_original": "dex.bluemove.net",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://dex.bluemove.net/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0375 through hei_unadded_0377 as one entity to avoid duplicate BlueMove / BlueMove DEX records."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000715",
+      "exchange_id": "hei_ex_000405",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "BlueMove recorded as Aptos / Sui ecosystem DEX",
+      "description": "BlueMove is recorded as an Aptos and Sui ecosystem DEX entity, with BlueMove and BlueMove DEX candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 4,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, chain migration, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001588",
+      "exchange_id": "hei_ex_000405",
+      "event_id": "hei_ev_000715",
+      "source_type": "official_statement",
+      "title": "BlueMove DEX official website",
+      "url": "https://dex.bluemove.net/",
+      "publisher": "BlueMove",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://dex.bluemove.net/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official DEX domain used to verify BlueMove identity."
+    },
+    {
+      "id": "hei_src_001589",
+      "exchange_id": "hei_ex_000405",
+      "event_id": "hei_ev_000715",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for BlueMove",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0375."
+    },
+    {
+      "id": "hei_src_001590",
+      "exchange_id": "hei_ex_000405",
+      "event_id": "hei_ev_000715",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BlueMove",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0376."
+    },
+    {
+      "id": "hei_src_001591",
+      "exchange_id": "hei_ex_000405",
+      "event_id": "hei_ev_000715",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for BlueMove DEX",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0377."
+    }
+  ]
+}

--- a/records/exchanges/blueprint.json
+++ b/records/exchanges/blueprint.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000406",
+    "slug": "blueprint",
+    "canonical_name": "Blueprint",
+    "aliases": ["blueprint.fi"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "DEX/exchange-like protocol candidate represented by CoinGecko source data and an official domain reference. HEI records Blueprint as an active protocol seed record pending stronger operating-history evidence.",
+    "official_url_original": "https://blueprint.fi/",
+    "official_domain_original": "blueprint.fi",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://blueprint.fi/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded row hei_unadded_0378. This record should be improved later with stronger official, launch, chain, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000716",
+      "exchange_id": "hei_ex_000406",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "Blueprint recorded as protocol seed record",
+      "description": "Blueprint is recorded as a DEX/exchange-like protocol entity based on its CoinGecko exchange source row and official domain reference.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, chain, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001592",
+      "exchange_id": "hei_ex_000406",
+      "event_id": "hei_ev_000716",
+      "source_type": "official_statement",
+      "title": "Blueprint official website",
+      "url": "https://blueprint.fi/",
+      "publisher": "Blueprint",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blueprint.fi/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Blueprint identity."
+    },
+    {
+      "id": "hei_src_001593",
+      "exchange_id": "hei_ex_000406",
+      "event_id": "hei_ev_000716",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Blueprint",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=4",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0378."
+    }
+  ]
+}

--- a/records/exchanges/bouncebit-swap-v3.json
+++ b/records/exchanges/bouncebit-swap-v3.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000407",
+    "slug": "bouncebit-swap-v3",
+    "canonical_name": "BounceBit Swap V3",
+    "aliases": ["bitswap-v3-bouncebit", "app.bouncebit.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "BounceBit ecosystem",
+    "summary": "BounceBit ecosystem DEX candidate represented by a CoinGecko exchange row and official app domain. HEI records BounceBit Swap V3 as a chain-specific DEX entity for v0.",
+    "official_url_original": "https://app.bouncebit.io/",
+    "official_domain_original": "app.bouncebit.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://app.bouncebit.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded row hei_unadded_0390. Kept as BounceBit Swap V3 because the source row is chain/version specific."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000717",
+      "exchange_id": "hei_ex_000407",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "BounceBit Swap V3 recorded as ecosystem DEX",
+      "description": "BounceBit Swap V3 is recorded as a BounceBit ecosystem DEX entity based on its CoinGecko source row and official app domain.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, version, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001594",
+      "exchange_id": "hei_ex_000407",
+      "event_id": "hei_ev_000717",
+      "source_type": "official_statement",
+      "title": "BounceBit official app",
+      "url": "https://app.bouncebit.io/",
+      "publisher": "BounceBit",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.bouncebit.io/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official app domain used to verify BounceBit Swap V3 identity."
+    },
+    {
+      "id": "hei_src_001595",
+      "exchange_id": "hei_ex_000407",
+      "event_id": "hei_ev_000717",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BounceBit Swap V3",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0390."
+    }
+  ]
+}


### PR DESCRIPTION
Add five exchange / DEX records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000403` Blockchain.com — `records/exchanges/blockchain-com.json`
- `hei_ex_000404` Bluefin — `records/exchanges/bluefin.json`
- `hei_ex_000405` BlueMove — `records/exchanges/bluemove.json`
- `hei_ex_000406` Blueprint — `records/exchanges/blueprint.json`
- `hei_ex_000407` BounceBit Swap V3 — `records/exchanges/bouncebit-swap-v3.json`

Consumed rows:
- Blockchain.com: `hei_unadded_0364`, `hei_unadded_0366`
- Bluefin: `hei_unadded_0372`-`hei_unadded_0374`
- BlueMove: `hei_unadded_0375`-`hei_unadded_0377`
- Blueprint: `hei_unadded_0378`
- BounceBit Swap V3: `hei_unadded_0390`

Files added:
- `records/exchanges/blockchain-com.json`
- `records/exchanges/bluefin.json`
- `records/exchanges/bluemove.json`
- `records/exchanges/blueprint.json`
- `records/exchanges/bouncebit-swap-v3.json`
- `docs/backlog/consumed/hei_unadded_0364-0390-exchange-batch-10.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are consolidated into one entity where appropriate.
- Blockchain.io is intentionally left unconsumed and not merged into Blockchain.com.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
