### PR TITLE
Include events from existing entity bundles

### DIFF
--- a/scripts/monitoring/core/load-canonical-data.mjs
+++ b/scripts/monitoring/core/load-canonical-data.mjs
@@ -1,15 +1,74 @@
-import { readJsonFile } from './fs-utils.mjs';
+import path from 'node:path';
+import { listJsonFiles, readJsonFile } from './fs-utils.mjs';
 
 const ENTITIES_PATH = 'data/entities.json';
 const EVENTS_PATH = 'data/events.json';
 const EVIDENCE_PATH = 'data/evidence.json';
+const RECORDS_PATH = path.join('records', 'exchanges');
 
-function normalizeArray(value, path) {
-  if (Array.isArray(value)) {
-    return value;
+function normalizeArray(value, filePath) {
+  if (Array.isArray(value)) return value;
+  throw new Error(`${filePath} must contain a JSON array`);
+}
+
+function normalizeIdentity(value) {
+  if (!value) return null;
+  const normalized = String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/$/, '');
+  return normalized || null;
+}
+
+function entityIdentityKeys(entity) {
+  return new Set([
+    entity?.id,
+    entity?.slug,
+    entity?.canonical_name,
+    entity?.official_domain_original,
+    entity?.official_url_original,
+    ...(entity?.aliases || []),
+  ].map(normalizeIdentity).filter(Boolean));
+}
+
+async function loadExchangeRecordBundles() {
+  const files = await listJsonFiles(RECORDS_PATH);
+  const bundles = [];
+  for (const filePath of files) {
+    const bundle = await readJsonFile(filePath, null);
+    if (!bundle?.entity || !Array.isArray(bundle.events) || !Array.isArray(bundle.evidence)) {
+      throw new Error(`${filePath}: expected { entity, events, evidence }`);
+    }
+    bundles.push(bundle);
   }
+  return bundles;
+}
 
-  throw new Error(`${path} must contain a JSON array`);
+function mergeNewEntities(baseEntities, bundles) {
+  const seen = new Set(baseEntities.flatMap((entity) => [...entityIdentityKeys(entity)]));
+  const added = [];
+  for (const bundle of bundles) {
+    const keys = entityIdentityKeys(bundle.entity);
+    if ([...keys].some((key) => seen.has(key))) continue;
+    added.push(bundle.entity);
+    for (const key of keys) seen.add(key);
+  }
+  return [...baseEntities, ...added];
+}
+
+function mergeBundleRecords(baseRecords, bundles, field) {
+  const seen = new Set(baseRecords.map((record) => record.id));
+  const added = [];
+  for (const bundle of bundles) {
+    for (const record of bundle[field]) {
+      if (seen.has(record.id)) continue;
+      seen.add(record.id);
+      added.push(record);
+    }
+  }
+  return [...baseRecords, ...added];
 }
 
 export async function loadEntities() {
@@ -25,20 +84,22 @@ export async function loadEvidence() {
 }
 
 export async function loadCanonicalData() {
-  const [entities, events, evidence] = await Promise.all([
+  const [baseEntities, baseEvents, baseEvidence, bundles] = await Promise.all([
     loadEntities(),
     loadEvents(),
     loadEvidence(),
+    loadExchangeRecordBundles(),
   ]);
 
   return {
-    entities,
-    events,
-    evidence,
+    entities: mergeNewEntities(baseEntities, bundles),
+    events: mergeBundleRecords(baseEvents, bundles, 'events'),
+    evidence: mergeBundleRecords(baseEvidence, bundles, 'evidence'),
     paths: {
       entities: ENTITIES_PATH,
       events: EVENTS_PATH,
       evidence: EVIDENCE_PATH,
+      records: RECORDS_PATH,
     },
   };
 }

--- a/src/lib/data/load-events.ts
+++ b/src/lib/data/load-events.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EventRecord } from '../types/event'
-import type { EntityRecord } from '../types/entity'
-import { filterNewExchangeRecordBundles, loadExchangeRecordBundles } from './load-record-bundles'
+import { loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -12,11 +11,14 @@ function readJsonFile<T>(relativePath: string): T {
 
 export function loadEvents(): EventRecord[] {
   const events = readJsonFile<EventRecord[]>('data/events.json')
-  const entities = readJsonFile<EntityRecord[]>('data/entities.json')
   const seenIds = new Set(events.map((event) => event.id))
-  const bundleEvents = filterNewExchangeRecordBundles(loadExchangeRecordBundles(), entities)
+  const bundleEvents = loadExchangeRecordBundles()
     .flatMap((bundle) => bundle.events)
-    .filter((event) => !seenIds.has(event.id))
+    .filter((event) => {
+      if (seenIds.has(event.id)) return false
+      seenIds.add(event.id)
+      return true
+    })
 
   return [...events, ...bundleEvents]
 }

--- a/src/lib/data/load-evidence.ts
+++ b/src/lib/data/load-evidence.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EvidenceRecord } from '../types/evidence'
-import type { EntityRecord } from '../types/entity'
-import { filterNewExchangeRecordBundles, loadExchangeRecordBundles } from './load-record-bundles'
+import { loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
   const filePath = path.join(process.cwd(), relativePath)
@@ -12,11 +11,14 @@ function readJsonFile<T>(relativePath: string): T {
 
 export function loadEvidence(): EvidenceRecord[] {
   const evidence = readJsonFile<EvidenceRecord[]>('data/evidence.json')
-  const entities = readJsonFile<EntityRecord[]>('data/entities.json')
   const seenIds = new Set(evidence.map((source) => source.id))
-  const bundleEvidence = filterNewExchangeRecordBundles(loadExchangeRecordBundles(), entities)
+  const bundleEvidence = loadExchangeRecordBundles()
     .flatMap((bundle) => bundle.evidence)
-    .filter((source) => !seenIds.has(source.id))
+    .filter((source) => {
+      if (seenIds.has(source.id)) return false
+      seenIds.add(source.id)
+      return true
+    })
 
   return [...evidence, ...bundleEvidence]
 }


### PR DESCRIPTION
## Summary

Fixes reviewed bundle projection for existing HEI entities.

- public event loader now reads events from all validated bundles
- public evidence loader now reads evidence from all validated bundles
- monitoring now combines aggregate JSON with reviewed bundle records
- entity rows still exclude duplicate identities
- event and evidence IDs remain deduplicated

This makes repair records from PRs #365, #366, and #369 visible to the site and prevents monitoring from using stale aggregate-only counts.

Canonical aggregate files are unchanged. Validation is pending CI.