### PR TITLE
Run initial external monitoring bootstrap

### DIFF
--- a/.github/workflows/hei-monitoring-bootstrap.yml
+++ b/.github/workflows/hei-monitoring-bootstrap.yml
@@ -1,0 +1,112 @@
+name: HEI Monitoring Bootstrap
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/hei-monitoring-bootstrap.yml"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: hei-monitoring-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  monitoring-bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Smoke test monitoring modules
+        run: npm run monitor:smoke
+
+      - name: Run bounded full monitoring
+        id: monitor
+        env:
+          HEI_MONITORING_ENABLE_REMOTE_LISTS: "1"
+          HEI_MONITORING_ENABLE_NEWS_RSS: "1"
+          HEI_MONITORING_ENABLE_DOMAIN_CHECKS: "1"
+          HEI_MONITORING_ENABLE_EVIDENCE_URL_CHECKS: "1"
+          HEI_MONITORING_ENABLE_REGULATORY_WATCH: "1"
+          HEI_MONITORING_ENABLE_SITE_SEO_CHECKS: "1"
+          HEI_MONITORING_SITE_URL: "https://hei.badjoke-lab.com"
+          HEI_MONITORING_NEWS_QUERY_LIMIT: "20"
+          HEI_MONITORING_REGULATORY_QUERY_LIMIT: "25"
+          HEI_MONITORING_DOMAIN_CHECK_LIMIT: "25"
+          HEI_MONITORING_EVIDENCE_URL_CHECK_LIMIT: "25"
+        run: npm run monitor
+
+      - name: Guard canonical data files
+        run: |
+          if git status --porcelain -- data/entities.json data/events.json data/evidence.json | grep .; then
+            echo "Monitoring must not modify canonical data files."
+            exit 1
+          fi
+
+      - name: Check generated report
+        id: changes
+        run: |
+          if git status --porcelain -- data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution | grep .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create bootstrap monitoring pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="auto/monitoring/bootstrap-$(date -u +%Y%m%d-%H%M%S)"
+          RUN_DATE="$(date -u +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          for path in data-staging/monitoring data-staging/watchlists/auto data-staging/watchlists/resolution; do
+            if [ -e "$path" ]; then
+              git add "$path"
+            fi
+          done
+          git commit -m "Add initial HEI external monitoring report"
+          git push origin "$BRANCH"
+
+          SUMMARY_FILE="$(find data-staging/monitoring -name summary.md | sort | tail -n 1)"
+          REPORT_DIR="$(dirname "$SUMMARY_FILE")"
+          BODY_FILE="/tmp/hei-monitoring-bootstrap-pr-body.md"
+          {
+            echo "## Initial HEI external monitoring report"
+            echo ""
+            echo "Run date: $RUN_DATE"
+            echo ""
+            echo "- Monitoring report directory: $REPORT_DIR"
+            echo "- Summary file: $SUMMARY_FILE"
+            echo "- State file: data-staging/monitoring/state/latest-findings.json"
+            echo ""
+            echo "This bootstrap report is for noise review. Canonical data files are unchanged."
+          } > "$BODY_FILE"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Initial external monitoring report: $RUN_DATE" \
+            --body-file "$BODY_FILE"


### PR DESCRIPTION
Adds a one-time workflow to run the bounded external monitoring configuration immediately after merge and open a monitoring-report PR. Canonical data files remain guarded and unchanged. The resulting report will be reviewed for false positives and fetch failures before the permanent Monday schedule is relied on.