### PR TITLE
Add guarded reviewed entity corrections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Validate reviewed record bundles
+        run: npm run records:validate
+
       - name: Smoke test monitoring modules
         run: npm run monitor:smoke
 

--- a/scripts/audit-record-entity-overlaps.mjs
+++ b/scripts/audit-record-entity-overlaps.mjs
@@ -1,14 +1,13 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
 
 const root = process.cwd()
 const entitiesPath = path.join(root, 'data', 'entities.json')
 const recordsDir = path.join(root, 'records', 'exchanges')
 
 const allowedEntityOverlapPairs = new Set([
-  // Prior methodology decision: Bittrex and Bittrex Global are separate entities even though they share bittrex.com history.
   'hei_ex_000031|hei_ex_000397',
-  // Generic shared BitTrade alias; BitTrade Australia and the later BitTrade record are retained separately pending a relationship decision.
   'hei_ex_000285|hei_ex_000396',
 ])
 
@@ -21,17 +20,13 @@ function readJson(filePath) {
 }
 
 function stableStringify(value) {
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(',')}]`
-  }
-
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`
   if (value && typeof value === 'object') {
     return `{${Object.keys(value)
       .sort()
       .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
       .join(',')}}`
   }
-
   return JSON.stringify(value)
 }
 
@@ -82,40 +77,55 @@ function identitySet(entity) {
   }
 }
 
