### PR TITLE
Add active CEX repair dispositions

### DIFF
--- a/config/active-cex-repair-dispositions.json
+++ b/config/active-cex-repair-dispositions.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "reviewed_at": "2026-06-23",
+  "description": "Reviewed temporary deferrals for the active-side CEX repair queue. Deferred records remain fully scored and visible in the audit; only automatic top-five selection is postponed until review_after.",
+  "entities": [
+    {
+      "id": "hei_ex_000250",
+      "slug": "coinedup",
+      "disposition": "defer",
+      "reason": "Remaining score is driven by intentionally unresolved origin and official URL state. The reviewed evidence does not justify a stronger country, URL, or terminal-status classification.",
+      "review_after": "2026-09-23"
+    },
+    {
+      "id": "hei_ex_000382",
+      "slug": "bitbaby",
+      "disposition": "defer",
+      "reason": "The record already has launch and current-status evidence, but no second meaningful historical event or directly verifiable operating legal entity was found. Additional changes would be filler.",
+      "review_after": "2026-09-23"
+    },
+    {
+      "id": "hei_ex_000416",
+      "slug": "byte-exchange",
+      "disposition": "defer",
+      "reason": "Official and independent materials conflict on establishment year and domicile, and no additional meaningful historical event is currently verified. The disagreement remains visible in the record.",
+      "review_after": "2026-09-23"
+    }
+  ]
+}

--- a/scripts/audit-thin-active-cex.mjs
+++ b/scripts/audit-thin-active-cex.mjs
@@ -7,10 +7,13 @@ const root = process.cwd()
 const outputArg = process.argv.find((arg) => arg.startsWith('--output='))
 const markdownArg = process.argv.find((arg) => arg.startsWith('--markdown='))
 const strict = process.argv.includes('--strict')
+const dispositionPath = path.join(root, 'config', 'active-cex-repair-dispositions.json')
+const generatedDate = new Date().toISOString().slice(0, 10)
 
 const ACTIVE_SIDE = new Set(['active', 'limited', 'inactive'])
 const OFFICIAL_SOURCE_TYPES = new Set(['official_statement', 'official_blog', 'official_social'])
 const INDEPENDENT_SOURCE_TYPES = new Set(['news_article', 'regulatory_notice', 'court_document', 'database_reference'])
+const REPAIR_DISPOSITIONS = new Set(['defer'])
 
 function listRecordBundles() {
   const dir = path.join(root, 'records', 'exchanges')
@@ -27,6 +30,66 @@ function listRecordBundles() {
     }
   }
   return byEntityId
