### PR TITLE
Defer unsupported Aivora event expansion

### DIFF
--- a/config/active-cex-repair-dispositions.json
+++ b/config/active-cex-repair-dispositions.json
@@ -23,6 +23,13 @@
       "disposition": "defer",
       "reason": "Official and independent materials conflict on establishment year and domicile, and no additional meaningful historical event is currently verified. The disagreement remains visible in the record.",
       "review_after": "2026-09-23"
+    },
+    {
+      "id": "hei_ex_000355",
+      "slug": "aivora-exchange",
+      "disposition": "defer",
+      "reason": "The record already has launch and current-status evidence. The only additional compliance milestone found is the platform's own MSB claim, which is not enough to create a separate verified historical event.",
+      "review_after": "2026-09-23"
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Record the reviewed decision not to create a second Aivora event from an unverified compliance claim.

## Final behavior

- Aivora Exchange remains visible with repair score 2.
- Automatic selection is postponed until `2026-09-23`.
- The next repair batch advances to KuCoin, BitStorage, Binance US, Bit2C, and Bitazza.
- The record is not marked complete and no data fields are changed.

## Validation

All eight applicable workflows pass on head `074651d8366dcc10e3421823b40e056dfe8b7d85`.

No record bundle, canonical data, or Cloudflare changes.