-function loadRecords() {
-  const records = []
-  for (const entity of readJson(entitiesPath)) {
-    records.push({
-      source: 'data/entities.json',
-      file: null,
-      entity,
-      identity: identitySet(entity),
-    })
-  }
-
-  if (fs.existsSync(recordsDir)) {
-    for (const fileName of fs.readdirSync(recordsDir).filter((name) => name.endsWith('.json')).sort()) {
+function loadBundleEntries() {
+  if (!fs.existsSync(recordsDir)) return []
+  return fs.readdirSync(recordsDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((fileName) => {
       const filePath = path.join(recordsDir, fileName)
-      const bundle = readJson(filePath)
-      if (!bundle.entity) continue
-      records.push({
-        source: 'records/exchanges',
-        file: path.relative(root, filePath),
-        entity: bundle.entity,
-        identity: identitySet(bundle.entity),
-      })
-    }
+      return { fileName, bundle: readJson(filePath), filePath }
+    })
+}
+
+const canonicalEntities = readJson(entitiesPath)
+const bundleEntries = loadBundleEntries()
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, bundleEntries)
+const originalCanonicalById = new Map(canonicalEntities.map((entity) => [entity.id, entity]))
+const correctedCanonicalById = new Map(correctedCanonicalEntities.map((entity) => [entity.id, entity]))
+
+function loadRecords() {
+  const records = canonicalEntities.map((entity) => ({
+    source: 'data/entities.json',
+    file: null,
+    entity,
+    bundle: null,
+    identity: identitySet(entity),
+  }))
+
+  for (const entry of bundleEntries) {
+    if (!entry.bundle.entity) continue
+    records.push({
+      source: 'records/exchanges',
+      file: path.relative(root, entry.filePath),
+      entity: entry.bundle.entity,
+      bundle: entry.bundle,
+      identity: identitySet(entry.bundle.entity),
+    })
   }
 
   return records
 }
 
-function isExactCanonicalMirrorPair(left, right) {
+function isAllowedCanonicalMirrorPair(left, right) {
   const canonical = left.source === 'data/entities.json' ? left : right.source === 'data/entities.json' ? right : null
-  const bundle = left.source === 'records/exchanges' ? left : right.source === 'records/exchanges' ? right : null
+  const bundleRecord = left.source === 'records/exchanges' ? left : right.source === 'records/exchanges' ? right : null
+  if (!canonical || !bundleRecord || !canonical.entity.id || canonical.entity.id !== bundleRecord.entity.id) return false
 
-  if (!canonical || !bundle || !canonical.entity.id || canonical.entity.id !== bundle.entity.id) return false
-  return stableStringify(canonical.entity) === stableStringify(bundle.entity)
+  const reference = bundleRecord.bundle?.entity_correction
+    ? correctedCanonicalById.get(bundleRecord.entity.id)
+    : originalCanonicalById.get(bundleRecord.entity.id)
+  return Boolean(reference && stableStringify(reference) === stableStringify(bundleRecord.entity))
 }
 
 function intersections(left, right) {
@@ -124,53 +134,43 @@ function intersections(left, right) {
 
 function compare(left, right) {
   const reasons = []
-
   if (left.identity.id && left.identity.id === right.identity.id) reasons.push(`id:${left.identity.id}`)
   if (left.identity.slug && left.identity.slug === right.identity.slug) reasons.push(`slug:${left.identity.slug}`)
-
-  for (const value of intersections(left.identity.names, right.identity.names)) {
-    reasons.push(`name-or-alias:${value}`)
-  }
-  for (const value of intersections(left.identity.domains, right.identity.domains)) {
-    reasons.push(`domain:${value}`)
-  }
-
+  for (const value of intersections(left.identity.names, right.identity.names)) reasons.push(`name-or-alias:${value}`)
+  for (const value of intersections(left.identity.domains, right.identity.domains)) reasons.push(`domain:${value}`)
   return [...new Set(reasons)]
 }
 
 const records = loadRecords()
 const collisions = []
 const allowedCollisions = []
-let exactMirrorPairs = 0
+let allowedMirrorPairs = 0
 
 for (let i = 0; i < records.length; i += 1) {
   for (let j = i + 1; j < records.length; j += 1) {
     const left = records[i]
     const right = records[j]
-
     if (left.source !== 'records/exchanges' && right.source !== 'records/exchanges') continue
 
-    if (isExactCanonicalMirrorPair(left, right)) {
-      exactMirrorPairs += 1
+    if (isAllowedCanonicalMirrorPair(left, right)) {
+      allowedMirrorPairs += 1
       continue
     }
 
     const reasons = compare(left, right)
     if (reasons.length === 0) continue
-
     const collision = { left, right, reasons }
     if (allowedEntityOverlapPairs.has(pairKey(left, right))) {
       allowedCollisions.push(collision)
       continue
     }
-
     collisions.push(collision)
   }
 }
 
 if (collisions.length === 0) {
   const notes = []
-  if (exactMirrorPairs) notes.push(`${exactMirrorPairs} exact canonical mirror pair(s) allowed for repair bundles`)
+  if (allowedMirrorPairs) notes.push(`${allowedMirrorPairs} reviewed canonical mirror pair(s) allowed`)
   if (allowedCollisions.length) notes.push(`${allowedCollisions.length} documented overlap pair(s) allowed`)
   const suffix = notes.length ? ` (${notes.join('; ')}).` : '.'
   console.log(`No blocking entity overlaps detected across ${records.length} canonical and bundle records${suffix}`)
@@ -182,12 +182,8 @@ for (const collision of collisions) {
   const { left, right, reasons } = collision
   console.error('\n---')
   console.error(`reasons: ${reasons.join(', ')}`)
-  console.error(
-    `left: ${left.source}${left.file ? `/${left.file}` : ''} :: ${left.entity.id} :: ${left.entity.slug} :: ${left.entity.canonical_name}`,
-  )
-  console.error(
-    `right: ${right.source}${right.file ? `/${right.file}` : ''} :: ${right.entity.id} :: ${right.entity.slug} :: ${right.entity.canonical_name}`,
-  )
+  console.error(`left: ${left.source}${left.file ? `/${left.file}` : ''} :: ${left.entity.id} :: ${left.entity.slug} :: ${left.entity.canonical_name}`)
+  console.error(`right: ${right.source}${right.file ? `/${right.file}` : ''} :: ${right.entity.id} :: ${right.entity.slug} :: ${right.entity.canonical_name}`)
 }
 
 process.exit(1)

--- a/scripts/build-data-from-records.mjs
+++ b/scripts/build-data-from-records.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs';
 
 const ROOT = process.cwd();
 const RECORD_DIR = path.join(ROOT, 'records', 'exchanges');
@@ -63,6 +64,13 @@ const evidencePath = path.join(DATA_DIR, 'evidence.json');
 const entities = readJson(entityPath);
 const events = readJson(eventPath);
 const evidence = readJson(evidencePath);
+const recordEntries = listRecordFiles().map((filePath) => ({
+  fileName: path.basename(filePath),
+  filePath,
+  bundle: readJson(filePath),
+}));
+const correctedEntities = applyReviewedEntityCorrections(entities, recordEntries);
+const correctedEntityById = new Map(correctedEntities.map((entity) => [entity.id, entity]));
 
 const entityById = new Map(entities.map((entity) => [entity.id, entity]));
 const eventById = new Map(events.map((event) => [event.id, event]));
@@ -72,17 +80,23 @@ let bundleCount = 0;
 let addedEntities = 0;
 let addedEvents = 0;
 let addedEvidence = 0;
+let correctionBundles = 0;
 let unchangedEntries = 0;
 
-for (const filePath of listRecordFiles()) {
-  const bundle = readJson(filePath);
+for (const { filePath, bundle } of recordEntries) {
   bundleCount += 1;
 
   if (!bundle.entity || !Array.isArray(bundle.events) || !Array.isArray(bundle.evidence)) {
     throw new Error(`${filePath}: expected { entity, events, evidence }`);
   }
 
-  if (addOrVerify(entityById, bundle.entity, filePath, 'entity') === 'added') {
+  if (bundle.entity_correction) {
+    const corrected = correctedEntityById.get(bundle.entity.id);
+    if (!corrected || stableStringify(corrected) !== stableStringify(bundle.entity)) {
+      throw new Error(`${filePath}: correction bundle entity does not match guarded correction result`);
+    }
+    correctionBundles += 1;
+  } else if (addOrVerify(entityById, bundle.entity, filePath, 'entity') === 'added') {
     addedEntities += 1;
   } else {
     unchangedEntries += 1;
@@ -114,7 +128,7 @@ writeJson(eventPath, nextEvents);
 writeJson(evidencePath, nextEvidence);
 
 console.log(`built data from ${bundleCount} record bundle(s)`);
-console.log(`entities: ${entities.length} -> ${nextEntities.length} (+${addedEntities})`);
+console.log(`entities: ${entities.length} -> ${nextEntities.length} (+${addedEntities}; ${correctionBundles} correction bundle(s) retained)`);
 console.log(`events: ${events.length} -> ${nextEvents.length} (+${addedEvents})`);
 console.log(`evidence: ${evidence.length} -> ${nextEvidence.length} (+${addedEvidence})`);
 console.log(`unchanged existing bundle entries: ${unchangedEntries}`);

--- a/scripts/build-machine-readable-layer.mjs
+++ b/scripts/build-machine-readable-layer.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { loadReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
 
 const root = process.cwd()
 const publicDir = path.join(root, 'public')
@@ -42,7 +43,8 @@ const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
 const canonicalEvidence = readJson('data/evidence.json')
 const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
-const entities = [...canonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, reviewedBundles)
+const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
 const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
 const generatedAt = new Date().toISOString()

--- a/scripts/check-record-duplicates.mjs
+++ b/scripts/check-record-duplicates.mjs
@@ -1,11 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
 
 const root = process.cwd()
 const entitiesPath = path.join(root, 'data', 'entities.json')
 const recordsDir = path.join(root, 'records', 'exchanges')
 
-// These are documented separate-entity decisions. Keep this list narrow.
 const allowedDuplicateEntityPairs = new Set([
   'hei_ex_000031|hei_ex_000397',
   'hei_ex_000285|hei_ex_000396',
@@ -16,17 +16,13 @@ function readJson(filePath) {
 }
 
 function stableStringify(value) {
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(',')}]`
-  }
-
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`
   if (value && typeof value === 'object') {
     return `{${Object.keys(value)
       .sort()
       .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
       .join(',')}}`
   }
-
   return JSON.stringify(value)
 }
 
@@ -37,7 +33,6 @@ function normalizeIdentity(value) {
   if (normalized.startsWith('http://')) normalized = normalized.slice(7)
   if (normalized.startsWith('www.')) normalized = normalized.slice(4)
   if (normalized.endsWith('/')) normalized = normalized.slice(0, -1)
-
   return normalized.length > 0 ? normalized : null
 }
 
@@ -53,18 +48,15 @@ function entityKeys(entity) {
   addKey(keys, 'canonical_name', entity.canonical_name)
   addKey(keys, 'official_domain_original', entity.official_domain_original)
   addKey(keys, 'official_url_original', entity.official_url_original)
-
-  for (const alias of entity.aliases || []) {
-    addKey(keys, 'alias', alias)
-  }
-
+  for (const alias of entity.aliases || []) addKey(keys, 'alias', alias)
   return keys
 }
 
-function makeRecord(source, entity, filePath = null) {
+function makeRecord(source, entity, filePath = null, bundle = null) {
   return {
     source,
     filePath,
+    bundle,
     entity,
     id: entity.id,
     slug: entity.slug,
@@ -80,30 +72,38 @@ function recordPairKey(records) {
   return ids.length === 2 ? ids.join('|') : null
 }
 
-function loadBundleRecords() {
+function loadBundleEntries() {
   if (!fs.existsSync(recordsDir)) return []
-
-  return fs
-    .readdirSync(recordsDir)
+  return fs.readdirSync(recordsDir)
     .filter((fileName) => fileName.endsWith('.json'))
     .sort((a, b) => a.localeCompare(b))
     .map((fileName) => {
       const filePath = path.join(recordsDir, fileName)
-      const bundle = readJson(filePath)
-      return makeRecord('records/exchanges', bundle.entity, path.relative(root, filePath))
+      return { fileName, filePath, bundle: readJson(filePath) }
     })
 }
 
-const baseRecords = readJson(entitiesPath).map((entity) => makeRecord('data/entities.json', entity))
+const canonicalEntities = readJson(entitiesPath)
+const bundleEntries = loadBundleEntries()
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, bundleEntries)
+const originalCanonicalById = new Map(canonicalEntities.map((entity) => [entity.id, entity]))
+const correctedCanonicalById = new Map(correctedCanonicalEntities.map((entity) => [entity.id, entity]))
+const baseRecords = canonicalEntities.map((entity) => makeRecord('data/entities.json', entity))
 const canonicalById = new Map(baseRecords.map((record) => [record.id, record]))
-const bundleRecords = loadBundleRecords()
+const bundleRecords = bundleEntries.map(({ filePath, bundle }) =>
+  makeRecord('records/exchanges', bundle.entity, path.relative(root, filePath), bundle),
+)
 const allRecords = [...baseRecords, ...bundleRecords]
 const byKey = new Map()
 
-function isExactCanonicalMirror(record) {
+function isReviewedCanonicalMirror(record) {
   if (record.source !== 'records/exchanges' || !record.id) return false
   const canonical = canonicalById.get(record.id)
-  return Boolean(canonical && stableStringify(canonical.entity) === stableStringify(record.entity))
+  if (!canonical) return false
+  const reference = record.bundle?.entity_correction
+    ? correctedCanonicalById.get(record.id)
+    : originalCanonicalById.get(record.id)
+  return Boolean(reference && stableStringify(reference) === stableStringify(record.entity))
 }
 
 for (const record of allRecords) {
@@ -118,20 +118,18 @@ for (const record of allRecords) {
 const duplicateGroups = []
 const allowedGroups = []
 const seenGroups = new Set()
-let exactMirrorRecords = 0
+let mirrorIdentityOccurrences = 0
 
 for (const [identity, records] of byKey) {
   const logicalRecords = records.filter((record) => {
-    if (!isExactCanonicalMirror(record)) return true
-    exactMirrorRecords += 1
+    if (!isReviewedCanonicalMirror(record)) return true
+    mirrorIdentityOccurrences += 1
     return false
   })
 
   const uniqueRecordIds = [...new Set(logicalRecords.map((record) => `${record.source}:${record.filePath || record.id}`))]
   if (uniqueRecordIds.length < 2) continue
-
-  const hasBundle = logicalRecords.some((record) => record.source === 'records/exchanges')
-  if (!hasBundle) continue
+  if (!logicalRecords.some((record) => record.source === 'records/exchanges')) continue
 
   const groupKey = uniqueRecordIds.sort().join('|')
   if (seenGroups.has(groupKey)) continue
@@ -142,27 +140,22 @@ for (const [identity, records] of byKey) {
     allowedGroups.push({ identity, records: logicalRecords })
     continue
   }
-
   duplicateGroups.push({ identity, records: logicalRecords })
 }
 
 if (duplicateGroups.length === 0) {
   const notes = []
-  if (exactMirrorRecords) notes.push(`${exactMirrorRecords} exact canonical mirror identity occurrence(s) ignored`)
+  if (mirrorIdentityOccurrences) notes.push(`${mirrorIdentityOccurrences} reviewed mirror identity occurrence(s) ignored`)
   if (allowedGroups.length) notes.push(`${allowedGroups.length} documented duplicate group(s) allowed`)
   const suffix = notes.length ? ` (${notes.join('; ')}).` : '.'
   console.log(`No record identity duplicates detected${suffix}`)
 } else {
   console.error(`Detected ${duplicateGroups.length} record identity duplicate group(s):`)
-
   for (const group of duplicateGroups) {
     console.error(`\n- key: ${group.identity}`)
     for (const record of group.records) {
-      console.error(
-        `  - ${record.source}${record.filePath ? `/${record.filePath}` : ''} :: ${record.id} :: ${record.slug} :: ${record.canonical_name}`,
-      )
+      console.error(`  - ${record.source}${record.filePath ? `/${record.filePath}` : ''} :: ${record.id} :: ${record.slug} :: ${record.canonical_name}`)
     }
   }
-
   process.exitCode = 1
 }

--- a/scripts/lib/entity-corrections.mjs
+++ b/scripts/lib/entity-corrections.mjs
@@ -1,0 +1,78 @@
+const ALLOWED_FIELDS = new Set([
+  'type',
+  'status',
+  'death_reason',
+  'launch_date',
+  'death_date',
+  'country_or_origin',
+  'summary',
+  'official_url_status',
+  'archived_url',
+  'predecessor_id',
+  'successor_id',
+  'parent_id',
+  'confidence',
+  'last_verified_at',
+  'notes',
+])
+
+function isObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export function applyReviewedEntityCorrections(entities, entries) {
+  const result = entities.map((entity) => ({ ...entity }))
+  const indexById = new Map(result.map((entity, index) => [entity.id, index]))
+  const fieldOwners = new Map()
+
+  for (const { fileName, bundle } of entries) {
+    const correction = bundle.entity_correction
+    if (correction === undefined) continue
+    if (!isObject(correction)) throw new Error(`${fileName}: entity_correction must be an object`)
+    if (correction.entity_id !== bundle.entity?.id) {
+      throw new Error(`${fileName}: entity_correction.entity_id must match bundle.entity.id`)
+    }
+
+    const index = indexById.get(correction.entity_id)
+    if (index === undefined) {
+      throw new Error(`${fileName}: entity_correction target is not canonical: ${correction.entity_id}`)
+    }
+    if (!isObject(correction.expected) || !isObject(correction.changes)) {
+      throw new Error(`${fileName}: entity_correction expected and changes must be objects`)
+    }
+
+    const expectedFields = Object.keys(correction.expected).sort()
+    const changedFields = Object.keys(correction.changes).sort()
+    if (changedFields.length === 0) throw new Error(`${fileName}: entity_correction changes must not be empty`)
+    if (stable(expectedFields) !== stable(changedFields)) {
+      throw new Error(`${fileName}: entity_correction expected and changes must have identical fields`)
+    }
+
+    const current = result[index]
+    const next = { ...current }
+    for (const field of changedFields) {
+      if (!ALLOWED_FIELDS.has(field)) throw new Error(`${fileName}: entity_correction field is not allowed: ${field}`)
+      const key = `${correction.entity_id}:${field}`
+      if (fieldOwners.has(key)) throw new Error(`${fileName}: entity field already corrected: ${key}`)
+      if (stable(current[field]) !== stable(correction.expected[field])) {
+        throw new Error(`${fileName}: stale entity_correction expected value for ${key}`)
+      }
+      if (stable(correction.expected[field]) === stable(correction.changes[field])) {
+        throw new Error(`${fileName}: entity_correction does not change ${key}`)
+      }
+      next[field] = correction.changes[field]
+      fieldOwners.set(key, fileName)
+    }
+    result[index] = next
+  }
+
+  return result
+}

--- a/scripts/monitoring/core/load-canonical-data.mjs
+++ b/scripts/monitoring/core/load-canonical-data.mjs
@@ -1,5 +1,7 @@
 import path from 'node:path';
 import { listJsonFiles, readJsonFile } from './fs-utils.mjs';
+import { classifyReviewedBundles, mergeRecords } from '../../lib/reviewed-bundle-aggregation.mjs';
+import { applyReviewedEntityCorrections } from '../../lib/entity-corrections.mjs';
 
 const ENTITIES_PATH = 'data/entities.json';
 const EVENTS_PATH = 'data/events.json';
@@ -11,64 +13,17 @@ function normalizeArray(value, filePath) {
   throw new Error(`${filePath} must contain a JSON array`);
 }
 
-function normalizeIdentity(value) {
-  if (!value) return null;
-  const normalized = String(value)
-    .trim()
-    .toLowerCase()
-    .replace(/^https?:\/\//, '')
-    .replace(/^www\./, '')
-    .replace(/\/$/, '');
-  return normalized || null;
-}
-
-function entityIdentityKeys(entity) {
-  return new Set([
-    entity?.id,
-    entity?.slug,
-    entity?.canonical_name,
-    entity?.official_domain_original,
-    entity?.official_url_original,
-    ...(entity?.aliases || []),
-  ].map(normalizeIdentity).filter(Boolean));
-}
-
-async function loadExchangeRecordBundles() {
+async function loadExchangeRecordEntries() {
   const files = await listJsonFiles(RECORDS_PATH);
-  const bundles = [];
+  const entries = [];
   for (const filePath of files) {
     const bundle = await readJsonFile(filePath, null);
     if (!bundle?.entity || !Array.isArray(bundle.events) || !Array.isArray(bundle.evidence)) {
       throw new Error(`${filePath}: expected { entity, events, evidence }`);
     }
-    bundles.push(bundle);
+    entries.push({ fileName: filePath, bundle });
   }
-  return bundles;
-}
-
-function mergeNewEntities(baseEntities, bundles) {
-  const seen = new Set(baseEntities.flatMap((entity) => [...entityIdentityKeys(entity)]));
-  const added = [];
-  for (const bundle of bundles) {
-    const keys = entityIdentityKeys(bundle.entity);
-    if ([...keys].some((key) => seen.has(key))) continue;
-    added.push(bundle.entity);
-    for (const key of keys) seen.add(key);
-  }
-  return [...baseEntities, ...added];
-}
-
-function mergeBundleRecords(baseRecords, bundles, field) {
-  const seen = new Set(baseRecords.map((record) => record.id));
-  const added = [];
-  for (const bundle of bundles) {
-    for (const record of bundle[field]) {
-      if (seen.has(record.id)) continue;
-      seen.add(record.id);
-      added.push(record);
-    }
-  }
-  return [...baseRecords, ...added];
+  return entries;
 }
 
 export async function loadEntities() {
@@ -84,17 +39,19 @@ export async function loadEvidence() {
 }
 
 export async function loadCanonicalData() {
-  const [baseEntities, baseEvents, baseEvidence, bundles] = await Promise.all([
+  const [baseEntities, baseEvents, baseEvidence, entries] = await Promise.all([
     loadEntities(),
     loadEvents(),
     loadEvidence(),
-    loadExchangeRecordBundles(),
+    loadExchangeRecordEntries(),
   ]);
+  const { all, newEntityBundles } = classifyReviewedBundles(baseEntities, entries);
+  const correctedEntities = applyReviewedEntityCorrections(baseEntities, all);
 
   return {
-    entities: mergeNewEntities(baseEntities, bundles),
-    events: mergeBundleRecords(baseEvents, bundles, 'events'),
-    evidence: mergeBundleRecords(baseEvidence, bundles, 'evidence'),
+    entities: [...correctedEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)],
+    events: mergeRecords(baseEvents, all, 'events', 'event'),
+    evidence: mergeRecords(baseEvidence, all, 'evidence', 'evidence'),
     paths: {
       entities: ENTITIES_PATH,
       events: EVENTS_PATH,

--- a/scripts/test-reviewed-bundle-aggregation.mjs
+++ b/scripts/test-reviewed-bundle-aggregation.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { classifyReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
 
 function canonicalEntity() {
   return {
@@ -9,9 +10,44 @@ function canonicalEntity() {
     aliases: [],
     type: 'cex',
     status: 'active',
+    launch_date: '2020-01-01',
+    summary: 'Canonical summary.',
     official_domain_original: 'canonical-one.test',
     official_url_original: 'https://canonical-one.test/',
+    confidence: 'medium',
     last_verified_at: '2026-01-01',
+    notes: '',
+  }
+}
+
+function correctedCanonicalEntity() {
+  return {
+    ...canonicalEntity(),
+    launch_date: '2019-12-01',
+    summary: 'Corrected canonical summary.',
+    confidence: 'high',
+    last_verified_at: '2026-03-01',
+    notes: 'Reviewed correction.',
+  }
+}
+
+function correction() {
+  return {
+    entity_id: 'hei_ex_000001',
+    expected: {
+      launch_date: '2020-01-01',
+      summary: 'Canonical summary.',
+      confidence: 'medium',
+      last_verified_at: '2026-01-01',
+      notes: '',
+    },
+    changes: {
+      launch_date: '2019-12-01',
+      summary: 'Corrected canonical summary.',
+      confidence: 'high',
+      last_verified_at: '2026-03-01',
+      notes: 'Reviewed correction.',
+    },
   }
 }
 
@@ -85,7 +121,8 @@ function reviewedEntries() {
     {
       fileName: 'repair-existing.json',
       bundle: {
-        entity: canonicalEntity(),
+        entity: correctedCanonicalEntity(),
+        entity_correction: correction(),
         events: [{ ...canonicalEvent, title: 'Ignored bundle mirror' }, repairEvent],
         evidence: [{ ...canonicalEvidence, title: 'Ignored evidence mirror' }, repairEvidence],
       },
@@ -115,13 +152,15 @@ export function runReviewedBundleAggregationRegression() {
   const canonicalEvidenceRecords = [canonicalEvidence]
   const { all, newEntityBundles } = classifyReviewedBundles(canonicalEntities, reviewedEntries())
 
-  const entities = [...canonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+  const correctedEntities = applyReviewedEntityCorrections(canonicalEntities, all)
+  const entities = [...correctedEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
   const events = mergeRecords(canonicalEvents, all, 'events', 'event')
   const evidence = mergeRecords(canonicalEvidenceRecords, all, 'evidence', 'evidence')
 
   assert.equal(entities.length, 2, 'existing-entity repair bundle must not increase entity count')
   assert.equal(events.length, 3, 'all reviewed bundle events must be included once')
   assert.equal(evidence.length, 3, 'all reviewed bundle evidence must be included once')
+  assert.deepEqual(entities[0], correctedCanonicalEntity())
   assert.equal(events.find((event) => event.id === canonicalEvent.id)?.title, canonicalEvent.title)
   assert.equal(evidence.find((item) => item.id === canonicalEvidence.id)?.title, canonicalEvidence.title)
 
@@ -136,10 +175,46 @@ export function runReviewedBundleAggregationRegression() {
       },
     },
   ]
-
   assert.throws(
     () => mergeRecords(canonicalEvents, conflictingEntries, 'events', 'event'),
     /conflicting event id: hei_ev_000003/,
+  )
+
+  const staleCorrection = reviewedEntries()
+  staleCorrection[0].bundle.entity_correction.expected.launch_date = '2018-01-01'
+  assert.throws(
+    () => applyReviewedEntityCorrections(canonicalEntities, staleCorrection),
+    /stale entity_correction expected value/,
+  )
+
+  const identityCorrection = reviewedEntries()
+  identityCorrection[0].bundle.entity_correction = {
+    entity_id: 'hei_ex_000001',
+    expected: { slug: 'canonical-one' },
+    changes: { slug: 'renamed-one' },
+  }
+  assert.throws(
+    () => applyReviewedEntityCorrections(canonicalEntities, identityCorrection),
+    /entity_correction field is not allowed: slug/,
+  )
+
+  const duplicateCorrection = reviewedEntries()
+  duplicateCorrection.push({
+    fileName: 'second-correction.json',
+    bundle: {
+      entity: correctedCanonicalEntity(),
+      entity_correction: {
+        entity_id: 'hei_ex_000001',
+        expected: { launch_date: '2019-12-01' },
+        changes: { launch_date: '2019-11-01' },
+      },
+      events: [],
+      evidence: [],
+    },
+  })
+  assert.throws(
+    () => applyReviewedEntityCorrections(canonicalEntities, duplicateCorrection),
+    /entity field already corrected/,
   )
 
   console.log('Reviewed bundle aggregation regression test passed.')

--- a/scripts/validate-record-bundles.mjs
+++ b/scripts/validate-record-bundles.mjs
@@ -172,5 +172,14 @@ for (const filePath of files) {
   checked += 1;
 }
 
-applyReviewedEntityCorrections(canonicalEntities, entries);
+const correctedEntities = applyReviewedEntityCorrections(canonicalEntities, entries);
+const correctedById = new Map(correctedEntities.map((entity) => [entity.id, entity]));
+for (const { fileName, bundle } of entries) {
+  if (!bundle.entity_correction) continue;
+  const corrected = correctedById.get(bundle.entity.id);
+  if (!corrected || stableStringify(corrected) !== stableStringify(bundle.entity)) {
+    fail(`${fileName}: correction bundle entity must exactly match the corrected canonical entity`);
+  }
+}
+
 console.log(`record bundle validation passed: ${checked} bundle(s)`);

--- a/scripts/validate-record-bundles.mjs
+++ b/scripts/validate-record-bundles.mjs
@@ -1,8 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { stableStringify } from './lib/reviewed-bundle-aggregation.mjs';
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs';
 
 const ROOT = process.cwd();
 const RECORD_DIR = path.join(ROOT, 'records', 'exchanges');
+const ENTITY_PATH = path.join(ROOT, 'data', 'entities.json');
 
 const REQUIRED_ENTITY_FIELDS = [
   'id',
@@ -104,11 +107,15 @@ function listRecordFiles() {
 }
 
 const files = listRecordFiles();
+const canonicalEntities = readJson(ENTITY_PATH);
+const entries = [];
 const allIds = new Set();
 let checked = 0;
 
 for (const filePath of files) {
   const bundle = readJson(filePath);
+  const fileName = path.basename(filePath);
+  entries.push({ fileName, bundle });
   requireObject(bundle, filePath);
   requireObject(bundle.entity, `${filePath}.entity`);
   requireArray(bundle.events, `${filePath}.events`);
@@ -121,6 +128,17 @@ for (const filePath of files) {
   const expectedFileName = `${entity.slug}.json`;
   if (path.basename(filePath) !== expectedFileName) {
     fail(`${filePath}: filename must match entity.slug (${expectedFileName})`);
+  }
+
+  if (bundle.entity_correction !== undefined) {
+    requireObject(bundle.entity_correction, `${filePath}.entity_correction`);
+    requireObject(bundle.entity_correction.expected, `${filePath}.entity_correction.expected`);
+    requireObject(bundle.entity_correction.changes, `${filePath}.entity_correction.changes`);
+    for (const [field, value] of Object.entries(bundle.entity_correction.changes)) {
+      if (stableStringify(entity[field]) !== stableStringify(value)) {
+        fail(`${filePath}: bundle.entity.${field} must match entity_correction.changes.${field}`);
+      }
+    }
   }
 
   for (const id of [entity.id, ...events.map((event) => event.id), ...evidence.map((source) => source.id)]) {
@@ -154,4 +172,5 @@ for (const filePath of files) {
   checked += 1;
 }
 
+applyReviewedEntityCorrections(canonicalEntities, entries);
 console.log(`record bundle validation passed: ${checked} bundle(s)`);

--- a/src/lib/data/entity-corrections.ts
+++ b/src/lib/data/entity-corrections.ts
@@ -1,0 +1,97 @@
+import type { EntityRecord } from '../types/entity'
+
+export type CorrectableEntityField =
+  | 'type'
+  | 'status'
+  | 'death_reason'
+  | 'launch_date'
+  | 'death_date'
+  | 'country_or_origin'
+  | 'summary'
+  | 'official_url_status'
+  | 'archived_url'
+  | 'confidence'
+  | 'last_verified_at'
+  | 'notes'
+
+export interface EntityCorrection {
+  entity_id: string
+  expected: Partial<Pick<EntityRecord, CorrectableEntityField>>
+  changes: Partial<Pick<EntityRecord, CorrectableEntityField>>
+}
+
+interface CorrectionBundle {
+  entity: EntityRecord
+  entity_correction?: EntityCorrection
+}
+
+const allowedFields = new Set<CorrectableEntityField>([
+  'type',
+  'status',
+  'death_reason',
+  'launch_date',
+  'death_date',
+  'country_or_origin',
+  'summary',
+  'official_url_status',
+  'archived_url',
+  'confidence',
+  'last_verified_at',
+  'notes',
+])
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stable(record[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export function applyReviewedEntityCorrections(
+  entities: EntityRecord[],
+  bundles: CorrectionBundle[],
+): EntityRecord[] {
+  const result = entities.map((entity) => ({ ...entity }))
+  const indexById = new Map(result.map((entity, index) => [entity.id, index]))
+  const correctedFields = new Set<string>()
+
+  for (const bundle of bundles) {
+    const correction = bundle.entity_correction
+    if (!correction) continue
+    if (correction.entity_id !== bundle.entity.id) {
+      throw new Error('entity_correction.entity_id must match bundle.entity.id')
+    }
+
+    const index = indexById.get(correction.entity_id)
+    if (index === undefined) {
+      throw new Error(`entity_correction target is not canonical: ${correction.entity_id}`)
+    }
+
+    const expectedFields = Object.keys(correction.expected).sort() as CorrectableEntityField[]
+    const changedFields = Object.keys(correction.changes).sort() as CorrectableEntityField[]
+    if (changedFields.length === 0 || stable(expectedFields) !== stable(changedFields)) {
+      throw new Error('entity_correction expected and changes must have identical non-empty fields')
+    }
+
+    const current = result[index]
+    const next = { ...current }
+    for (const field of changedFields) {
+      if (!allowedFields.has(field)) throw new Error(`entity_correction field is not allowed: ${field}`)
+      const key = `${correction.entity_id}:${field}`
+      if (correctedFields.has(key)) throw new Error(`entity field already corrected: ${key}`)
+      if (stable(current[field]) !== stable(correction.expected[field])) {
+        throw new Error(`stale entity_correction expected value for ${key}`)
+      }
+      if (stable(correction.expected[field]) === stable(correction.changes[field])) {
+        throw new Error(`entity_correction does not change ${key}`)
+      }
+      Object.assign(next, { [field]: correction.changes[field] })
+      correctedFields.add(key)
+    }
+    result[index] = next
+  }
+
+  return result
+}

--- a/src/lib/data/entity-corrections.ts
+++ b/src/lib/data/entity-corrections.ts
@@ -10,6 +10,9 @@ export type CorrectableEntityField =
   | 'summary'
   | 'official_url_status'
   | 'archived_url'
+  | 'predecessor_id'
+  | 'successor_id'
+  | 'parent_id'
   | 'confidence'
   | 'last_verified_at'
   | 'notes'
@@ -35,6 +38,9 @@ const allowedFields = new Set<CorrectableEntityField>([
   'summary',
   'official_url_status',
   'archived_url',
+  'predecessor_id',
+  'successor_id',
+  'parent_id',
   'confidence',
   'last_verified_at',
   'notes',

--- a/src/lib/data/load-entities.ts
+++ b/src/lib/data/load-entities.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { EntityRecord } from '../types/entity'
+import { applyReviewedEntityCorrections } from './entity-corrections'
 import { filterNewExchangeRecordBundles, loadExchangeRecordBundles } from './load-record-bundles'
 
 function readJsonFile<T>(relativePath: string): T {
@@ -11,9 +12,11 @@ function readJsonFile<T>(relativePath: string): T {
 
 export function loadEntities(): EntityRecord[] {
   const entities = readJsonFile<EntityRecord[]>('data/entities.json')
-  const bundleEntities = filterNewExchangeRecordBundles(loadExchangeRecordBundles(), entities).map(
+  const bundles = loadExchangeRecordBundles()
+  const correctedEntities = applyReviewedEntityCorrections(entities, bundles)
+  const bundleEntities = filterNewExchangeRecordBundles(bundles, entities).map(
     (bundle) => bundle.entity,
   )
 
-  return [...entities, ...bundleEntities]
+  return [...correctedEntities, ...bundleEntities]
 }

--- a/src/lib/data/load-record-bundles.ts
+++ b/src/lib/data/load-record-bundles.ts
@@ -3,9 +3,11 @@ import path from 'node:path'
 import type { EntityRecord } from '../types/entity'
 import type { EventRecord } from '../types/event'
 import type { EvidenceRecord } from '../types/evidence'
+import type { EntityCorrection } from './entity-corrections'
 
 export interface ExchangeRecordBundle {
   entity: EntityRecord
+  entity_correction?: EntityCorrection
   events: EventRecord[]
   evidence: EvidenceRecord[]
 }

--- a/src/lib/types/entity.ts
+++ b/src/lib/types/entity.ts
@@ -49,6 +49,9 @@ export interface EntityRecord {
   official_domain_original: string | null
   official_url_status: UrlStatus
   archived_url: string | null
+  predecessor_id?: string | null
+  successor_id?: string | null
+  parent_id?: string | null
   confidence: Confidence
   last_verified_at: string
   notes: string


### PR DESCRIPTION
Adds a reviewed entity-correction mechanism for existing exchange records. Corrections require exact expected values, forbid identity-field edits, apply consistently across the public loader, monitoring loader, machine-readable counts, overlap checks, duplicate checks, record materialization, and bundle validation, and add CI coverage through records:validate. No canonical entity is changed in this PR.