### PR TITLE
Allow exact canonical mirror bundles for record repairs

### DIFF
--- a/records/exchanges/kraken.json
+++ b/records/exchanges/kraken.json
@@ -1,0 +1,70 @@
+{
+  "entity": {
+    "id": "hei_ex_000009",
+    "slug": "kraken",
+    "canonical_name": "Kraken",
+    "aliases": [],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2011-07-28",
+    "death_date": null,
+    "country_or_origin": "United States",
+    "summary": "United States-based centralized exchange launched in 2011 and still operating under the Kraken brand.",
+    "official_url_original": "https://www.kraken.com/",
+    "official_domain_original": "kraken.com",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://www.kraken.com/",
+    "confidence": "high",
+    "notes": "Launch date updated from Kraken’s official founding post dated 2011-07-28.",
+    "last_verified_at": "2026-04-07"
+  },
+  "events": [
+    {
+      "id": "hei_ev_002046",
+      "exchange_id": "hei_ex_000009",
+      "event_type": "launched",
+      "event_date": "2011-07-28",
+      "title": "Kraken was founded",
+      "description": "Kraken traces its founding to 2011-07-28, when the exchange project began under the Kraken name.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "The event uses Kraken’s official founding date already stored in the canonical entity."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_003110",
+      "exchange_id": "hei_ex_000009",
+      "event_id": "hei_ev_002046",
+      "source_type": "official_blog",
+      "title": "Kraken is Born",
+      "url": "https://blog.kraken.com/news/kraken-is-born",
+      "publisher": "Kraken",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blog.kraken.com/news/kraken-is-born",
+      "accessed_at": "2026-06-15",
+      "reliability": "high",
+      "claim_scope": "launch_date",
+      "notes": "Primary project history source identifying 2011-07-28 as Kraken’s founding date."
+    },
+    {
+      "id": "hei_src_003111",
+      "exchange_id": "hei_ex_000009",
+      "event_id": "hei_ev_002046",
+      "source_type": "official_blog",
+      "title": "13 Years Ago: The Kraken Emerged",
+      "url": "https://blog.kraken.com/news/13-years-ago-the-kraken-emerged",
+      "publisher": "Kraken",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blog.kraken.com/news/13-years-ago-the-kraken-emerged",
+      "accessed_at": "2026-06-15",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Official retrospective corroborating Kraken’s 2011 origin and continuing exchange identity."
+    }
+  ]
+}

