### PR TITLE
Clarify monthly snapshot timing

### DIFF
--- a/scripts/review/build-monthly-review.mjs
+++ b/scripts/review/build-monthly-review.mjs
@@ -22,6 +22,8 @@ const OUTPUT_FILES = [
   'next-month-plan.md',
 ]
 
+const REGISTRY_SNAPSHOT_BASIS = 'current_reviewed_registry_at_generation_time'
+
 function parseArgs(argv) {
   const args = { month: null }
   for (let index = 2; index < argv.length; index += 1) {
@@ -92,6 +94,36 @@ async function loadMonitoringManifests(directory, monthInfo, warnings) {
   return manifests
 }
 
+function applyRegistrySnapshotSemantics(registryReview, canonicalData, generatedAt) {
+  const snapshotTime = Date.parse(generatedAt)
+  if (!Number.isFinite(snapshotTime)) {
+    throw new Error(`Invalid monthly review generation timestamp: ${generatedAt}`)
+  }
+
+  const staleBefore = new Date(snapshotTime)
+  staleBefore.setUTCFullYear(staleBefore.getUTCFullYear() - 1)
+  const staleRecords = (canonicalData.entities || []).filter((entity) => {
+    const timestamp = Date.parse(entity.last_verified_at)
+    return Number.isFinite(timestamp) && timestamp < staleBefore.getTime()
+  }).length
+
+  registryReview.metrics = {
+    ...registryReview.metrics,
+    review_period: {
+      start: registryReview.monthInfo.start_iso,
+      end: registryReview.monthInfo.end_iso,
+    },
+    snapshot_basis: REGISTRY_SNAPSHOT_BASIS,
+    generated_as_of: generatedAt,
+    quality: {
+      ...registryReview.metrics.quality,
+      last_verified_older_than_one_year: staleRecords,
+    },
+  }
+
+  return registryReview
+}
+
 function buildNextMonthPlan(registryReview, watchlistBacklog) {
   const priorities = []
   const add = (action, count) => {
@@ -118,6 +150,9 @@ function buildSummary(month, registryReview, watchlistBacklog, nextMonthPlan, wa
     `# HEI Monthly Review - ${month}`,
     '',
     '## Registry snapshot',
+    `- Review period: ${metrics.review_period.start} to ${metrics.review_period.end}`,
+    `- Registry snapshot generated: ${metrics.generated_as_of}`,
+    `- Snapshot basis: ${metrics.snapshot_basis}`,
     `- Entities: ${metrics.counts.entities}`,
     `- Events: ${metrics.counts.events}`,
     `- Evidence: ${metrics.counts.evidence}`,
@@ -192,14 +227,14 @@ export function buildMonthlyReviewArtifacts({
   generatedAt = new Date().toISOString(),
 }) {
   parseReviewMonth(month)
-  const registryReview = buildMonthlyRegistryReview({
+  const registryReview = applyRegistrySnapshotSemantics(buildMonthlyRegistryReview({
     month,
     canonicalData,
     monitoringManifests,
     previousMetrics,
     publicVersion,
     publicManifest,
-  })
+  }), canonicalData, generatedAt)
   const watchlistBacklog = buildWatchlistBacklog(
     watchlists,
     resolutionDocuments,
@@ -211,7 +246,12 @@ export function buildMonthlyReviewArtifacts({
     'manifest.json': {
       schema_version: 1,
       review_month: month,
+      review_period: registryReview.metrics.review_period,
       generated_at: generatedAt,
+      registry_snapshot: {
+        basis: REGISTRY_SNAPSHOT_BASIS,
+        generated_at: generatedAt,
+      },
       canonical_data_changed: false,
       output_files: OUTPUT_FILES,
       source_counts: {

--- a/scripts/review/test-monthly-review-builder.mjs
+++ b/scripts/review/test-monthly-review-builder.mjs
@@ -102,6 +102,7 @@ export function runMonthlyReviewBuilderRegression() {
     },
   }
 
+  const generatedAt = '2026-06-01T04:00:00.000Z'
   const publicCounts = { primary_records: 2, events: 2, evidence: 2 }
   const artifacts = buildMonthlyReviewArtifacts({
     month: '2026-05',
@@ -112,7 +113,7 @@ export function runMonthlyReviewBuilderRegression() {
     previousMetrics,
     publicVersion: { data: { record_counts: publicCounts } },
     publicManifest: { record_counts: publicCounts },
-    generatedAt: '2026-06-01T04:00:00.000Z',
+    generatedAt,
   })
 
   assert.deepEqual(Object.keys(artifacts), [
@@ -127,7 +128,19 @@ export function runMonthlyReviewBuilderRegression() {
     'next-month-plan.md',
   ])
   assert.equal(artifacts['manifest.json'].review_month, '2026-05')
+  assert.deepEqual(artifacts['manifest.json'].review_period, {
+    start: '2026-05-01T00:00:00.000Z',
+    end: '2026-05-31T23:59:59.999Z',
+  })
+  assert.deepEqual(artifacts['manifest.json'].registry_snapshot, {
+    basis: 'current_reviewed_registry_at_generation_time',
+    generated_at: generatedAt,
+  })
   assert.equal(artifacts['manifest.json'].canonical_data_changed, false)
+  assert.equal(artifacts['metrics.json'].generated_as_of, generatedAt)
+  assert.equal(artifacts['metrics.json'].snapshot_basis, 'current_reviewed_registry_at_generation_time')
+  assert.deepEqual(artifacts['metrics.json'].review_period, artifacts['manifest.json'].review_period)
+  assert.notEqual(artifacts['metrics.json'].generated_as_of, artifacts['metrics.json'].review_period.end)
   assert.equal(artifacts['metrics.json'].counts.entities, 2)
   assert.equal(artifacts['monitoring-health.json'].observed_unique_runs, 1)
   assert.equal(artifacts['watchlist-backlog.json'].aging.b_90_plus, 1)
@@ -135,6 +148,8 @@ export function runMonthlyReviewBuilderRegression() {
   assert.equal(artifacts['quality-delta.json'].counts.entities, 1)
   assert.equal(artifacts['consistency-check.json'].status, 'pass')
   assert.equal(artifacts['event-snapshot.json'].total, 1)
+  assert.match(artifacts['summary.md'], /Registry snapshot generated: 2026-06-01T04:00:00.000Z/)
+  assert.match(artifacts['summary.md'], /Snapshot basis: current_reviewed_registry_at_generation_time/)
   assert.match(artifacts['summary.md'], /## Watchlist backlog/)
   assert.match(artifacts['summary.md'], /## Next-month priorities/)
   assert.match(artifacts['next-month-plan.md'], /Reclassify B candidates open for 90\+ days/)


### PR DESCRIPTION
Separates the monthly review period from the registry snapshot generation time. Adds explicit period and snapshot metadata, updates summary output, and extends regression coverage. Canonical data and public routes are unchanged.