### PR TITLE
Repair twelfth active CEX record batch

### DIFF
--- a/records/exchanges/bequant.json
+++ b/records/exchanges/bequant.json
@@ -3,21 +3,25 @@
     "id": "hei_ex_000376",
     "slug": "bequant",
     "canonical_name": "Bequant",
-    "aliases": ["BEQUANT", "BeQuant", "BEQUANT Global"],
+    "aliases": [
+      "BEQUANT",
+      "BeQuant",
+      "BEQUANT Global"
+    ],
     "type": "cex",
     "status": "active",
     "death_reason": null,
     "launch_date": "2022-08-08",
     "death_date": null,
     "country_or_origin": "Malta",
-    "summary": "Malta-based centralized digital-asset exchange and institutional trading platform whose current BEQUANT Global service launched in August 2022 as part of the wider BEQUANT group.",
+    "summary": "Malta-based centralized digital-asset exchange and institutional trading platform whose current BEQUANT Global service launched in August 2022; CrossTower announced an agreement to acquire the wider BEQUANT business in November 2022.",
     "official_url_original": "https://bequant.io/",
     "official_domain_original": "bequant.io",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://bequant.io/",
     "confidence": "high",
-    "last_verified_at": "2026-06-22",
-    "notes": "The BEQUANT group predates the current BEQUANT Global exchange service. HEI uses August 8, 2022 as the launch date for the present retail and professional exchange line, while preserving the broader group identity and Malta origin."
+    "last_verified_at": "2026-06-23",
+    "notes": "The BEQUANT group predates the current BEQUANT Global exchange service. HEI uses August 8, 2022 as the launch date for the present exchange line. The November 2022 CrossTower announcement is recorded as acquisition history without treating it as a terminal shutdown because BEQUANT services remain publicly accessible."
   },
   "events": [
     {
@@ -33,6 +37,20 @@
       "source_count": 1,
       "sort_order": 1,
       "notes": "The wider BEQUANT group and institutional platform existed before this launch; this event marks the current exchange service line."
+    },
+    {
+      "id": "hei_ev_009003",
+      "exchange_id": "hei_ex_000376",
+      "event_type": "acquired",
+      "event_date": "2022-11-28",
+      "title": "CrossTower announced an agreement to acquire BEQUANT",
+      "description": "CrossTower announced that it had reached an agreement to acquire BEQUANT, including its prime-brokerage and digital-asset exchange business.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 2,
+      "notes": "The reviewed sources establish an announced acquisition agreement. HEI does not infer a terminal status change because BEQUANT's current services remain available."
     }
   ],
   "evidence": [
@@ -95,6 +113,36 @@
       "reliability": "high",
       "claim_scope": "status",
       "notes": "Current official support material documents active BEQUANT Global markets and trading support."
+    },
+    {
+      "id": "hei_src_009006",
+      "exchange_id": "hei_ex_000376",
+      "event_id": "hei_ev_009003",
+      "source_type": "official_statement",
+      "title": "CrossTower to Acquire BEQUANT",
+      "url": "https://www.prnewswire.com/news-releases/crosstower-to-acquire-bequant-and-launches-the-industry-first-esg-crypto-fund-301687937.html",
+      "publisher": "CrossTower",
+      "published_at": "2022-11-28",
+      "archived_url": "https://web.archive.org/web/*/https://www.prnewswire.com/news-releases/crosstower-to-acquire-bequant-and-launches-the-industry-first-esg-crypto-fund-301687937.html",
+      "accessed_at": "2026-06-23",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "CrossTower-issued announcement states that it reached an agreement to acquire BEQUANT."
+    },
+    {
+      "id": "hei_src_009007",
+      "exchange_id": "hei_ex_000376",
+      "event_id": "hei_ev_009003",
+      "source_type": "news_article",
+      "title": "CrossTower to acquire institutional prime brokerage BEQUANT",
+      "url": "https://cointelegraph.com/news/crosstower-to-acquire-institutional-prime-brokerage-bequant",
+      "publisher": "Cointelegraph",
+      "published_at": "2022-11-30",
+      "archived_url": "https://web.archive.org/web/*/https://cointelegraph.com/news/crosstower-to-acquire-institutional-prime-brokerage-bequant",
+      "accessed_at": "2026-06-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Independent report corroborates the November 2022 acquisition agreement and BEQUANT's exchange business."
     }
   ]
 }

--- a/records/exchanges/bitcointry.json
+++ b/records/exchanges/bitcointry.json
@@ -12,15 +12,15 @@
     "death_reason": null,
     "launch_date": "2023-01-01",
     "death_date": null,
-    "country_or_origin": "Global",
-    "summary": "Self-described global cryptocurrency exchange operating since 2023 and combining centralized trading with Web3 wallet access.",
+    "country_or_origin": "Seychelles",
+    "summary": "Seychelles-operated hybrid cryptocurrency exchange active since 2023, combining centralized trading, Web3 wallet connectivity, and multi-chain services under the Bitcointry brand.",
     "official_url_original": "https://bitcointry.com/",
     "official_domain_original": "bitcointry.com",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://bitcointry.com/",