--- a/scripts/audit-record-entity-overlaps.mjs
+++ b/scripts/audit-record-entity-overlaps.mjs
@@ -20,6 +20,21 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
 
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`
+  }
+
+  return JSON.stringify(value)
+}
+
 function normalizeText(value) {
   if (!value || typeof value !== 'string') return null
   const normalized = value
@@ -95,6 +110,14 @@ function loadRecords() {
   return records
 }
 
+function isExactCanonicalMirrorPair(left, right) {
+  const canonical = left.source === 'data/entities.json' ? left : right.source === 'data/entities.json' ? right : null
+  const bundle = left.source === 'records/exchanges' ? left : right.source === 'records/exchanges' ? right : null
+
+  if (!canonical || !bundle || !canonical.entity.id || canonical.entity.id !== bundle.entity.id) return false
+  return stableStringify(canonical.entity) === stableStringify(bundle.entity)
+}
+
 function intersections(left, right) {
   return [...left].filter((value) => right.has(value))
 }
@@ -118,6 +141,7 @@ function compare(left, right) {
 const records = loadRecords()
 const collisions = []
 const allowedCollisions = []
+let exactMirrorPairs = 0
 
 for (let i = 0; i < records.length; i += 1) {
   for (let j = i + 1; j < records.length; j += 1) {
@@ -125,6 +149,11 @@ for (let i = 0; i < records.length; i += 1) {
     const right = records[j]
 
     if (left.source !== 'records/exchanges' && right.source !== 'records/exchanges') continue
+
+    if (isExactCanonicalMirrorPair(left, right)) {
+      exactMirrorPairs += 1
+      continue
+    }
 
     const reasons = compare(left, right)
     if (reasons.length === 0) continue
@@ -140,8 +169,11 @@ for (let i = 0; i < records.length; i += 1) {
 }
 
 if (collisions.length === 0) {
-  const allowedSuffix = allowedCollisions.length ? ` (${allowedCollisions.length} documented overlap pair(s) allowed).` : '.'
-  console.log(`No blocking entity overlaps detected across ${records.length} canonical and bundle records${allowedSuffix}`)
+  const notes = []
+  if (exactMirrorPairs) notes.push(`${exactMirrorPairs} exact canonical mirror pair(s) allowed for repair bundles`)
+  if (allowedCollisions.length) notes.push(`${allowedCollisions.length} documented overlap pair(s) allowed`)
+  const suffix = notes.length ? ` (${notes.join('; ')}).` : '.'
+  console.log(`No blocking entity overlaps detected across ${records.length} canonical and bundle records${suffix}`)
   process.exit(0)
 }
 

--- a/scripts/check-record-duplicates.mjs
+++ b/scripts/check-record-duplicates.mjs
@@ -15,6 +15,21 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
 
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`
+  }
+
+  return JSON.stringify(value)
+}
+
 function normalizeIdentity(value) {
   if (!value || typeof value !== 'string') return null
   let normalized = value.trim().toLowerCase()
@@ -50,6 +65,7 @@ function makeRecord(source, entity, filePath = null) {
   return {
     source,
     filePath,
+    entity,
     id: entity.id,
     slug: entity.slug,
     canonical_name: entity.canonical_name,
@@ -79,9 +95,16 @@ function loadBundleRecords() {
 }
 
 const baseRecords = readJson(entitiesPath).map((entity) => makeRecord('data/entities.json', entity))
+const canonicalById = new Map(baseRecords.map((record) => [record.id, record]))
 const bundleRecords = loadBundleRecords()
 const allRecords = [...baseRecords, ...bundleRecords]
 const byKey = new Map()
+
+function isExactCanonicalMirror(record) {
+  if (record.source !== 'records/exchanges' || !record.id) return false
+  const canonical = canonicalById.get(record.id)
+  return Boolean(canonical && stableStringify(canonical.entity) === stableStringify(record.entity))
+}
 
 for (const record of allRecords) {
   for (const key of record.keys) {
@@ -95,30 +118,40 @@ for (const record of allRecords) {
 const duplicateGroups = []
 const allowedGroups = []
 const seenGroups = new Set()
+let exactMirrorRecords = 0
 
 for (const [identity, records] of byKey) {
-  const uniqueRecordIds = [...new Set(records.map((record) => `${record.source}:${record.filePath || record.id}`))]
+  const logicalRecords = records.filter((record) => {
+    if (!isExactCanonicalMirror(record)) return true
+    exactMirrorRecords += 1
+    return false
+  })
+
+  const uniqueRecordIds = [...new Set(logicalRecords.map((record) => `${record.source}:${record.filePath || record.id}`))]
   if (uniqueRecordIds.length < 2) continue
 
-  const hasBundle = records.some((record) => record.source === 'records/exchanges')
+  const hasBundle = logicalRecords.some((record) => record.source === 'records/exchanges')
   if (!hasBundle) continue
 
   const groupKey = uniqueRecordIds.sort().join('|')
   if (seenGroups.has(groupKey)) continue
   seenGroups.add(groupKey)
 
-  const pairKey = recordPairKey(records)
+  const pairKey = recordPairKey(logicalRecords)
   if (pairKey && allowedDuplicateEntityPairs.has(pairKey)) {
-    allowedGroups.push({ identity, records })
+    allowedGroups.push({ identity, records: logicalRecords })
     continue
   }
 
-  duplicateGroups.push({ identity, records })
+  duplicateGroups.push({ identity, records: logicalRecords })
 }
 
 if (duplicateGroups.length === 0) {
-  const allowedSuffix = allowedGroups.length ? ` (${allowedGroups.length} documented duplicate group(s) allowed).` : '.'
-  console.log(`No record identity duplicates detected${allowedSuffix}`)
+  const notes = []
+  if (exactMirrorRecords) notes.push(`${exactMirrorRecords} exact canonical mirror identity occurrence(s) ignored`)
+  if (allowedGroups.length) notes.push(`${allowedGroups.length} documented duplicate group(s) allowed`)
+  const suffix = notes.length ? ` (${notes.join('; ')}).` : '.'
+  console.log(`No record identity duplicates detected${suffix}`)
 } else {
   console.error(`Detected ${duplicateGroups.length} record identity duplicate group(s):`)
 


### PR DESCRIPTION
## Summary

Adds a safe path for supplementing existing canonical entities with new event/evidence records through `records/exchanges/*.json` bundles.

## Safety rule

A canonical-to-bundle identity overlap is ignored only when:

- the entity IDs are identical, and
- the complete entity objects are structurally identical.

The following remain blocking errors:

- same ID with different entity content
- same slug/name/domain under a different ID
- bundle-to-bundle identity collisions
- undocumented separate-entity overlaps

## Implementation

- update `scripts/audit-record-entity-overlaps.mjs`
- update `scripts/check-record-duplicates.mjs`
- retain the existing strict duplicate and overlap gates

## Proof bundle

Adds `records/exchanges/kraken.json` as the first existing-entity repair bundle:

- canonical entity mirror: `hei_ex_000009`
- new launch event: `hei_ev_002046`
- new evidence: `hei_src_003110..003111`

The entity content is intentionally unchanged. The bundle only supplies the missing launch event and official evidence.

## Validation

Pending Records validation and normal CI.