### PR TITLE
Defer KuCoin canonical correction

### DIFF
--- a/config/active-cex-repair-dispositions.json
+++ b/config/active-cex-repair-dispositions.json
@@ -30,6 +30,13 @@
       "disposition": "defer",
       "reason": "The record already has launch and current-status evidence. The only additional compliance milestone found is the platform's own MSB claim, which is not enough to create a separate verified historical event.",
       "review_after": "2026-09-23"
+    },
+    {
+      "id": "hei_ex_000014",
+      "slug": "kucoin",
+      "disposition": "defer",
+      "reason": "The record already contains launch, security-incident, and U.S. regulatory history. Its remaining score comes from canonical summary and URL-verification fields that require a separate guarded canonical correction rather than more events or evidence.",
+      "review_after": "2026-07-07"
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Keep KuCoin's existing three-event history intact while postponing its remaining canonical summary and URL-verification correction.

## Final behavior

- KuCoin remains visible with repair score 4.
- Automatic selection is postponed only until `2026-07-07`.
- Its launch, 2020 security incident, and 2025 U.S. regulatory history remain unchanged.
- No filler event or evidence was added.

## Validation

All eight applicable workflows pass on head `21d4ad1a00b9fa5897862fe6b281bded29436459`.

No record bundle, canonical data, or Cloudflare changes.