### PR TITLE
Schedule read-only HEI monthly reviews

### DIFF
--- a/.github/workflows/hei-monthly-review.yml
+++ b/.github/workflows/hei-monthly-review.yml
@@ -1,0 +1,209 @@
+name: HEI Monthly Review
+
+on:
+  schedule:
+    - cron: "0 4 1 * *"
+  workflow_dispatch:
+    inputs:
+      review_month:
+        description: "Review month in YYYY-MM; blank uses the previous UTC month"
+        type: string
+        required: false
+        default: ""
+      overwrite_existing:
+        description: "Regenerate a month already present on main"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: hei-monthly-review
+  cancel-in-progress: false
+
+jobs:
+  monthly-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Determine review month
+        id: month
+        env:
+          MANUAL_REVIEW_MONTH: ${{ github.event.inputs.review_month || '' }}
+          MANUAL_OVERWRITE: ${{ github.event.inputs.overwrite_existing || 'false' }}
+        run: |
+          if [ -n "$MANUAL_REVIEW_MONTH" ]; then
+            REVIEW_MONTH="$MANUAL_REVIEW_MONTH"
+          else
+            REVIEW_MONTH="$(date -u -d 'last month' +%Y-%m)"
+          fi
+
+          if ! printf '%s' "$REVIEW_MONTH" | grep -Eq '^[0-9]{4}-(0[1-9]|1[0-2])$'; then
+            echo "Invalid review month: $REVIEW_MONTH"
+            exit 1
+          fi
+
+          echo "review_month=$REVIEW_MONTH" >> "$GITHUB_OUTPUT"
+          echo "overwrite_existing=$MANUAL_OVERWRITE" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing review or open PR
+        id: preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+          OVERWRITE_EXISTING: ${{ steps.month.outputs.overwrite_existing }}
+        run: |
+          OUTPUT_DIR="data-staging/monthly-reviews/$REVIEW_MONTH"
+          if git ls-files --error-unmatch "$OUTPUT_DIR/manifest.json" >/dev/null 2>&1 \
+            && [ "$OVERWRITE_EXISTING" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh pr list --state open --limit 100 --json title > /tmp/open-prs.json
+          OPEN_COUNT="$(jq --arg title "Monthly review: $REVIEW_MONTH" '[.[] | select(.title == $title)] | length' /tmp/open-prs.json)"
+          if [ "$OPEN_COUNT" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test review modules
+        if: steps.preflight.outputs.skip != 'true'
+        run: npm run monitor:smoke
+
+      - name: Import unmerged weekly monitoring PR outputs
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+        run: |
+          IMPORT_ROOT="data-staging/monthly-review-input/$REVIEW_MONTH"
+          rm -rf "$IMPORT_ROOT"
+          mkdir -p "$IMPORT_ROOT"
+
+          gh pr list --state all --limit 200 --json number,title,mergedAt > /tmp/monitoring-prs.json
+          jq -r --arg prefix "Auto monitoring report: $REVIEW_MONTH-" '
+            [.[] | select(.title | startswith($prefix))]
+            | group_by(.title)
+            | map(select((any(.[]; .mergedAt != null)) | not) | sort_by(.number) | last)
+            | .[].number
+          ' /tmp/monitoring-prs.json > /tmp/monthly-monitoring-pr-numbers.txt
+
+          while IFS= read -r PR_NUMBER; do
+            [ -n "$PR_NUMBER" ] || continue
+            REF="refs/remotes/origin/monthly-pr-$PR_NUMBER"
+            git fetch --no-tags origin "pull/$PR_NUMBER/head:$REF"
+            gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > "/tmp/pr-$PR_NUMBER-files.txt"
+
+            while IFS= read -r FILE_PATH; do
+              case "$FILE_PATH" in
+                data-staging/monitoring/*|data-staging/watchlists/auto/*|data-staging/watchlists/resolution/*)
+                  TARGET="$IMPORT_ROOT/${FILE_PATH#data-staging/}"
+                  mkdir -p "$(dirname "$TARGET")"
+                  git show "$REF:$FILE_PATH" > "$TARGET"
+                  ;;
+                *)
+                  echo "Ignoring non-monitoring PR file: $FILE_PATH"
+                  ;;
+              esac
+            done < "/tmp/pr-$PR_NUMBER-files.txt"
+          done < /tmp/monthly-monitoring-pr-numbers.txt
+
+      - name: Build current machine-readable counts
+        if: steps.preflight.outputs.skip != 'true'
+        run: npm run machine:build
+
+      - name: Build monthly review
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+        run: node scripts/review/build-monthly-review.mjs --month "$REVIEW_MONTH"
+
+      - name: Validate monthly review
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+        run: node scripts/review/validate-monthly-review.mjs --month "$REVIEW_MONTH"
+
+      - name: Remove temporary imported inputs
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+        run: rm -rf "data-staging/monthly-review-input/$REVIEW_MONTH"
+
+      - name: Guard canonical data files
+        if: steps.preflight.outputs.skip != 'true'
+        run: |
+          if git status --porcelain -- data/entities.json data/events.json data/evidence.json | grep .; then
+            echo "Monthly review must not modify canonical data files."
+            exit 1
+          fi
+
+      - name: Check monthly review changes
+        if: steps.preflight.outputs.skip != 'true'
+        id: changes
+        env:
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+        run: |
+          OUTPUT_DIR="data-staging/monthly-reviews/$REVIEW_MONTH"
+          if git status --porcelain -- "$OUTPUT_DIR" | grep .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create monthly review pull request
+        if: steps.preflight.outputs.skip != 'true' && steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
+        run: |
+          OUTPUT_DIR="data-staging/monthly-reviews/$REVIEW_MONTH"
+          BRANCH="auto/monthly-review/$REVIEW_MONTH-$(date -u +%Y%m%d-%H%M%S)"
+          BODY_FILE="/tmp/hei-monthly-review-pr-body.md"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "$OUTPUT_DIR"
+          git commit -m "Add HEI monthly review $REVIEW_MONTH"
+          git push origin "$BRANCH"
+
+          echo "## HEI monthly review" > "$BODY_FILE"
+          echo "" >> "$BODY_FILE"
+          echo "Review month: $REVIEW_MONTH" >> "$BODY_FILE"
+          echo "" >> "$BODY_FILE"
+          cat "$OUTPUT_DIR/summary.md" >> "$BODY_FILE"
+          echo "" >> "$BODY_FILE"
+          echo "Canonical data files are not changed by this PR." >> "$BODY_FILE"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Monthly review: $REVIEW_MONTH" \
+            --body-file "$BODY_FILE"

--- a/.github/workflows/hei-monthly-review.yml
+++ b/.github/workflows/hei-monthly-review.yml
@@ -10,15 +10,10 @@ on:
         type: string
         required: false
         default: ""
-      overwrite_existing:
-        description: "Regenerate a month already present on main"
-        type: boolean
-        required: false
-        default: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -53,7 +48,6 @@ jobs:
         id: month
         env:
           MANUAL_REVIEW_MONTH: ${{ github.event.inputs.review_month || '' }}
-          MANUAL_OVERWRITE: ${{ github.event.inputs.overwrite_existing || 'false' }}
         run: |
           if [ -n "$MANUAL_REVIEW_MONTH" ]; then
             REVIEW_MONTH="$MANUAL_REVIEW_MONTH"
@@ -67,37 +61,12 @@ jobs:
           fi
 
           echo "review_month=$REVIEW_MONTH" >> "$GITHUB_OUTPUT"
-          echo "overwrite_existing=$MANUAL_OVERWRITE" >> "$GITHUB_OUTPUT"
-
-      - name: Check for existing review or open PR
-        id: preflight
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
-          OVERWRITE_EXISTING: ${{ steps.month.outputs.overwrite_existing }}
-        run: |
-          OUTPUT_DIR="data-staging/monthly-reviews/$REVIEW_MONTH"
-          if git ls-files --error-unmatch "$OUTPUT_DIR/manifest.json" >/dev/null 2>&1 \
-            && [ "$OVERWRITE_EXISTING" != "true" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          gh pr list --state open --limit 100 --json title > /tmp/open-prs.json
-          OPEN_COUNT="$(jq --arg title "Monthly review: $REVIEW_MONTH" '[.[] | select(.title == $title)] | length' /tmp/open-prs.json)"
-          if [ "$OPEN_COUNT" -gt 0 ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "Review month: $REVIEW_MONTH"
 
       - name: Smoke test review modules
-        if: steps.preflight.outputs.skip != 'true'
         run: npm run monitor:smoke
 
       - name: Import unmerged weekly monitoring PR outputs
-        if: steps.preflight.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
@@ -117,15 +86,24 @@ jobs:
           while IFS= read -r PR_NUMBER; do
             [ -n "$PR_NUMBER" ] || continue
             REF="refs/remotes/origin/monthly-pr-$PR_NUMBER"
+            echo "Importing monitoring PR #$PR_NUMBER"
             git fetch --no-tags origin "pull/$PR_NUMBER/head:$REF"
             gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > "/tmp/pr-$PR_NUMBER-files.txt"
 
             while IFS= read -r FILE_PATH; do
               case "$FILE_PATH" in
+                /*|*..*)
+                  echo "Invalid monitoring path: $FILE_PATH"
+                  exit 1
+                  ;;
                 data-staging/monitoring/*|data-staging/watchlists/auto/*|data-staging/watchlists/resolution/*)
-                  TARGET="$IMPORT_ROOT/${FILE_PATH#data-staging/}"
-                  mkdir -p "$(dirname "$TARGET")"
-                  git show "$REF:$FILE_PATH" > "$TARGET"
+                  if git cat-file -e "$REF:$FILE_PATH" 2>/dev/null; then
+                    TARGET="$IMPORT_ROOT/${FILE_PATH#data-staging/}"
+                    mkdir -p "$(dirname "$TARGET")"
+                    git show "$REF:$FILE_PATH" > "$TARGET"
+                  else
+                    echo "Skipping deleted monitoring file: $FILE_PATH"
+                  fi
                   ;;
                 *)
                   echo "Ignoring non-monitoring PR file: $FILE_PATH"
@@ -135,75 +113,39 @@ jobs:
           done < /tmp/monthly-monitoring-pr-numbers.txt
 
       - name: Build current machine-readable counts
-        if: steps.preflight.outputs.skip != 'true'
         run: npm run machine:build
 
       - name: Build monthly review
-        if: steps.preflight.outputs.skip != 'true'
         env:
           REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
         run: node scripts/review/build-monthly-review.mjs --month "$REVIEW_MONTH"
 
       - name: Validate monthly review
-        if: steps.preflight.outputs.skip != 'true'
         env:
           REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
         run: node scripts/review/validate-monthly-review.mjs --month "$REVIEW_MONTH"
 
       - name: Remove temporary imported inputs
-        if: steps.preflight.outputs.skip != 'true'
         env:
           REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
         run: rm -rf "data-staging/monthly-review-input/$REVIEW_MONTH"
 
       - name: Guard canonical data files
-        if: steps.preflight.outputs.skip != 'true'
         run: |
           if git status --porcelain -- data/entities.json data/events.json data/evidence.json | grep .; then
             echo "Monthly review must not modify canonical data files."
             exit 1
           fi
 
-      - name: Check monthly review changes
-        if: steps.preflight.outputs.skip != 'true'
-        id: changes
+      - name: Publish summary
         env:
           REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
-        run: |
-          OUTPUT_DIR="data-staging/monthly-reviews/$REVIEW_MONTH"
-          if git status --porcelain -- "$OUTPUT_DIR" | grep .; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: cat "data-staging/monthly-reviews/$REVIEW_MONTH/summary.md" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Create monthly review pull request
-        if: steps.preflight.outputs.skip != 'true' && steps.changes.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REVIEW_MONTH: ${{ steps.month.outputs.review_month }}
-        run: |
-          OUTPUT_DIR="data-staging/monthly-reviews/$REVIEW_MONTH"
-          BRANCH="auto/monthly-review/$REVIEW_MONTH-$(date -u +%Y%m%d-%H%M%S)"
-          BODY_FILE="/tmp/hei-monthly-review-pr-body.md"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-          git add "$OUTPUT_DIR"
-          git commit -m "Add HEI monthly review $REVIEW_MONTH"
-          git push origin "$BRANCH"
-
-          echo "## HEI monthly review" > "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "Review month: $REVIEW_MONTH" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          cat "$OUTPUT_DIR/summary.md" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "Canonical data files are not changed by this PR." >> "$BODY_FILE"
-
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "Monthly review: $REVIEW_MONTH" \
-            --body-file "$BODY_FILE"
+      - name: Upload monthly review artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: hei-monthly-review-${{ steps.month.outputs.review_month }}
+          path: data-staging/monthly-reviews/${{ steps.month.outputs.review_month }}
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -7,6 +7,7 @@ import { buildRegistryMetrics, parseReviewMonth } from '../review/monthly-regist
 import { runMonthlyWatchlistBacklogRegression } from '../review/test-monthly-watchlist-core.mjs';
 import { runMonthlyReviewBuilderRegression } from '../review/test-monthly-review-builder.mjs';
 import { runMonthlyReviewIntegrationRegression } from '../review/test-monthly-review-integration.mjs';
+import { runMonthlyReviewWorkflowRegression } from '../review/test-monthly-review-workflow.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -65,6 +66,7 @@ async function main() {
   runMonthlyWatchlistBacklogRegression();
   runMonthlyReviewBuilderRegression();
   await runMonthlyReviewIntegrationRegression();
+  runMonthlyReviewWorkflowRegression();
 
   const reviewMonth = parseReviewMonth('2026-05');
   const monthlyMetrics = buildRegistryMetrics(canonicalData, reviewMonth);

--- a/scripts/review/test-monthly-review-workflow.mjs
+++ b/scripts/review/test-monthly-review-workflow.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+export function runMonthlyReviewWorkflowRegression() {
+  const workflow = fs.readFileSync('.github/workflows/hei-monthly-review.yml', 'utf8')
+
+  const requiredSnippets = [
+    'cron: "0 4 1 * *"',
+    'workflow_dispatch:',
+    'review_month:',
+    'overwrite_existing:',
+    'contents: write',
+    'pull-requests: write',
+    'ref: main',
+    'fetch-depth: 0',
+    "date -u -d 'last month' +%Y-%m",
+    'gh pr list --state all --limit 200 --json number,title,mergedAt',
+    'Auto monitoring report: $REVIEW_MONTH-',
+    'any(.[]; .mergedAt != null)',
+    'pull/$PR_NUMBER/head:$REF',
+    'data-staging/monthly-review-input/$REVIEW_MONTH',
+    'npm run machine:build',
+    'node scripts/review/build-monthly-review.mjs --month "$REVIEW_MONTH"',
+    'node scripts/review/validate-monthly-review.mjs --month "$REVIEW_MONTH"',
+    'data/entities.json data/events.json data/evidence.json',
+    'git add "$OUTPUT_DIR"',
+    '--title "Monthly review: $REVIEW_MONTH"',
+  ]
+
+  for (const snippet of requiredSnippets) {
+    assert(workflow.includes(snippet), `monthly review workflow is missing: ${snippet}`)
+  }
+
+  assert.equal(workflow.includes('git add .'), false)
+  assert.equal(workflow.includes('git add data/entities.json'), false)
+  assert.equal(workflow.includes('git add data/events.json'), false)
+  assert.equal(workflow.includes('git add data/evidence.json'), false)
+
+  console.log('Monthly review workflow regression test passed.')
+}

--- a/scripts/review/test-monthly-review-workflow.mjs
+++ b/scripts/review/test-monthly-review-workflow.mjs
@@ -8,9 +8,8 @@ export function runMonthlyReviewWorkflowRegression() {
     'cron: "0 4 1 * *"',
     'workflow_dispatch:',
     'review_month:',
-    'overwrite_existing:',
-    'contents: write',
-    'pull-requests: write',
+    'contents: read',
+    'pull-requests: read',
     'ref: main',
     'fetch-depth: 0',
     "date -u -d 'last month' +%Y-%m",
@@ -19,22 +18,31 @@ export function runMonthlyReviewWorkflowRegression() {
     'any(.[]; .mergedAt != null)',
     'pull/$PR_NUMBER/head:$REF',
     'data-staging/monthly-review-input/$REVIEW_MONTH',
+    'Invalid monitoring path: $FILE_PATH',
     'npm run machine:build',
     'node scripts/review/build-monthly-review.mjs --month "$REVIEW_MONTH"',
     'node scripts/review/validate-monthly-review.mjs --month "$REVIEW_MONTH"',
     'data/entities.json data/events.json data/evidence.json',
-    'git add "$OUTPUT_DIR"',
-    '--title "Monthly review: $REVIEW_MONTH"',
+    'actions/upload-artifact@v6',
+    'hei-monthly-review-${{ steps.month.outputs.review_month }}',
+    'if-no-files-found: error',
+    'retention-days: 30',
   ]
 
   for (const snippet of requiredSnippets) {
     assert(workflow.includes(snippet), `monthly review workflow is missing: ${snippet}`)
   }
 
-  assert.equal(workflow.includes('git add .'), false)
-  assert.equal(workflow.includes('git add data/entities.json'), false)
-  assert.equal(workflow.includes('git add data/events.json'), false)
-  assert.equal(workflow.includes('git add data/evidence.json'), false)
+  for (const forbidden of [
+    'contents: write',
+    'pull-requests: write',
+    'git add .',
+    'git push',
+    'gh pr create',
+    'git checkout -b',
+  ]) {
+    assert.equal(workflow.includes(forbidden), false, `monthly review workflow must not contain: ${forbidden}`)
+  }
 
   console.log('Monthly review workflow regression test passed.')
 }


### PR DESCRIPTION
Adds the scheduled, read-only HEI monthly review workflow.

- runs at 04:00 UTC on the first day of each month
- supports a manual YYYY-MM override
- imports approved monitoring-output paths from the latest unmerged weekly monitoring PR for each report date
- builds the current machine-readable counts before review generation
- builds and validates all nine monthly review artifacts
- rejects unsafe monitoring paths and guards canonical data files
- publishes the generated summary to the workflow run
- uploads the validated monthly review as a 30-day GitHub Actions artifact
- uses contents: read and pull-requests: read only
- does not create branches, push commits, or open pull requests

No canonical data or public-route changes.