### PR TITLE
Resolve A2 country origin gaps — Batch 2

### DIFF
--- a/docs/audits/HEI_A2_COUNTRY_ORIGIN_AUDIT_2026-06-19.md
+++ b/docs/audits/HEI_A2_COUNTRY_ORIGIN_AUDIT_2026-06-19.md
@@ -109,9 +109,9 @@ The second batch resolves five additional active records with official legal, co
 
 Each record receives one additional evidence item, and the linked event `source_count` is updated.
 
-## Expected post-Batch 2 state
+## Verified post-Batch 2 state
 
-The main-target CI audit must confirm:
+The main-target CI audit generated on 2026-06-20 confirmed:
 
 ```text
 Projected public entities:      412
@@ -121,6 +121,17 @@ Total review queue:              20
 Invalid non-string values:        0
 Projected public evidence:     1600
 ```
+
+Required checks passed on commit `628f9f042b96adeddbc02ab29aeb4b1d85930ca0` before this audit confirmation was recorded:
+
+- CI
+- Records validation
+- lint
+- reviewed bundle validation
+- canonical enum validation
+- static production build
+- machine-readable validation
+- built HTML and JSON count consistency
 
 Remaining true missing values are:
 
@@ -145,7 +156,7 @@ Remaining true missing values are:
 
 ## Merge state
 
-PR #399 is merged. PR #400 now targets `main`. Because PR #399 was squash-merged, the Batch 2 branch was rebuilt directly from the merged main commit so its final diff contains only this audit document and the five Batch 2 record changes.
+PR #399 is merged. PR #400 targets `main`. Because PR #399 was squash-merged, the Batch 2 branch was rebuilt directly from the merged main commit so its final diff contains only this audit document and the five Batch 2 record changes.
 
 ## Rules
 

--- a/docs/audits/HEI_A2_COUNTRY_ORIGIN_AUDIT_2026-06-19.md
+++ b/docs/audits/HEI_A2_COUNTRY_ORIGIN_AUDIT_2026-06-19.md
@@ -66,8 +66,6 @@ Invalid non-string values:        0
 
 ## Batch 1 decisions
 
-The first batch resolves five entries with direct official support.
-
 | Entity | Decision | Basis |
 | --- | --- | --- |
 | ApolloX | `BNB Chain ecosystem` | Official ApolloX material describes BNB Chain support and a multichain protocol; no unsupported legal country is asserted. |
@@ -76,9 +74,9 @@ The first batch resolves five entries with direct official support.
 | Blockchain.com | `United Kingdom` | Official company history states that it began in York and has its global headquarters in London. |
 | BYDFi | `Seychelles` | Official legal and privacy material identifies BYDFi Fintech LTD as registered in Seychelles. |
 
-## Verified post-batch state
+## Verified post-Batch 1 state
 
-The final CI artifact generated from PR #399 confirmed:
+PR #399 was validated and merged as commit `bd665468f6159a8e2aaeb1a71f738dbfc5210102` after the repository-owned Cloudflare Pages policy was successfully applied.
 
 ```text
 Projected public entities:      412
@@ -88,7 +86,7 @@ Total review queue:              25
 Invalid non-string values:        0
 ```
 
-All required PR checks passed on commit `7c335a8634450899430f04bfca462647b2ba3dfb`:
+Required checks passed before merge:
 
 - CI
 - Records validation