-    "confidence": "medium",
+    "confidence": "high",
     "last_verified_at": "2026-06-23",
-    "notes": "Independent exchange data places Bitcointry's establishment in 2023 and reports Seychelles registration under Devcode Technology. HEI retains Global as the origin because the reviewed accessible official surface describes global operations but does not independently establish a canonical domicile. January 1 is used as a year-level date placeholder."
+    "notes": "Bitcointry's official whitepaper places exchange operations in Seychelles. The Google Play listing identifies Devcode Technology Ltd as the app developer, while the specific CoinGecko profile provides the same operator name and a Seychelles company address. January 1 remains a year-level launch placeholder."
   },
   "events": [
     {
@@ -82,7 +82,37 @@
       "accessed_at": "2026-06-23",
       "reliability": "medium",
       "claim_scope": "launch_date",
-      "notes": "Independent exchange profile identifies Bitcointry as established in 2023. Its Seychelles registration information is noted but does not override the retained Global origin without accessible official corroboration."
+      "notes": "Independent exchange profile identifies Bitcointry as established in 2023 and provides the Devcode Technology Ltd Seychelles company address."
+    },
+    {
+      "id": "hei_src_009004",
+      "exchange_id": "hei_ex_000385",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Bitcointry Whitepaper v3.0",
+      "url": "https://bitcointry.com/Whitepaper.pdf",
+      "publisher": "Bitcointry",
+      "published_at": "2024-01-05",
+      "archived_url": "https://web.archive.org/web/*/https://bitcointry.com/Whitepaper.pdf",
+      "accessed_at": "2026-06-23",
+      "reliability": "high",
+      "claim_scope": "ownership",
+      "notes": "Official whitepaper states that the Bitcointry exchange operates in Seychelles."
+    },
+    {
+      "id": "hei_src_009005",
+      "exchange_id": "hei_ex_000385",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Bitcointry app listing",
+      "url": "https://play.google.com/store/apps/details?id=com.bitcointry.com",
+      "publisher": "Google Play",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://play.google.com/store/apps/details?id=com.bitcointry.com",
+      "accessed_at": "2026-06-23",
+      "reliability": "medium",
+      "claim_scope": "ownership",
+      "notes": "The official app-store listing identifies Devcode Technology Ltd as the Bitcointry application developer."
     }
   ]
 }

--- a/records/exchanges/bitstamp.json
+++ b/records/exchanges/bitstamp.json
@@ -13,11 +13,24 @@
     "summary": "Luxembourg-based centralized exchange launched in 2011 and still operating under the Bitstamp brand.",
     "official_url_original": "https://www.bitstamp.net/",
     "official_domain_original": "bitstamp.net",
-    "official_url_status": "live_unverified",
+    "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://www.bitstamp.net/",
     "confidence": "high",
