### PR TITLE
Add eleventh batch exchange records

### DIFF
--- a/docs/backlog/consumed/hei_unadded_0393-0420-exchange-batch-11.md
+++ b/docs/backlog/consumed/hei_unadded_0393-0420-exchange-batch-11.md
@@ -1,0 +1,86 @@
+# Consumed backlog rows: exchange / DEX batch 11
+
+Status: added
+
+## Purpose
+
+Batch-consume verified-unadded rows for five exchange / DEX records under the revised HEI record-addition workflow.
+
+This batch prioritizes candidates with official domains and rows that can be consolidated cleanly by entity or protocol.
+
+## Added records
+
+| entity_id | record | path | consumed rows |
+|---|---|---|---|
+| `hei_ex_000408` | Bron Intents | `records/exchanges/bron-intents.json` | `hei_unadded_0393` |
+| `hei_ex_000409` | BTC Trade UA | `records/exchanges/btc-trade-ua.json` | `hei_unadded_0397`, `hei_unadded_0398` |
+| `hei_ex_000410` | BTCC | `records/exchanges/btcc.json` | `hei_unadded_0403`, `hei_unadded_0404` |
+| `hei_ex_000411` | BulbaSwap | `records/exchanges/bulbaswap.json` | `hei_unadded_0416`-`hei_unadded_0418` |
+| `hei_ex_000412` | Bulla Exchange | `records/exchanges/bulla-exchange.json` | `hei_unadded_0419`, `hei_unadded_0420` |
+
+## Source confirmation
+
+Rows were checked in `docs/backlog/verified-unadded-candidates-v1/unadded-candidates-verified-v1.jsonl` before creation.
+
+## Duplicate handling
+
+### Bron Intents
+
+Consumed row:
+
+- `hei_unadded_0393` Bron Intents
+
+Decision: create one `Bron Intents` exchange/protocol seed record.
+
+### BTC Trade UA
+
+Consumed rows:
+
+- `hei_unadded_0397` BTC Trade UA
+- `hei_unadded_0398` BTC Trade UA
+
+Decision: create one `BTC Trade UA` centralized exchange record.
+
+### BTCC
+
+Consumed rows:
+
+- `hei_unadded_0403` BTCC
+- `hei_unadded_0404` BTCC
+
+Decision: create one `BTCC` centralized exchange record. CoinPaprika and CoinGecko source rows disagree on inactive/active status, so status remains active with notes pending deeper historical segmentation.
+
+### BulbaSwap
+
+Consumed rows:
+
+- `hei_unadded_0416` Bulbaswap V2
+- `hei_unadded_0417` BulbaSwap V2
+- `hei_unadded_0418` BulbaSwap V3
+
+Decision: create one `BulbaSwap` protocol-level DEX record and treat V2/V3 rows as variants.
+
+### Bulla Exchange
+
+Consumed rows:
+
+- `hei_unadded_0419` Bulla
+- `hei_unadded_0420` Bulla Exchange
+
+Decision: create one `Bulla Exchange` protocol-level DEX record and treat Bulla as an alias/context row.
+
+## Notes
+
+- This batch intentionally avoids rows with no official domain or unclear identity.
+- Braziliex and other inactive/dead-looking rows are left for stronger evidence review rather than thin active-style seed insertion.
+- Records in this batch should be improved later with stronger launch, licensing, chain, shutdown, or operating-history evidence where available.
+
+## Next action
+
+Continue with remaining candidates:
+
+- Braziliex as inactive/dead if closure evidence is found
+- BrownFi after official-domain/source review
+- BTC-Alpha / BTCBOX / BTCMEX if official-domain evidence is found
+- Buda / Buenbit / BTSE Futures after source review
+- BunSwap / BurrBear / Butter after next-range DEX review

--- a/records/exchanges/bron-intents.json
+++ b/records/exchanges/bron-intents.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000408",
+    "slug": "bron-intents",
+    "canonical_name": "Bron Intents",
+    "aliases": ["Bron", "bron.org"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Intent-based exchange / DEX candidate represented by a CoinGecko exchange row and official domain reference. HEI records Bron Intents as an active protocol seed record pending stronger launch and operating-history evidence.",
+    "official_url_original": "https://bron.org/",
+    "official_domain_original": "bron.org",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bron.org/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded row hei_unadded_0393. This record should be improved later with stronger official, launch, chain, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000718",
+      "exchange_id": "hei_ex_000408",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "Bron Intents recorded as exchange protocol candidate",
+      "description": "Bron Intents is recorded as an exchange / DEX protocol candidate based on its CoinGecko source row and official domain reference.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, chain, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001596",
+      "exchange_id": "hei_ex_000408",
+      "event_id": "hei_ev_000718",
+      "source_type": "official_statement",
+      "title": "Bron official website",
+      "url": "https://bron.org/",
+      "publisher": "Bron",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bron.org/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bron Intents identity."
+    },
+    {
+      "id": "hei_src_001597",
+      "exchange_id": "hei_ex_000408",
+      "event_id": "hei_ev_000718",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bron Intents",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=2",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0393."
+    }
+  ]
+}