@@ -97,6 +95,33 @@ All required PR checks passed on commit `7c335a8634450899430f04bfca462647b2ba3df
 - machine-readable validation
 - built HTML and JSON count consistency
 
+## Batch 2 decisions
+
+The second batch resolves five additional active records with official legal, company-history, or protocol documentation.
+
+| Entity | Decision | Basis |
+| --- | --- | --- |
+| BitMart | `Marshall Islands` | BitMart's official user agreement identifies GBM Global Inc. as BitMart and gives its registration number and Marshall Islands address. Cayman governing law is not treated as the entity origin. |
+| BitKan | `China` | BitKan's official site confirms its 2012 history, and an official-domain company explainer identifies Beijing, China as its headquarters. This is treated as historical operating origin rather than current legal domicile. |
+| BTCC | `United Kingdom` | BTCC's standardized official-site company profile describes the exchange as headquartered in the UK. Notes preserve its historical Chinese roots and multi-jurisdiction legal-provider structure. |
+| BitDelta | `Romania` | BitDelta's official general terms identify Lionheart Limited S.R.L as the platform company and state that it is incorporated under Romanian law. |
+| Bulla Exchange | `Berachain ecosystem` | Official Bulla documentation explicitly describes the protocol as a DEX built for Berachain. No unsupported legal-country assignment is made. |
+
+Each record receives one additional evidence item, and the linked event `source_count` is updated.
+
+## Expected post-Batch 2 state
+
+The main-target CI audit must confirm:
+
+```text
+Projected public entities:      412
+True missing values:             11
+Explicit Unknown values:          9
+Total review queue:              20
+Invalid non-string values:        0
+Projected public evidence:     1600
+```
+
 Remaining true missing values are:
 
 - OPNX
@@ -104,30 +129,23 @@ Remaining true missing values are:
 - Aivora Exchange
 - Bitbaby
 - Bitcointry
-- BitDelta
 - Bitexlive
-- BitKan
-- BitMart
 - BitStorage
 - Bitzy
 - Blueprint
 - Bron Intents
-- BTCC
-- Bulla Exchange
 - Byte Exchange
 
 ## Remaining work
 
-The remaining queue must be processed in evidence-quality batches.
-
-1. High-confidence active entities with official corporate, legal, or protocol documentation.
-2. Active low-confidence seed records where `Global`, an ecosystem label, or `Unknown` may be more accurate than a country.
-3. Historical dead-side records requiring archived or secondary historical evidence.
+1. Process active low-confidence seed records where `Global`, an ecosystem label, or `Unknown` may be more accurate than a country.
+2. Process historical dead-side records requiring archived or secondary historical evidence.
+3. Review the nine existing explicit `Unknown` values separately from structural missing values.
 4. Convert the audit to a strict structural gate once true missing values reach zero.
 
 ## Merge state
 
-PR #399 is intentionally left unmerged while Cloudflare project access is unavailable. The branch is fully validated and should not be merged until the repository-owned Cloudflare Pages policy has been applied or a safe merge window is explicitly confirmed.
+PR #399 is merged. PR #400 now targets `main`. Because PR #399 was squash-merged, the Batch 2 branch was rebuilt directly from the merged main commit so its final diff contains only this audit document and the five Batch 2 record changes.
 
 ## Rules
 

--- a/records/exchanges/bitdelta.json
+++ b/records/exchanges/bitdelta.json
@@ -9,15 +9,15 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
-    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records BitDelta as an active CEX seed record.",
+    "country_or_origin": "Romania",
+    "summary": "Centralized crypto and derivatives exchange operated through Romania-incorporated Lionheart Limited S.R.L according to BitDelta's official terms.",
     "official_url_original": "https://bitdelta.com/",
     "official_domain_original": "bitdelta.com",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://bitdelta.com/",
     "confidence": "medium",
-    "last_verified_at": "2026-06-01",
-    "notes": "Added from verified-unadded row hei_unadded_0283. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+    "last_verified_at": "2026-06-19",
+    "notes": "Added from verified-unadded row hei_unadded_0283. The official general terms identify Lionheart Limited S.R.L as the company governing use of the BitDelta exchange platform and state that it is incorporated under Romanian law."
   },
   "events": [
     {
@@ -26,13 +26,13 @@
       "event_type": "listed_reference",
       "event_date": "2026-06-01",
       "title": "BitDelta recorded as centralized exchange",
-      "description": "BitDelta is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "description": "BitDelta is recorded as a Romania-operated centralized crypto and derivatives exchange based on its official terms, official domain, and CoinGecko exchange source row.",
       "confidence": "medium",
       "impact_level": "low",
       "event_status_effect": "active",
-      "source_count": 2,
+      "source_count": 3,
       "sort_order": 1,
-      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+      "notes": "Upgrade with a precise launch, licensing, or major operating-history event if stronger dated sources are added."
     }
   ],
   "evidence": [
@@ -65,6 +65,21 @@
       "reliability": "medium",
       "claim_scope": "entity",
       "notes": "Source used by verified-unadded backlog row hei_unadded_0283."
+    },
+    {
+      "id": "hei_src_003188",
+      "exchange_id": "hei_ex_000387",
+      "event_id": "hei_ev_000695",
+      "source_type": "official_statement",
+      "title": "BitDelta General Terms and Conditions",
+      "url": "https://media.bitdelta.com/pdf/terms-and-conditions-general.pdf",
+      "publisher": "BitDelta",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://media.bitdelta.com/pdf/terms-and-conditions-general.pdf",
+      "accessed_at": "2026-06-19",
+      "reliability": "high",
+      "claim_scope": "ownership",
+      "notes": "The official terms identify Lionheart Limited S.R.L as the company operating the exchange platform and state that it is incorporated under the laws of Romania."
     }
   ]
 }

--- a/records/exchanges/bitkan.json
+++ b/records/exchanges/bitkan.json
@@ -9,15 +9,15 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
-    "summary": "Centralized crypto exchange candidate with CoinGecko source data and official domain. HEI records BitKan as an active CEX seed record.",
+    "country_or_origin": "China",
+    "summary": "China-origin crypto broker and exchange platform founded in 2012 and described on its official domain as headquartered in Beijing.",
     "official_url_original": "https://bitkan.com/",
     "official_domain_original": "bitkan.com",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://bitkan.com/",
     "confidence": "medium",
-    "last_verified_at": "2026-06-01",
-    "notes": "Added from verified-unadded row hei_unadded_0307. This record should be improved later with stronger launch, licensing, or operating-history evidence."
+    "last_verified_at": "2026-06-19",
+    "notes": "Added from verified-unadded row hei_unadded_0307. BitKan's current official site confirms a 2012 founding, while an official-domain company explainer identifies Beijing, China as its headquarters. HEI records China as the historical operating origin rather than inferring a current legal domicile."
   },
   "events": [
     {
@@ -26,13 +26,13 @@
       "event_type": "listed_reference",
       "event_date": "2026-06-01",
       "title": "BitKan recorded as centralized exchange",
-      "description": "BitKan is recorded as a centralized exchange entity based on its official domain and CoinGecko exchange source row.",
+      "description": "BitKan is recorded as a China-origin crypto broker and exchange platform based on its official domain, 2012 operating history, and CoinGecko exchange source row.",
       "confidence": "medium",
       "impact_level": "low",
       "event_status_effect": "active",
-      "source_count": 2,
+      "source_count": 3,
       "sort_order": 1,
-      "notes": "Upgrade with a precise launch, licensing, or operating-history event if stronger sources are added."
+      "notes": "Upgrade with a precise launch, licensing, or major operating-history event if stronger dated sources are added."
     }
   ],
   "evidence": [
@@ -49,7 +49,7 @@
       "accessed_at": "2026-06-01",
       "reliability": "high",
       "claim_scope": "entity",
-      "notes": "Official domain used to verify BitKan identity."
+      "notes": "Official domain used to verify BitKan identity and its stated 2012 founding."
     },
     {
       "id": "hei_src_001548",
@@ -65,6 +65,21 @@
       "reliability": "medium",
       "claim_scope": "entity",
       "notes": "Source used by verified-unadded backlog row hei_unadded_0307."
+    },
+    {
+      "id": "hei_src_003186",
+      "exchange_id": "hei_ex_000391",
+      "event_id": "hei_ev_000699",
+      "source_type": "official_blog",
+      "title": "What to Do if You are not Receiving Verification Texts on BitKan?",
+      "url": "https://bitkan.com/learn/what-to-do-if-you-are-not-receiving-verification-texts-on-bitkan-21890",
+      "publisher": "BitKan",
+      "published_at": "2023-11-29",
+      "archived_url": "https://web.archive.org/web/*/https://bitkan.com/learn/what-to-do-if-you-are-not-receiving-verification-texts-on-bitkan-21890",
+      "accessed_at": "2026-06-19",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "The official-domain explainer states that BitKan was founded in 2012 and is headquartered in Beijing, China. This supports historical operating origin, not a current legal-domicile claim."
     }
   ]
 }

--- a/records/exchanges/bitmart.json
+++ b/records/exchanges/bitmart.json
@@ -9,15 +9,15 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
-    "summary": "Centralized crypto exchange represented by CoinPaprika and CoinGecko source rows. HEI treats BitMart duplicate rows as one entity.",
+    "country_or_origin": "Marshall Islands",
+    "summary": "Centralized crypto exchange whose current user agreement identifies Marshall Islands-addressed GBM Global Inc. as the BitMart service provider.",
     "official_url_original": "https://www.bitmart.com/",
     "official_domain_original": "bitmart.com",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://www.bitmart.com/",
     "confidence": "medium",
-    "last_verified_at": "2026-06-02",
-    "notes": "Added from verified-unadded rows hei_unadded_0311 and hei_unadded_0312 as one entity. This record should be improved later with incident, launch, licensing, or operating-history evidence."
+    "last_verified_at": "2026-06-19",
+    "notes": "Added from verified-unadded rows hei_unadded_0311 and hei_unadded_0312 as one entity. The origin field follows the current BitMart user agreement, which identifies GBM Global Inc. with a Marshall Islands registration number and address. Cayman Islands governing law is documented separately and is not treated as the entity origin."
   },
   "events": [
     {
@@ -26,11 +26,11 @@
       "event_type": "listed_reference",
       "event_date": "2026-06-02",
       "title": "BitMart recorded as centralized exchange",
-      "description": "BitMart is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "description": "BitMart is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record and current provider identity supported by the official user agreement.",
       "confidence": "medium",
       "impact_level": "low",
       "event_status_effect": "active",
-      "source_count": 3,
+      "source_count": 4,
       "sort_order": 1,
       "notes": "Upgrade with a precise launch, hack, licensing, or operating-history event if stronger sources are added."
     }
@@ -80,6 +80,21 @@
       "reliability": "medium",
       "claim_scope": "entity",
       "notes": "Source used by verified-unadded backlog row hei_unadded_0312."
+    },
+    {
+      "id": "hei_src_003185",
+      "exchange_id": "hei_ex_000393",
+      "event_id": "hei_ev_000701",
+      "source_type": "official_statement",
+      "title": "BitMart User Agreement",
+      "url": "https://www.bitmart.com/en-US/support/articles/21383985713435/21384004345627/115004890354",
+      "publisher": "BitMart",
+      "published_at": "2025-12-04",
+      "archived_url": "https://web.archive.org/web/*/https://www.bitmart.com/en-US/support/articles/21383985713435/21384004345627/115004890354",
+      "accessed_at": "2026-06-19",
+      "reliability": "high",
+      "claim_scope": "ownership",
+      "notes": "The agreement identifies GBM Global Inc. as BitMart, provides registration number 134925, and gives a Marshall Islands address. HEI uses this as the current provider-origin basis."
     }
   ]
 }

--- a/records/exchanges/btcc.json
+++ b/records/exchanges/btcc.json
@@ -9,15 +9,15 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
-    "summary": "Centralized crypto exchange candidate represented by CoinPaprika and CoinGecko source rows. HEI treats active and inactive source signals as one BTCC entity and keeps the final status active pending stronger historical segmentation evidence.",
+    "country_or_origin": "United Kingdom",
+    "summary": "Long-running centralized crypto exchange founded in 2011 and currently described by its official site as headquartered in the United Kingdom.",
     "official_url_original": "https://www.btcc.com/",
     "official_domain_original": "btcc.com",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://www.btcc.com/",
     "confidence": "medium",
-    "last_verified_at": "2026-06-03",
-    "notes": "Added from verified-unadded rows hei_unadded_0403 and hei_unadded_0404 as one entity. CoinPaprika marked one source row inactive while CoinGecko has an active-domain row; status is kept active until a stronger shutdown/rebrand split is researched."
+    "last_verified_at": "2026-06-19",
+    "notes": "Added from verified-unadded rows hei_unadded_0403 and hei_unadded_0404 as one entity. HEI uses the current operating-headquarters description published on BTCC's official site. This does not erase the brand's historical Chinese roots or imply that all current regional legal providers are UK-incorporated; official materials also identify Poland, Lithuania, and Cayman Islands entities for particular services."
   },
   "events": [
     {
@@ -26,13 +26,13 @@
       "event_type": "listed_reference",
       "event_date": "2026-06-03",
       "title": "BTCC recorded as centralized exchange",
-      "description": "BTCC is recorded as a centralized exchange entity, with CoinPaprika and CoinGecko candidate rows consolidated into one HEI record.",
+      "description": "BTCC is recorded as a long-running centralized exchange founded in 2011, with CoinPaprika and CoinGecko candidate rows consolidated into one active entity and current UK headquarters supported by official-site material.",
       "confidence": "medium",
       "impact_level": "low",
       "event_status_effect": "active",
-      "source_count": 3,
+      "source_count": 4,
       "sort_order": 1,
-      "notes": "Upgrade with precise launch, rebrand, shutdown, licensing, or operating-history evidence if stronger sources are added."
+      "notes": "Upgrade with a precise launch, rebrand, shutdown, licensing, or operating-history event if stronger sources are added."
     }
   ],
   "evidence": [
@@ -80,6 +80,21 @@
       "reliability": "medium",
       "claim_scope": "entity",
       "notes": "Source used by verified-unadded backlog row hei_unadded_0404."
+    },
+    {
+      "id": "hei_src_003187",
+      "exchange_id": "hei_ex_000410",
+      "event_id": "hei_ev_000720",
+      "source_type": "official_statement",
+      "title": "BTCC official company profile",
+      "url": "https://www.btcc.com/en-US/markets/buy/Shanghai%20Inu",
+      "publisher": "BTCC",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.btcc.com/en-US/markets/buy/Shanghai%20Inu",
+      "accessed_at": "2026-06-19",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "BTCC's standardized official-site company profile states that the exchange was founded in 2011 and is headquartered in the UK. HEI uses this only for the current operating-origin field."
     }
   ]
 }

--- a/records/exchanges/bulla-exchange.json
+++ b/records/exchanges/bulla-exchange.json
@@ -9,15 +9,15 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
-    "summary": "DEX / exchange protocol candidate represented by CoinGecko and DefiLlama source rows. HEI treats Bulla and Bulla Exchange rows as one protocol-level entity for v0.",
+    "country_or_origin": "Berachain ecosystem",
+    "summary": "Berachain-native decentralized exchange based on Algebra Integral and designed as a liquidity marketplace for the Berachain network.",
     "official_url_original": "https://bulla.exchange/",
     "official_domain_original": "bulla.exchange",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://bulla.exchange/",
-    "confidence": "medium",
-    "last_verified_at": "2026-06-03",
-    "notes": "Added from verified-unadded rows hei_unadded_0419 and hei_unadded_0420 as one entity. This record should be improved later with stronger launch, chain, or operating-history evidence."
+    "confidence": "high",
+    "last_verified_at": "2026-06-19",
+    "notes": "Added from verified-unadded rows hei_unadded_0419 and hei_unadded_0420 as one entity. Official documentation explicitly describes Bulla as a DEX built for Berachain, so HEI uses an ecosystem origin rather than inventing a legal-country assignment."
   },
   "events": [
     {
@@ -25,14 +25,14 @@
       "exchange_id": "hei_ex_000412",
       "event_type": "listed_reference",
       "event_date": "2026-06-03",
-      "title": "Bulla Exchange recorded as DEX candidate",
-      "description": "Bulla Exchange is recorded as a DEX / exchange protocol entity, with Bulla and Bulla Exchange candidate rows consolidated into one HEI record.",
-      "confidence": "medium",
+      "title": "Bulla Exchange recorded as Berachain DEX",
+      "description": "Bulla Exchange is recorded as a Berachain-native DEX and liquidity marketplace, with Bulla and Bulla Exchange candidate rows consolidated into one protocol-level HEI entity.",
+      "confidence": "high",
       "impact_level": "low",
       "event_status_effect": "active",
-      "source_count": 3,
+      "source_count": 4,
       "sort_order": 1,
-      "notes": "Upgrade with precise launch, chain, or operating-history evidence if stronger sources are added."
+      "notes": "Upgrade with a precise launch or major operating-history event if stronger dated sources are added."
     }
   ],
   "evidence": [
@@ -80,6 +80,21 @@
       "reliability": "medium",
       "claim_scope": "entity",
       "notes": "Source used by verified-unadded backlog row hei_unadded_0420."
+    },
+    {
+      "id": "hei_src_003189",
+      "exchange_id": "hei_ex_000412",
+      "event_id": "hei_ev_000722",
+      "source_type": "official_statement",
+      "title": "Introduction to Bulla",
+      "url": "https://docs.bulla.exchange/bulla-exchange",
+      "publisher": "Bulla Exchange",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.bulla.exchange/bulla-exchange",
+      "accessed_at": "2026-06-19",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official documentation explicitly states that Bulla is a DEX built for the Berachain network and aims to become a core part of the BERA ecosystem."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Second A2 `country_or_origin` completion batch, now based directly on the merged `main` state after PR #399.

Resolved records:
- BitMart: `Marshall Islands`
- BitKan: `China`
- BTCC: `United Kingdom`
- BitDelta: `Romania`
- Bulla Exchange: `Berachain ecosystem`

Expected post-batch state:

```text
Projected public entities:      412
True missing origin values:      11
Explicit Unknown values:          9
Total origin review queue:       20
Projected public evidence:     1600
```

Each record receives one official-source evidence item and a matching event `source_count` update. Evidence IDs continue from PR #399:

```text
hei_src_003185
hei_src_003186
hei_src_003187
hei_src_003188
hei_src_003189
```

## Branch normalization

PR #399 was squash-merged as `bd665468f6159a8e2aaeb1a71f738dbfc5210102`. To prevent the former stacked history from reappearing in this PR, the Batch 2 branch was rebuilt directly from that merged main commit and the six intended files were reapplied.

Final intended diff:
- `docs/audits/HEI_A2_COUNTRY_ORIGIN_AUDIT_2026-06-19.md`
- `records/exchanges/bitmart.json`
- `records/exchanges/bitkan.json`
- `records/exchanges/btcc.json`
- `records/exchanges/bitdelta.json`
- `records/exchanges/bulla-exchange.json`

No PR #399 files or obsolete stacked commits remain in the main comparison.

## Cloudflare boundary

The repository-owned Cloudflare Pages policy has been applied successfully:
- production branch: `main`
- production deployments: enabled
- preview deployments: disabled
- PR deployment comments: disabled

This PR must pass the complete main-target CI suite before merge. Its branch commits use `[CF-Pages-Skip]`, and no preview deployment is required.