+}
+
+function loadRepairDispositions() {
+  if (!fs.existsSync(dispositionPath)) {
+    return {
+      reviewed_at: null,
+      entries: [],
+      byEntityId: new Map(),
+    }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(dispositionPath, 'utf8'))
+  } catch (error) {
+    throw new Error(`${path.relative(root, dispositionPath)}: invalid JSON: ${error.message}`)
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${path.relative(root, dispositionPath)}: expected object`)
+  }
+  if (parsed.schema_version !== 1) {
+    throw new Error(`${path.relative(root, dispositionPath)}: schema_version must be 1`)
+  }
+  if (!Array.isArray(parsed.entities)) {
+    throw new Error(`${path.relative(root, dispositionPath)}: entities must be an array`)
+  }
+
+  const byEntityId = new Map()
+  for (const [index, entry] of parsed.entities.entries()) {
+    const label = `${path.relative(root, dispositionPath)}.entities[${index}]`
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`${label}: expected object`)
+    }
+    if (typeof entry.id !== 'string' || !entry.id.startsWith('hei_ex_')) {
+      throw new Error(`${label}.id: expected hei_ex_ identifier`)
+    }
+    if (typeof entry.slug !== 'string' || entry.slug.trim() === '') {
+      throw new Error(`${label}.slug: required`)
+    }
+    if (!REPAIR_DISPOSITIONS.has(entry.disposition)) {
+      throw new Error(`${label}.disposition: expected one of ${[...REPAIR_DISPOSITIONS].join(', ')}`)
+    }
+    if (typeof entry.reason !== 'string' || entry.reason.trim().length < 20) {
+      throw new Error(`${label}.reason: must contain a substantive reviewed reason`)
+    }
+    if (typeof entry.review_after !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.review_after) || !Number.isFinite(Date.parse(entry.review_after))) {
+      throw new Error(`${label}.review_after: expected YYYY-MM-DD`)
+    }
+    if (byEntityId.has(entry.id)) {
+      throw new Error(`${label}.id: duplicate disposition for ${entry.id}`)
+    }
+    byEntityId.set(entry.id, entry)
+  }
+
+  return {
+    reviewed_at: parsed.reviewed_at || null,
+    entries: parsed.entities,
+    byEntityId,
+  }
 }
 
 function ageDays(value) {
@@ -105,6 +168,7 @@ function scoreEntity(entity, events, evidence, bundleFile) {
 
 const canonical = await loadCanonicalData()
 const bundleByEntityId = listRecordBundles()
+const dispositions = loadRepairDispositions()
 const eventsByEntity = new Map()
 const evidenceByEntity = new Map()
 for (const event of canonical.events) {
@@ -120,15 +184,54 @@ for (const item of canonical.evidence) {
 
 const records = canonical.entities
   .filter((entity) => entity.type === 'cex' && ACTIVE_SIDE.has(entity.status))
-  .map((entity) => scoreEntity(
-    entity,
-    eventsByEntity.get(entity.id) || [],
-    evidenceByEntity.get(entity.id) || [],
-    bundleByEntityId.get(entity.id),
-  ))
+  .map((entity) => {
+    const record = scoreEntity(
+      entity,
+      eventsByEntity.get(entity.id) || [],
+      evidenceByEntity.get(entity.id) || [],
+      bundleByEntityId.get(entity.id),
+    )
+    const disposition = dispositions.byEntityId.get(entity.id) || null
+    const dispositionActive = Boolean(disposition && disposition.review_after > generatedDate)
+    return {
+      ...record,
+      repair_disposition: disposition?.disposition || null,
+      repair_disposition_reason: disposition?.reason || null,
+      repair_review_after: disposition?.review_after || null,
+      repair_disposition_active: dispositionActive,
+    }
+  })
   .sort((left, right) => right.repair_score - left.repair_score || left.canonical_name.localeCompare(right.canonical_name))
 
-const bundleRepairable = records.filter((record) => record.bundle_file && record.repair_score > 0)
+const recordById = new Map(records.map((record) => [record.entity_id, record]))
+const dispositionErrors = []
+for (const entry of dispositions.entries) {
+  const record = recordById.get(entry.id)
+  if (!record) {
+    dispositionErrors.push(`${entry.id}: disposition does not map to an active-side CEX record`)
+    continue
+  }
+  if (record.slug !== entry.slug) {
+    dispositionErrors.push(`${entry.id}: disposition slug ${entry.slug} does not match ${record.slug}`)
+  }
+  if (!record.bundle_file) {
+    dispositionErrors.push(`${entry.id}: disposition requires an existing reviewed record bundle`)
+  }
+  if (record.repair_score === 0) {
+    dispositionErrors.push(`${entry.id}: disposition is stale because the record repair score is already zero`)
+  }
+}
+if (dispositionErrors.length > 0) {
+  throw new Error(`Invalid active CEX repair dispositions:\n- ${dispositionErrors.join('\n- ')}`)
+}
+
+const deferredRecords = records.filter((record) => record.repair_disposition === 'defer' && record.repair_disposition_active)
+const dueDispositions = records.filter((record) => record.repair_disposition === 'defer' && !record.repair_disposition_active)
+const bundleRepairable = records.filter((record) => (
+  record.bundle_file
+  && record.repair_score > 0
+  && !record.repair_disposition_active
+))
 const selectedBatch = bundleRepairable.slice(0, 5).map((record) => record.entity_id)
 const scoreBands = {
   critical: records.filter((record) => record.repair_score >= 20).length,
@@ -149,10 +252,15 @@ const report = {
     types: ['cex'],
     statuses: [...ACTIVE_SIDE],
   },
-  selection_policy: 'Rank all active-side CEX records, then select the five highest-scoring records that already have a reviewed bundle and can be repaired count-neutrally.',
+  selection_policy: 'Rank all active-side CEX records, keep every score visible, exclude only active reviewed deferrals, then select the five highest-scoring records that already have a reviewed bundle.',
   active_side_cex_count: records.length,
   mapped_record_bundles: records.filter((record) => record.bundle_file).length,
   canonical_only_records: records.filter((record) => !record.bundle_file).length,
+  repair_dispositions_reviewed_at: dispositions.reviewed_at,
+  deferred_record_count: deferredRecords.length,
+  deferred_records: deferredRecords,
+  due_disposition_count: dueDispositions.length,
+  due_dispositions: dueDispositions,
   score_bands: scoreBands,
   selected_batch: selectedBatch,
   selected_records: selectedBatch.map((id) => records.find((record) => record.entity_id === id)),
@@ -167,18 +275,32 @@ const markdown = [
   `- Active-side CEX records: ${records.length}`,
   `- Mapped record bundles: ${report.mapped_record_bundles}`,
   `- Canonical-only records: ${report.canonical_only_records}`,
+  `- Active reviewed deferrals: ${report.deferred_record_count}`,
+  `- Deferrals due for review: ${report.due_disposition_count}`,
   `- Score bands: ${JSON.stringify(scoreBands)}`,
-  '- Selection: top five scored records with an existing reviewed bundle; canonical-only repairs are a separate workstream.',
+  '- Selection: top five scored records with an existing reviewed bundle, excluding only active reviewed deferrals; deferred records remain visible and scored.',
   '',
   '## Selected repair batch',
   '',
   ...report.selected_records.map((record, index) => `${index + 1}. ${record.canonical_name} (${record.entity_id}) — score ${record.repair_score} — ${record.bundle_file}`),
   '',
+  '## Reviewed deferrals',
+  '',
+  ...(deferredRecords.length > 0
+    ? deferredRecords.map((record) => `- ${record.canonical_name} (${record.entity_id}) — score ${record.repair_score} — review after ${record.repair_review_after} — ${record.repair_disposition_reason}`)
+    : ['- None']),
+  '',
+  '## Deferrals due for review',
+  '',
+  ...(dueDispositions.length > 0
+    ? dueDispositions.map((record) => `- ${record.canonical_name} (${record.entity_id}) — score ${record.repair_score} — review date ${record.repair_review_after}`)
+    : ['- None']),
+  '',
   '## Highest-priority records',
   '',
-  '| Entity | Status | Score | Events | Evidence | Bundle | Top issues |',
-  '|---|---:|---:|---:|---:|---|---|',
-  ...records.slice(0, 25).map((record) => `| ${record.canonical_name} | ${record.status} | ${record.repair_score} | ${record.event_count} | ${record.evidence_count} | ${record.bundle_file || 'canonical-only'} | ${record.issues.slice(0, 3).map((issue) => issue.code).join(', ')} |`),
+  '| Entity | Status | Score | Events | Evidence | Bundle | Disposition | Top issues |',
+  '|---|---:|---:|---:|---:|---|---|---|',
+  ...records.slice(0, 25).map((record) => `| ${record.canonical_name} | ${record.status} | ${record.repair_score} | ${record.event_count} | ${record.evidence_count} | ${record.bundle_file || 'canonical-only'} | ${record.repair_disposition_active ? `defer until ${record.repair_review_after}` : '—'} | ${record.issues.slice(0, 3).map((issue) => issue.code).join(', ')} |`),
   '',
 ].join('\n')
 
@@ -195,6 +317,8 @@ if (markdownArg) {
 
 console.log(`Active-side CEX records: ${records.length}`)
 console.log(`Mapped bundles: ${report.mapped_record_bundles}`)
+console.log(`Active reviewed deferrals: ${report.deferred_record_count}`)
+console.log(`Deferrals due for review: ${report.due_disposition_count}`)
 console.log(`Score bands: ${JSON.stringify(scoreBands)}`)
 console.log(`Selected batch: ${selectedBatch.join(', ')}`)
 if (strict && report.status !== 'pass') process.exit(1)


### PR DESCRIPTION
## Purpose

Add reviewed queue dispositions for active-side CEX records that need later source review.

## Final behavior

- CoinedUp, Bitbaby, and Byte Exchange remain visible and scored in every audit report.
- Only automatic top-five selection is postponed.
- Each entry returns to selection on `2026-09-23` unless reviewed earlier.
- Invalid IDs, slugs, dates, reasons, missing bundles, duplicate entries, and stale zero-score dispositions fail the audit.
- JSON and Markdown artifacts list active and due dispositions separately.

## New selected batch

```text
KuCoin
BitStorage
Aivora Exchange
Binance US
Bit2C
```

## Validation

All eight applicable workflows pass on head `1bfcd6635dda71c0a6dcb9750c5dfcc6c9a7b30d`, including the modified Active CEX repair audit and full CI. Records validation is path-filtered and did not run because no record bundle changed.

No canonical data or Cloudflare changes.