--- a/records/exchanges/btc-trade-ua.json
+++ b/records/exchanges/btc-trade-ua.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000409",
+    "slug": "btc-trade-ua",
+    "canonical_name": "BTC Trade UA",
+    "aliases": ["BTC-Trade", "BTC Trade", "btc-trade.com.ua"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Ukraine",
+    "summary": "Ukraine-focused centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats BTC Trade UA duplicate rows as one entity.",
+    "official_url_original": "https://btc-trade.com.ua/",
+    "official_domain_original": "btc-trade.com.ua",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://btc-trade.com.ua/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0397 and hei_unadded_0398 as one entity. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000719",
+      "exchange_id": "hei_ex_000409",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "BTC Trade UA recorded as centralized exchange",
+      "description": "BTC Trade UA is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, licensing, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001598",
+      "exchange_id": "hei_ex_000409",
+      "event_id": "hei_ev_000719",
+      "source_type": "official_statement",
+      "title": "BTC Trade UA official website",
+      "url": "https://btc-trade.com.ua/",
+      "publisher": "BTC Trade UA",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://btc-trade.com.ua/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BTC Trade UA identity."
+    },
+    {
+      "id": "hei_src_001599",
+      "exchange_id": "hei_ex_000409",
+      "event_id": "hei_ev_000719",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for BTC Trade UA",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0397."
+    },
+    {
+      "id": "hei_src_001600",
+      "exchange_id": "hei_ex_000409",
+      "event_id": "hei_ev_000719",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BTC Trade UA",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0398."
+    }
+  ]
+}

--- a/records/exchanges/btcc.json
+++ b/records/exchanges/btcc.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000410",
+    "slug": "btcc",
+    "canonical_name": "BTCC",
+    "aliases": ["BTCC Exchange", "btcc.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats active and inactive source signals as one BTCC entity and keeps the final status active pending stronger historical segmentation evidence.",
+    "official_url_original": "https://www.btcc.com/",
+    "official_domain_original": "btcc.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.btcc.com/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0403 and hei_unadded_0404 as one entity. CoinPaprika marked one source row inactive while CoinGecko has an active-domain row; status is kept active until a stronger shutdown/rebrand split is researched."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000720",
+      "exchange_id": "hei_ex_000410",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "BTCC recorded as centralized exchange",
+      "description": "BTCC is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, rebrand, shutdown, licensing, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001601",
+      "exchange_id": "hei_ex_000410",
+      "event_id": "hei_ev_000720",
+      "source_type": "official_statement",
+      "title": "BTCC official website",
+      "url": "https://www.btcc.com/",
+      "publisher": "BTCC",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.btcc.com/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BTCC identity."
+    },
+    {
+      "id": "hei_src_001602",
+      "exchange_id": "hei_ex_000410",
+      "event_id": "hei_ev_000720",
+      "source_type": "database_reference",
+      "title": "CoinPaprika exchange reference for BTCC",
+      "url": "https://api.coinpaprika.com/v1/exchanges",
+      "publisher": "CoinPaprika",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coinpaprika.com/v1/exchanges",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0403."
+    },
+    {
+      "id": "hei_src_001603",
+      "exchange_id": "hei_ex_000410",
+      "event_id": "hei_ev_000720",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BTCC",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=1",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0404."
+    }
+  ]
+}

--- a/records/exchanges/bulbaswap.json
+++ b/records/exchanges/bulbaswap.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000411",
+    "slug": "bulbaswap",
+    "canonical_name": "BulbaSwap",
+    "aliases": ["BulbaSwap V2", "BulbaSwap V3", "bulbaswap.io"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Morph ecosystem",
+    "summary": "Morph ecosystem DEX/protocol candidate represented by CoinGecko and DefiLlama rows. HEI treats BulbaSwap V2 and V3 rows as one protocol-level DEX entity for v0.",
+    "official_url_original": "https://bulbaswap.io/",
+    "official_domain_original": "bulbaswap.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bulbaswap.io/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0416 through hei_unadded_0418 as one entity to avoid V2/V3 duplication."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000721",
+      "exchange_id": "hei_ex_000411",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "BulbaSwap recorded as Morph ecosystem DEX",
+      "description": "BulbaSwap is recorded as a Morph ecosystem DEX/protocol entity, with V2 and V3 candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, version, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001604",
+      "exchange_id": "hei_ex_000411",
+      "event_id": "hei_ev_000721",
+      "source_type": "official_statement",
+      "title": "BulbaSwap official website",
+      "url": "https://bulbaswap.io/",
+      "publisher": "BulbaSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bulbaswap.io/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify BulbaSwap identity."
+    },
+    {
+      "id": "hei_src_001605",
+      "exchange_id": "hei_ex_000411",
+      "event_id": "hei_ev_000721",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for BulbaSwap V2",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0416."
+    },
+    {
+      "id": "hei_src_001606",
+      "exchange_id": "hei_ex_000411",
+      "event_id": "hei_ev_000721",
+      "source_type": "database_reference",
+      "title": "DefiLlama references for BulbaSwap V2 and V3",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Backlog rows hei_unadded_0417 and hei_unadded_0418 referenced BulbaSwap V2 and V3."
+    }
+  ]
+}

