### PR TITLE
Add reviewed bundle aggregation regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check production smoke script syntax
         run: node --check scripts/check-machine-readable-production.mjs
 
+      - name: Test reviewed bundle aggregation
+        run: node scripts/test-reviewed-bundle-aggregation.mjs
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Check production smoke script syntax
         run: node --check scripts/check-machine-readable-production.mjs
 
-      - name: Test reviewed bundle aggregation
-        run: node scripts/test-reviewed-bundle-aggregation.mjs
-
       - name: Build
         run: npm run build
 

--- a/scripts/build-machine-readable-layer.mjs
+++ b/scripts/build-machine-readable-layer.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { loadReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
 
 const root = process.cwd()
 const publicDir = path.join(root, 'public')
@@ -9,78 +10,6 @@ const mainRoutes = ['/', '/dead/', '/active/', '/exchange/{slug}/', '/stats/', '
 function readJson(relativePath, fallback = []) {
   const filePath = path.join(root, relativePath)
   return fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, 'utf8')) : fallback
-}
-
-function normalizeIdentity(value) {
-  if (!value) return null
-  return String(value).trim().toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/$/, '') || null
-}
-
-function entityIdentityKeys(entity) {
-  return new Set([
-    entity.id,
-    entity.slug,
-    entity.canonical_name,
-    entity.official_domain_original,
-    entity.official_url_original,
-    ...(entity.aliases ?? []),
-  ].map(normalizeIdentity).filter(Boolean))
-}
-
-function loadReviewedBundles(canonicalEntities) {
-  const recordsDir = path.join(root, 'records', 'exchanges')
-  if (!fs.existsSync(recordsDir)) return { all: [], newEntityBundles: [] }
-
-  const seen = new Set(canonicalEntities.flatMap((entity) => [...entityIdentityKeys(entity)]))
-  const all = []
-  const newEntityBundles = []
-
-  for (const fileName of fs.readdirSync(recordsDir).filter((name) => name.endsWith('.json')).sort()) {
-    const bundle = readJson(path.join('records', 'exchanges', fileName), null)
-    if (!bundle?.entity || !Array.isArray(bundle.events) || !Array.isArray(bundle.evidence)) {
-      throw new Error(`${fileName}: expected { entity, events, evidence }`)
-    }
-    const entry = { fileName, bundle }
-    all.push(entry)
-    const keys = entityIdentityKeys(bundle.entity)
-    if ([...keys].some((key) => seen.has(key))) continue
-    newEntityBundles.push(entry)
-    for (const key of keys) seen.add(key)
-  }
-
-  return { all, newEntityBundles }
-}
-
-function stableStringify(value) {
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
-  if (value && typeof value === 'object') {
-    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
-  }
-  return JSON.stringify(value)
-}
-
-function mergeRecords(canonicalRecords, bundles, field, label) {
-  const canonicalIds = new Set()
-  for (const record of canonicalRecords) {
-    if (!record?.id) throw new Error(`canonical data: ${label} record is missing id`)
-    if (canonicalIds.has(record.id)) throw new Error(`canonical data: duplicate ${label} id: ${record.id}`)
-    canonicalIds.add(record.id)
-  }
-
-  const additions = new Map()
-  for (const { fileName, bundle } of bundles) {
-    for (const record of bundle[field]) {
-      if (!record?.id) throw new Error(`${fileName}: ${label} record is missing id`)
-      if (canonicalIds.has(record.id)) continue
-
-      const existing = additions.get(record.id)
-      if (existing && stableStringify(existing) !== stableStringify(record)) {
-        throw new Error(`${fileName}: conflicting ${label} id: ${record.id}`)
-      }
-      additions.set(record.id, record)
-    }
-  }
-  return [...canonicalRecords, ...additions.values()]
 }
 
 function countBy(items, key) {
@@ -112,7 +41,7 @@ function writeText(relativePath, value) {
 const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
 const canonicalEvidence = readJson('data/evidence.json')
-const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(canonicalEntities)
+const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
 const entities = [...canonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
 const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')

--- a/scripts/lib/reviewed-bundle-aggregation.mjs
+++ b/scripts/lib/reviewed-bundle-aggregation.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export function normalizeIdentity(value) {
+  if (!value) return null
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/$/, '') || null
+}
+
+export function entityIdentityKeys(entity) {
+  return new Set([
+    entity.id,
+    entity.slug,
+    entity.canonical_name,
+    entity.official_domain_original,
+    entity.official_url_original,
+    ...(entity.aliases ?? []),
+  ].map(normalizeIdentity).filter(Boolean))
+}
+
+export function classifyReviewedBundles(canonicalEntities, entries) {
+  const seenIdentities = new Set(
+    canonicalEntities.flatMap((entity) => [...entityIdentityKeys(entity)]),
+  )
+  const all = []
+  const newEntityBundles = []
+
+  for (const entry of entries) {
+    const { fileName, bundle } = entry
+    if (!bundle?.entity || !Array.isArray(bundle.events) || !Array.isArray(bundle.evidence)) {
+      throw new Error(`${fileName}: expected { entity, events, evidence }`)
+    }
+
+    all.push(entry)
+    const keys = entityIdentityKeys(bundle.entity)
+    if ([...keys].some((key) => seenIdentities.has(key))) continue
+
+    newEntityBundles.push(entry)
+    for (const key of keys) seenIdentities.add(key)
+  }
+
+  return { all, newEntityBundles }
+}
+
+export function loadReviewedBundles(root, canonicalEntities) {
+  const recordsDir = path.join(root, 'records', 'exchanges')
+  if (!fs.existsSync(recordsDir)) return { all: [], newEntityBundles: [] }
+
+  const entries = fs.readdirSync(recordsDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((fileName) => ({
+      fileName,
+      bundle: JSON.parse(fs.readFileSync(path.join(recordsDir, fileName), 'utf8')),
+    }))
+
+  return classifyReviewedBundles(canonicalEntities, entries)
+}
+
+export function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export function mergeRecords(canonicalRecords, bundles, field, label) {
+  const canonicalIds = new Set()
+  for (const record of canonicalRecords) {
+    if (!record?.id) throw new Error(`canonical data: ${label} record is missing id`)
+    if (canonicalIds.has(record.id)) throw new Error(`canonical data: duplicate ${label} id: ${record.id}`)
+    canonicalIds.add(record.id)
+  }
+
+  const additions = new Map()
+  for (const { fileName, bundle } of bundles) {
+    for (const record of bundle[field]) {
+      if (!record?.id) throw new Error(`${fileName}: ${label} record is missing id`)
+      if (canonicalIds.has(record.id)) continue
+
+      const existing = additions.get(record.id)
+      if (existing && stableStringify(existing) !== stableStringify(record)) {
+        throw new Error(`${fileName}: conflicting ${label} id: ${record.id}`)
+      }
+      additions.set(record.id, record)
+    }
+  }
+
+  return [...canonicalRecords, ...additions.values()]
+}

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { MONITOR_NAMES } from './core/constants.mjs';
 import { monitorRegistryNames, MONITOR_REGISTRY } from './core/monitor-registry.mjs';
 import { loadCanonicalData } from './core/load-canonical-data.mjs';
@@ -30,6 +31,18 @@ function validateMonitorResult(result, expectedName) {
   assert(Number.isInteger(result.summary.errors_count), `${expectedName} summary.errors_count must be integer`);
 }
 
+function runBundleAggregationRegression() {
+  const result = spawnSync(process.execPath, ['scripts/test-reviewed-bundle-aggregation.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+
+  assert(
+    result.status === 0,
+    `reviewed bundle aggregation regression failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
 async function main() {
   assertSameSet(MONITOR_NAMES, monitorRegistryNames(), 'MONITOR_NAMES and MONITOR_REGISTRY are out of sync');
 
@@ -56,6 +69,7 @@ async function main() {
   });
   validateMonitorResult(synthetic, 'smoke-synthetic');
 
+  runBundleAggregationRegression();
   console.log('HEI monitoring smoke test passed.');
 }
 

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -1,8 +1,8 @@
-import { spawnSync } from 'node:child_process';
 import { MONITOR_NAMES } from './core/constants.mjs';
 import { monitorRegistryNames, MONITOR_REGISTRY } from './core/monitor-registry.mjs';
 import { loadCanonicalData } from './core/load-canonical-data.mjs';
 import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
+import { runReviewedBundleAggregationRegression } from '../test-reviewed-bundle-aggregation.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -31,18 +31,6 @@ function validateMonitorResult(result, expectedName) {
   assert(Number.isInteger(result.summary.errors_count), `${expectedName} summary.errors_count must be integer`);
 }
 
-function runBundleAggregationRegression() {
-  const result = spawnSync(process.execPath, ['scripts/test-reviewed-bundle-aggregation.mjs'], {
-    cwd: process.cwd(),
-    encoding: 'utf8',
-  });
-
-  assert(
-    result.status === 0,
-    `reviewed bundle aggregation regression failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-  );
-}
-
 async function main() {
   assertSameSet(MONITOR_NAMES, monitorRegistryNames(), 'MONITOR_NAMES and MONITOR_REGISTRY are out of sync');
 
@@ -69,7 +57,7 @@ async function main() {
   });
   validateMonitorResult(synthetic, 'smoke-synthetic');
 
-  runBundleAggregationRegression();
+  runReviewedBundleAggregationRegression();
   console.log('HEI monitoring smoke test passed.');
 }
 

--- a/scripts/test-reviewed-bundle-aggregation.mjs
+++ b/scripts/test-reviewed-bundle-aggregation.mjs
@@ -1,46 +1,5 @@
 import assert from 'node:assert/strict'
-import { spawnSync } from 'node:child_process'
-import fs from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-
-const repoRoot = process.cwd()
-const buildScript = path.join(repoRoot, 'scripts', 'build-machine-readable-layer.mjs')
-const validateScript = path.join(repoRoot, 'scripts', 'validate-machine-readable-layer.mjs')
-
-async function writeJson(root, relativePath, value) {
-  const filePath = path.join(root, relativePath)
-  await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
-}
-
-async function readJson(root, relativePath) {
-  return JSON.parse(await fs.readFile(path.join(root, relativePath), 'utf8'))
-}
-
-function runNode(script, cwd, { expectFailure = false } = {}) {
-  const result = spawnSync(process.execPath, [script], {
-    cwd,
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      GITHUB_SHA: 'fixture-sha',
-      GITHUB_REF_NAME: 'fixture-branch',
-    },
-  })
-
-  if (expectFailure) {
-    assert.notEqual(result.status, 0, `Expected ${path.basename(script)} to fail`)
-    return result
-  }
-
-  assert.equal(
-    result.status,
-    0,
-    `${path.basename(script)} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-  )
-  return result
-}
+import { classifyReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
 
 function canonicalEntity() {
   return {
@@ -121,74 +80,67 @@ const newEntityEvidence = {
   url: 'https://new-two.test/source',
 }
 
-async function prepareFixture(root) {
-  await writeJson(root, 'data/entities.json', [canonicalEntity()])
-  await writeJson(root, 'data/events.json', [canonicalEvent])
-  await writeJson(root, 'data/evidence.json', [canonicalEvidence])
-
-  await writeJson(root, 'records/exchanges/repair-existing.json', {
-    entity: canonicalEntity(),
-    events: [canonicalEvent, repairEvent],
-    evidence: [canonicalEvidence, repairEvidence],
-  })
-
-  await writeJson(root, 'records/exchanges/add-new-entity.json', {
-    entity: newEntity(),
-    events: [newEntityEvent],
-    evidence: [newEntityEvidence],
-  })
-
-  await writeJson(root, 'records/exchanges/duplicate-new-entity.json', {
-    entity: newEntity(),
-    events: [newEntityEvent],
-    evidence: [newEntityEvidence],
-  })
+function reviewedEntries() {
+  return [
+    {
+      fileName: 'repair-existing.json',
+      bundle: {
+        entity: canonicalEntity(),
+        events: [{ ...canonicalEvent, title: 'Ignored bundle mirror' }, repairEvent],
+        evidence: [{ ...canonicalEvidence, title: 'Ignored evidence mirror' }, repairEvidence],
+      },
+    },
+    {
+      fileName: 'add-new-entity.json',
+      bundle: {
+        entity: newEntity(),
+        events: [newEntityEvent],
+        evidence: [newEntityEvidence],
+      },
+    },
+    {
+      fileName: 'duplicate-new-entity.json',
+      bundle: {
+        entity: newEntity(),
+        events: [newEntityEvent],
+        evidence: [newEntityEvidence],
+      },
+    },
+  ]
 }
 
-async function verifySuccessfulAggregation(root) {
-  runNode(buildScript, root)
+export function runReviewedBundleAggregationRegression() {
+  const canonicalEntities = [canonicalEntity()]
+  const canonicalEvents = [canonicalEvent]
+  const canonicalEvidenceRecords = [canonicalEvidence]
+  const { all, newEntityBundles } = classifyReviewedBundles(canonicalEntities, reviewedEntries())
 
-  const version = await readJson(root, 'public/version.json')
-  const manifest = await readJson(root, 'public/data/manifest.json')
-  const expectedCounts = {
-    primary_records: 2,
-    events: 3,
-    evidence: 3,
-  }
+  const entities = [...canonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+  const events = mergeRecords(canonicalEvents, all, 'events', 'event')
+  const evidence = mergeRecords(canonicalEvidenceRecords, all, 'evidence', 'evidence')
 
-  assert.deepEqual(version.data.record_counts, expectedCounts)
-  assert.deepEqual(manifest.record_counts, expectedCounts)
-  assert.equal(version.data.record_count_breakdown.active_side, 2)
-  assert.equal(version.data.record_count_breakdown.type.cex, 1)
-  assert.equal(version.data.record_count_breakdown.type.dex, 1)
+  assert.equal(entities.length, 2, 'existing-entity repair bundle must not increase entity count')
+  assert.equal(events.length, 3, 'all reviewed bundle events must be included once')
+  assert.equal(evidence.length, 3, 'all reviewed bundle evidence must be included once')
+  assert.equal(events.find((event) => event.id === canonicalEvent.id)?.title, canonicalEvent.title)
+  assert.equal(evidence.find((item) => item.id === canonicalEvidence.id)?.title, canonicalEvidence.title)
 
-  assert.equal(Object.hasOwn(version, 'data_schema_version'), false)
-  assert.equal(Object.hasOwn(version, 'verification_marker'), false)
-  assert.equal(version.data.data_schema_version, 'hei_entity_event_evidence_v1')
-  assert.equal(version.build.verification_marker, 'hei_machine_readable_layer_v1')
+  const conflictingEntries = [
+    ...all,
+    {
+      fileName: 'conflicting-duplicate.json',
+      bundle: {
+        entity: newEntity(),
+        events: [{ ...newEntityEvent, title: 'Conflicting event content' }],
+        evidence: [newEntityEvidence],
+      },
+    },
+  ]
 
-  runNode(validateScript, root)
-}
+  assert.throws(
+    () => mergeRecords(canonicalEvents, conflictingEntries, 'events', 'event'),
+    /conflicting event id: hei_ev_000003/,
+  )
 
-async function verifyBundleConflictFails(root) {
-  await writeJson(root, 'records/exchanges/conflicting-duplicate.json', {
-    entity: newEntity(),
-    events: [{ ...newEntityEvent, title: 'Conflicting event content' }],
-    evidence: [newEntityEvidence],
-  })
-
-  const result = runNode(buildScript, root, { expectFailure: true })
-  const output = `${result.stdout}\n${result.stderr}`
-  assert.match(output, /conflicting event id: hei_ev_000003/)
-}
-
-const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hei-reviewed-bundle-test-'))
-
-try {
-  await prepareFixture(fixtureRoot)
-  await verifySuccessfulAggregation(fixtureRoot)
-  await verifyBundleConflictFails(fixtureRoot)
   console.log('Reviewed bundle aggregation regression test passed.')
-} finally {
-  await fs.rm(fixtureRoot, { recursive: true, force: true })
 }

--- a/scripts/test-reviewed-bundle-aggregation.mjs
+++ b/scripts/test-reviewed-bundle-aggregation.mjs
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const buildScript = path.join(repoRoot, 'scripts', 'build-machine-readable-layer.mjs')
+const validateScript = path.join(repoRoot, 'scripts', 'validate-machine-readable-layer.mjs')
+
+async function writeJson(root, relativePath, value) {
+  const filePath = path.join(root, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+async function readJson(root, relativePath) {
+  return JSON.parse(await fs.readFile(path.join(root, relativePath), 'utf8'))
+}
+
+function runNode(script, cwd, { expectFailure = false } = {}) {
+  const result = spawnSync(process.execPath, [script], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GITHUB_SHA: 'fixture-sha',
+      GITHUB_REF_NAME: 'fixture-branch',
+    },
+  })
+
+  if (expectFailure) {
+    assert.notEqual(result.status, 0, `Expected ${path.basename(script)} to fail`)
+    return result
+  }
+
+  assert.equal(
+    result.status,
+    0,
+    `${path.basename(script)} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  )
+  return result
+}
+
+function canonicalEntity() {
+  return {
+    id: 'hei_ex_000001',
+    slug: 'canonical-one',
+    canonical_name: 'Canonical One',
+    aliases: [],
+    type: 'cex',
+    status: 'active',
+    official_domain_original: 'canonical-one.test',
+    official_url_original: 'https://canonical-one.test/',
+    last_verified_at: '2026-01-01',
+  }
+}
+
+function newEntity() {
+  return {
+    id: 'hei_ex_000002',
+    slug: 'new-two',
+    canonical_name: 'New Two',
+    aliases: [],
+    type: 'dex',
+    status: 'active',
+    official_domain_original: 'new-two.test',
+    official_url_original: 'https://new-two.test/',
+    last_verified_at: '2026-02-01',
+  }
+}
+
+const canonicalEvent = {
+  id: 'hei_ev_000001',
+  exchange_id: 'hei_ex_000001',
+  event_type: 'launched',
+  event_date: '2020-01-01',
+  title: 'Canonical launch',
+}
+
+const repairEvent = {
+  id: 'hei_ev_000002',
+  exchange_id: 'hei_ex_000001',
+  event_type: 'regulatory_action',
+  event_date: '2021-01-01',
+  title: 'Repair event',
+}
+
+const newEntityEvent = {
+  id: 'hei_ev_000003',
+  exchange_id: 'hei_ex_000002',
+  event_type: 'launched',
+  event_date: '2022-01-01',
+  title: 'New entity launch',
+}
+
+const canonicalEvidence = {
+  id: 'hei_src_000001',
+  exchange_id: 'hei_ex_000001',
+  event_id: 'hei_ev_000001',
+  source_type: 'official_statement',
+  title: 'Canonical source',
+  url: 'https://canonical-one.test/source',
+}
+
+const repairEvidence = {
+  id: 'hei_src_000002',
+  exchange_id: 'hei_ex_000001',
+  event_id: 'hei_ev_000002',
+  source_type: 'regulatory_notice',
+  title: 'Repair source',
+  url: 'https://regulator.test/repair',
+}
+
+const newEntityEvidence = {
+  id: 'hei_src_000003',
+  exchange_id: 'hei_ex_000002',
+  event_id: 'hei_ev_000003',
+  source_type: 'official_statement',
+  title: 'New entity source',
+  url: 'https://new-two.test/source',
+}
+
+async function prepareFixture(root) {
+  await writeJson(root, 'data/entities.json', [canonicalEntity()])
+  await writeJson(root, 'data/events.json', [canonicalEvent])
+  await writeJson(root, 'data/evidence.json', [canonicalEvidence])
+
+  await writeJson(root, 'records/exchanges/repair-existing.json', {
+    entity: canonicalEntity(),
+    events: [canonicalEvent, repairEvent],
+    evidence: [canonicalEvidence, repairEvidence],
+  })
+
+  await writeJson(root, 'records/exchanges/add-new-entity.json', {
+    entity: newEntity(),
+    events: [newEntityEvent],
+    evidence: [newEntityEvidence],
+  })
+
+  await writeJson(root, 'records/exchanges/duplicate-new-entity.json', {
+    entity: newEntity(),
+    events: [newEntityEvent],
+    evidence: [newEntityEvidence],
+  })
+}
+
+async function verifySuccessfulAggregation(root) {
+  runNode(buildScript, root)
+
+  const version = await readJson(root, 'public/version.json')
+  const manifest = await readJson(root, 'public/data/manifest.json')
+  const expectedCounts = {
+    primary_records: 2,
+    events: 3,
+    evidence: 3,
+  }
+
+  assert.deepEqual(version.data.record_counts, expectedCounts)
+  assert.deepEqual(manifest.record_counts, expectedCounts)
+  assert.equal(version.data.record_count_breakdown.active_side, 2)
+  assert.equal(version.data.record_count_breakdown.type.cex, 1)
+  assert.equal(version.data.record_count_breakdown.type.dex, 1)
+
+  assert.equal(Object.hasOwn(version, 'data_schema_version'), false)
+  assert.equal(Object.hasOwn(version, 'verification_marker'), false)
+  assert.equal(version.data.data_schema_version, 'hei_entity_event_evidence_v1')
+  assert.equal(version.build.verification_marker, 'hei_machine_readable_layer_v1')
+
+  runNode(validateScript, root)
+}
+
+async function verifyBundleConflictFails(root) {
+  await writeJson(root, 'records/exchanges/conflicting-duplicate.json', {
+    entity: newEntity(),
+    events: [{ ...newEntityEvent, title: 'Conflicting event content' }],
+    evidence: [newEntityEvidence],
+  })
+
+  const result = runNode(buildScript, root, { expectFailure: true })
+  const output = `${result.stdout}\n${result.stderr}`
+  assert.match(output, /conflicting event id: hei_ev_000003/)
+}
+
+const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'hei-reviewed-bundle-test-'))
+
+try {
+  await prepareFixture(fixtureRoot)
+  await verifySuccessfulAggregation(fixtureRoot)
+  await verifyBundleConflictFails(fixtureRoot)
+  console.log('Reviewed bundle aggregation regression test passed.')
+} finally {
+  await fs.rm(fixtureRoot, { recursive: true, force: true })
+}

--- a/scripts/validate-machine-readable-layer.mjs
+++ b/scripts/validate-machine-readable-layer.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { loadReviewedBundles, mergeRecords, stableStringify } from './lib/reviewed-bundle-aggregation.mjs'
 
 const root = process.cwd()
 const publicDir = path.join(root, 'public')
@@ -22,100 +23,6 @@ function readText(relativePath) {
   const filePath = path.join(root, relativePath)
   assert(fs.existsSync(filePath), `missing ${relativePath}`)
   return fs.readFileSync(filePath, 'utf8')
-}
-
-function normalizeIdentity(value) {
-  if (!value) return null
-  const normalized = String(value)
-    .trim()
-    .toLowerCase()
-    .replace(/^https?:\/\//, '')
-    .replace(/^www\./, '')
-    .replace(/\/$/, '')
-  return normalized || null
-}
-
-function entityIdentityKeys(entity) {
-  return new Set(
-    [
-      entity.id,
-      entity.slug,
-      entity.canonical_name,
-      entity.official_domain_original,
-      entity.official_url_original,
-      ...(entity.aliases ?? []),
-    ]
-      .map(normalizeIdentity)
-      .filter(Boolean),
-  )
-}
-
-function loadReviewedBundles(canonicalEntities) {
-  const recordsDir = path.join(root, 'records', 'exchanges')
-  if (!fs.existsSync(recordsDir)) return { all: [], newEntityBundles: [] }
-
-  const seenIdentities = new Set(
-    canonicalEntities.flatMap((entity) => [...entityIdentityKeys(entity)]),
-  )
-  const all = []
-  const newEntityBundles = []
-
-  for (const fileName of fs.readdirSync(recordsDir).filter((name) => name.endsWith('.json')).sort()) {
-    const bundle = JSON.parse(fs.readFileSync(path.join(recordsDir, fileName), 'utf8'))
-    assert(bundle.entity && Array.isArray(bundle.events) && Array.isArray(bundle.evidence), `${fileName} is not a valid record bundle`)
-
-    const entry = { fileName, bundle }
-    all.push(entry)
-
-    const keys = entityIdentityKeys(bundle.entity)
-    if ([...keys].some((key) => seenIdentities.has(key))) continue
-
-    newEntityBundles.push(entry)
-    for (const key of keys) seenIdentities.add(key)
-  }
-
-  return { all, newEntityBundles }
-}
-
-function stableStringify(value) {
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
-  if (value && typeof value === 'object') {
-    return `{${Object.keys(value)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
-      .join(',')}}`
-  }
-  return JSON.stringify(value)
-}
-
-function mergeRecords(canonicalRecords, bundles, field, label) {
-  const canonicalIds = new Set()
-  for (const record of canonicalRecords) {
-    assert(record?.id, `canonical ${label} record is missing id`)
-    assert(!canonicalIds.has(record.id), `duplicate canonical ${label} id ${record.id}`)
-    canonicalIds.add(record.id)
-  }
-
-  const acceptedById = new Map()
-  for (const { fileName, bundle } of bundles) {
-    for (const record of bundle[field]) {
-      assert(record?.id, `${fileName} contains ${label} without id`)
-      if (canonicalIds.has(record.id)) continue
-
-      const existing = acceptedById.get(record.id)
-      if (!existing) {
-        acceptedById.set(record.id, record)
-        continue
-      }
-
-      assert(
-        stableStringify(existing) === stableStringify(record),
-        `${fileName} conflicts with another reviewed bundle for ${label} id ${record.id}`,
-      )
-    }
-  }
-
-  return [...canonicalRecords, ...acceptedById.values()]
 }
 
 function countBy(items, key) {
@@ -146,7 +53,7 @@ const ai = readText('public/ai.txt')
 const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
 const canonicalEvidence = readJson('data/evidence.json')
-const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(canonicalEntities)
+const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
 const entities = [...canonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
 const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
@@ -176,6 +83,8 @@ assert(version.project_id === 'historical-exchange-index', 'version project_id i
 assert(version.registry_family === 'badjoke-lab-ledger-series', 'version registry_family is incorrect')
 assert(version.registry_type === 'historical_crypto_exchange_registry', 'version registry_type is incorrect')
 assert(version.canonical_origin === 'https://hei.badjoke-lab.com', 'version canonical_origin is incorrect')
+assert(!Object.hasOwn(version, 'data_schema_version'), 'data_schema_version must not be a top-level version field')
+assert(!Object.hasOwn(version, 'verification_marker'), 'verification_marker must not be a top-level version field')
 assert(version.build?.verification_marker === 'hei_machine_readable_layer_v1', 'verification marker is incorrect')
 assert(version.build?.commit === expectedCommit(), 'build commit does not match deployment environment')
 assert(version.build?.branch === expectedBranch(), 'build branch does not match deployment environment')


### PR DESCRIPTION
Superseded by PR #376.

The final code in #375 was valid and passed CI, but its branch history temporarily included a GitHub Actions workflow edit and an earlier child-process-based test implementation. The merge safety check rejected that history even after the final diff was cleaned.

PR #376 was recreated from current main with only the final shared-module implementation, pure in-memory regression fixture, generator/validator updates, and smoke-test connection. No canonical data or workflow files are changed.