-    "notes": "",
-    "last_verified_at": "2026-04-07"
+    "notes": "Bitstamp's official exchange and About Us surfaces were accessible and verified on June 23, 2026.",
+    "last_verified_at": "2026-06-23"
+  },
+  "entity_correction": {
+    "entity_id": "hei_ex_000010",
+    "expected": {
+      "official_url_status": "live_unverified",
+      "notes": "",
+      "last_verified_at": "2026-04-07"
+    },
+    "changes": {
+      "official_url_status": "live_verified",
+      "notes": "Bitstamp's official exchange and About Us surfaces were accessible and verified on June 23, 2026.",
+      "last_verified_at": "2026-06-23"
+    }
   },
   "events": [
     {

--- a/records/exchanges/btc-trade-ua.json
+++ b/records/exchanges/btc-trade-ua.json
@@ -14,14 +14,14 @@
     "launch_date": "2014-01-01",
     "death_date": null,
     "country_or_origin": "Ukraine",
-    "summary": "Ukraine-focused centralized cryptocurrency exchange established in 2014, supporting hryvnia-denominated and crypto-to-crypto trading through its active official platform.",
+    "summary": "Ukraine-focused centralized cryptocurrency exchange established in 2014 that announced a planned closure after repeated attacks in May 2015 but later resumed and continues operating its official trading platform.",
     "official_url_original": "https://btc-trade.com.ua/",
     "official_domain_original": "btc-trade.com.ua",
     "official_url_status": "live_verified",
     "archived_url": "https://web.archive.org/web/*/https://btc-trade.com.ua/",
     "confidence": "medium",
     "last_verified_at": "2026-06-23",
-    "notes": "Multiple independent exchange profiles identify BTC Trade UA as established in 2014, and official-domain pages retain a 2014 copyright baseline. The exact launch day is not available in reviewed primary material, so January 1 is used as a year-level placeholder and confidence remains medium."
+    "notes": "Independent exchange profiles identify a 2014 establishment year. Contemporaneous May 2015 reporting documented the founder's plan to close after repeated attacks, but the current official site and API remain accessible, so HEI records the announcement as a historical event rather than a terminal death marker."
   },
   "events": [
     {
@@ -37,6 +37,20 @@
       "source_count": 2,
       "sort_order": 1,
       "notes": "Reviewed sources establish the year but not the exact day, so January 1 is used as a year-level placeholder."
+    },
+    {
+      "id": "hei_ev_009002",
+      "exchange_id": "hei_ex_000409",
+      "event_type": "shutdown_announced",
+      "event_date": "2015-05-13",
+      "title": "BTC Trade UA founder announced plans to close the exchange",
+      "description": "The exchange's founder announced plans to close BTC Trade UA after repeated attacks and operational pressure; the service later returned and is currently active.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "limited",
+      "source_count": 2,
+      "sort_order": 2,
+      "notes": "This is a historical shutdown announcement, not a terminal death event, because the official platform later resumed operation."
     }
   ],
   "evidence": [
@@ -99,6 +113,36 @@
       "reliability": "high",
       "claim_scope": "status",
       "notes": "Official API documentation corroborates an operating exchange service and supported trading pairs."
+    },
+    {
+      "id": "hei_src_009002",
+      "exchange_id": "hei_ex_000409",
+      "event_id": "hei_ev_009002",
+      "source_type": "news_article",
+      "title": "Ukrainian bitcoin exchange btc-trade.com.ua is closing",
+      "url": "https://forklog.com/news/ukrainskaya-bitkoin-birzha-btc-trade-com-ua-okonchatelno-zakryvaetsya/",
+      "publisher": "ForkLog",
+      "published_at": "2015-05-13",
+      "archived_url": "https://web.archive.org/web/*/https://forklog.com/news/ukrainskaya-bitkoin-birzha-btc-trade-com-ua-okonchatelno-zakryvaetsya/",
+      "accessed_at": "2026-06-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Contemporaneous report on the founder's announced closure plan."
+    },
+    {
+      "id": "hei_src_009003",
+      "exchange_id": "hei_ex_000409",
+      "event_id": "hei_ev_009002",
+      "source_type": "news_article",
+      "title": "Ukrainian programmer plans to close bitcoin exchange after hacker attacks",
+      "url": "https://ain.ua/2015/05/13/580215",
+      "publisher": "AIN.UA",
+      "published_at": "2015-05-13",
+      "archived_url": "https://web.archive.org/web/*/https://ain.ua/2015/05/13/580215",
+      "accessed_at": "2026-06-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Contemporaneous report identifying repeated attacks as the reason for the announced closure plan."
     }
   ]
 }

--- a/records/exchanges/zondacrypto.json
+++ b/records/exchanges/zondacrypto.json
@@ -27,8 +27,39 @@
     "last_verified_at": "2026-04-25",
     "notes": "Do not mark dead yet. The official website is still live and no formal shutdown / bankruptcy / liquidation marker has been confirmed. Status is limited because prosecutor materials and victim instructions document withdrawal problems, an inaccessible approximately 4,500 BTC cold wallet, and losses reported at no less than 350 million PLN. Recheck frequently; potential future reclassification paths are inactive, dead, or scam_rug/insolvency depending on court, regulator, or liquidation evidence."
   },
-  "events": [],
-  "evidence": [],
+  "events": [
+    {
+      "id": "hei_ev_009001",
+      "exchange_id": "hei_ex_000216",
+      "event_type": "launched",
+      "event_date": "2014-01-01",
+      "title": "BitBay predecessor exchange was founded in Poland",
+      "description": "The exchange now known as zondacrypto was founded in Poland in 2014 under its earlier BitBay identity.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "The official history establishes the year but not the exact day, so January 1 is used as a year-level placeholder."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_009001",
+      "exchange_id": "hei_ex_000216",
+      "event_id": "hei_ev_009001",
+      "source_type": "official_statement",
+      "title": "About us - zondacrypto",
+      "url": "https://zondacrypto.com/who-we-are",
+      "publisher": "zondacrypto",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://zondacrypto.com/who-we-are",
+      "accessed_at": "2026-06-23",
+      "reliability": "high",
+      "claim_scope": "launch_date",
+      "notes": "Official company history states that the exchange was founded in Poland in 2014."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000216",
     "expected": {


### PR DESCRIPTION
## Purpose

Repair the twelfth active-side CEX batch with five evidence-backed quality improvements.

## Records

```text
zondacrypto
Bitcointry
BTC Trade UA
Bitstamp
Bequant
```

## Final changes

- Added the missing official 2014 launch event for the BitBay / zondacrypto lineage.
- Resolved Bitcointry's origin to Seychelles with official whitepaper, app-store operator, and specific independent company evidence.
- Added BTC Trade UA's May 2015 shutdown announcement as a non-terminal historical event because the platform later resumed.
- Promoted Bitstamp's official URL state to `live_verified` through a reviewed canonical entity correction.
- Added CrossTower's November 2022 agreement to acquire BEQUANT without forcing a terminal status change.
- Left Bitbaby and KuCoin out rather than forcing unsupported or tool-blocked changes.

## Final projected counts

```text
Entities:  413
Events:    701
Evidence: 1703
```

## Validation

All nine permanent gates pass on head `17fca186b07a982f82aa5b8357211d61af0c0bec`.

GitHub-only. No Cloudflare changes or deployment.