--- a/records/exchanges/bulla-exchange.json
+++ b/records/exchanges/bulla-exchange.json
@@ -1,0 +1,85 @@
+{
+  "entity": {
+    "id": "hei_ex_000412",
+    "slug": "bulla-exchange",
+    "canonical_name": "Bulla Exchange",
+    "aliases": ["Bulla", "bulla.exchange"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "DEX / exchange protocol candidate represented by CoinGecko and DefiLlama source rows. HEI treats Bulla and Bulla Exchange rows as one protocol-level entity for v0.",
+    "official_url_original": "https://bulla.exchange/",
+    "official_domain_original": "bulla.exchange",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://bulla.exchange/",
+    "confidence": "medium",
+    "last_verified_at": "2026-06-03",
+    "notes": "Added from verified-unadded rows hei_unadded_0419 and hei_unadded_0420 as one entity. This record should be improved later with stronger launch, chain, or operating-history evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_000722",
+      "exchange_id": "hei_ex_000412",
+      "event_type": "listed_reference",
+      "event_date": "2026-06-03",
+      "title": "Bulla Exchange recorded as DEX candidate",
+      "description": "Bulla Exchange is recorded as a DEX / exchange protocol entity, with Bulla and Bulla Exchange candidate rows consolidated into one HEI record.",
+      "confidence": "medium",
+      "impact_level": "low",
+      "event_status_effect": "active",
+      "source_count": 3,
+      "sort_order": 1,
+      "notes": "Upgrade with precise launch, chain, or operating-history evidence if stronger sources are added."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_001607",
+      "exchange_id": "hei_ex_000412",
+      "event_id": "hei_ev_000722",
+      "source_type": "official_statement",
+      "title": "Bulla Exchange official website",
+      "url": "https://bulla.exchange/",
+      "publisher": "Bulla Exchange",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://bulla.exchange/",
+      "accessed_at": "2026-06-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official domain used to verify Bulla Exchange identity."
+    },
+    {
+      "id": "hei_src_001608",
+      "exchange_id": "hei_ex_000412",
+      "event_id": "hei_ev_000722",
+      "source_type": "database_reference",
+      "title": "CoinGecko exchange reference for Bulla",
+      "url": "https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0419."
+    },
+    {
+      "id": "hei_src_001609",
+      "exchange_id": "hei_ex_000412",
+      "event_id": "hei_ev_000722",
+      "source_type": "database_reference",
+      "title": "DefiLlama DEX reference for Bulla Exchange",
+      "url": "https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume",
+      "accessed_at": "2026-06-03",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Source used by verified-unadded backlog row hei_unadded_0420."
+    }
+  ]
+}


### PR DESCRIPTION
Add five exchange / DEX records from the verified-unadded backlog pool and consume their source rows in a single batch memo.

Records added:
- `hei_ex_000408` Bron Intents — `records/exchanges/bron-intents.json`
- `hei_ex_000409` BTC Trade UA — `records/exchanges/btc-trade-ua.json`
- `hei_ex_000410` BTCC — `records/exchanges/btcc.json`
- `hei_ex_000411` BulbaSwap — `records/exchanges/bulbaswap.json`
- `hei_ex_000412` Bulla Exchange — `records/exchanges/bulla-exchange.json`

Consumed rows:
- Bron Intents: `hei_unadded_0393`
- BTC Trade UA: `hei_unadded_0397`-`hei_unadded_0398`
- BTCC: `hei_unadded_0403`-`hei_unadded_0404`
- BulbaSwap: `hei_unadded_0416`-`hei_unadded_0418`
- Bulla Exchange: `hei_unadded_0419`-`hei_unadded_0420`

Files added:
- `records/exchanges/bron-intents.json`
- `records/exchanges/btc-trade-ua.json`
- `records/exchanges/btcc.json`
- `records/exchanges/bulbaswap.json`
- `records/exchanges/bulla-exchange.json`
- `docs/backlog/consumed/hei_unadded_0393-0420-exchange-batch-11.md`

Policy notes:
- This follows the revised batch policy.
- Duplicate or closely related rows are consolidated into one entity where appropriate.
- Version rows are consolidated at protocol level for BulbaSwap in v0.

Validation target:
- record bundle schema / duplicate identity checks
- backlog dedupe
- CI build/lint
