### PR TITLE
Fix monitoring sitemap, summary, and news extraction regressions

### DIFF
--- a/scripts/monitoring/adapters/sitemap-check.mjs
+++ b/scripts/monitoring/adapters/sitemap-check.mjs
@@ -16,6 +16,19 @@ function extractLocs(xml) {
     .filter(Boolean);
 }
 
+export function normalizeSitemapUrl(value) {
+  const input = String(value || '').trim();
+  if (!input) return input;
+
+  try {
+    const parsed = new URL(input);
+    const pathname = parsed.pathname === '/' ? '/' : parsed.pathname.replace(/\/+$/, '');
+    return `${parsed.origin}${pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return input === '/' ? '/' : input.replace(/\/+$/, '');
+  }
+}
+
 async function fetchText(url) {
   const response = await fetch(url, {
     headers: { 'user-agent': 'HEI-Monitoring/0.1' },
@@ -43,13 +56,14 @@ export async function checkSitemap({ sitemapUrl, siteUrl, entities = [], require
 
   const xml = await fetchText(sitemapUrl);
   const urls = extractLocs(xml);
+  const normalizedUrls = new Set(urls.map(normalizeSitemapUrl));
   const normalizedSiteUrl = String(siteUrl || '').replace(/\/+$/, '');
   const exchangePrefix = `${normalizedSiteUrl}/exchange/`;
   const actualExchangeRoutes = urls.filter((url) => url.startsWith(exchangePrefix)).length;
   const missingStaticRoutes = requiredStaticRoutes.filter((route) => {
     const normalizedRoute = route === '/' ? '/' : route.replace(/\/+$/, '');
     const expected = normalizedRoute === '/' ? `${normalizedSiteUrl}/` : `${normalizedSiteUrl}${normalizedRoute}`;
-    return !urls.includes(expected);
+    return !normalizedUrls.has(normalizeSitemapUrl(expected));
   });
 
   return {

--- a/scripts/monitoring/core/news-extract.mjs
+++ b/scripts/monitoring/core/news-extract.mjs
@@ -23,6 +23,7 @@ const STOP_PREFIXES = [
 ];
 
 const KNOWN_BAD_NAMES = new Set([
+  'closure',
   'crypto',
   'cryptocurrency',
   'bitcoin',
@@ -77,9 +78,9 @@ export function inferEventCategory(textValue, fallbackCategory = 'unknown') {
 export function extractCandidateNameFromNews(item) {
   const text = `${item.title || ''} ${item.snippet || ''}`;
   const patterns = [
+    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2})\s+(?:(?:[Ss]huts|[Ww]ill [Ss]hut|[Tt]o [Ss]hut) [Dd]own|[Cc]eases [Oo]perations|[Hh]alts [Tt]rading|[Ss]uspends [Ww]ithdrawals|[Ii]s [Hh]acked|[Ww]as [Hh]acked|[Rr]ebrands|[Ii]s [Aa]cquired|[Ww]arning|[Ee]nforcement [Aa]ction|[Ss]anctioned)\b/,
     /\b(?:exchange|platform|protocol|DEX)\s+([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\b/,
     /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\s+(?:exchange|DEX|protocol|platform)\b/,
-    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2})\s+(?:shuts down|ceases operations|halts trading|suspends withdrawals|is hacked|was hacked|rebrands|is acquired|warning|enforcement action|sanctioned)\b/,
   ];
 
   for (const pattern of patterns) {

--- a/scripts/monitoring/core/summary-writer.mjs
+++ b/scripts/monitoring/core/summary-writer.mjs
@@ -20,6 +20,10 @@ function findResult(results, monitor) {
   return results.find((result) => result.monitor === monitor) || null;
 }
 
+function summaryValue(value, fallback = 0) {
+  return value ?? fallback;
+}
+
 export function buildSummaryMarkdown({ runId, mode, startedAt, finishedAt, results, hasMeaningfulFindings, noiseSummary = null }) {
   const allFindings = flattenFindings(results);
   const findings = visibleFindings(allFindings);
@@ -132,7 +136,7 @@ ${sectionList(evidenceHealthFindings, (finding) => `- [${finding.severity}] ${fi
 
 ## Watchlist state
 
-${watchlistState ? `- watchlist_files: ${watchlistState.watchlist_files}\n- watchlist_candidates: ${watchlistState.watchlist_candidates}\n- class_A: ${watchlistState.watchlist_class_counts?.A || 0}\n- class_B: ${watchlistState.watchlist_class_counts?.B || 0}\n- class_C: ${watchlistState.watchlist_class_counts?.C || 0}\n- manual_staging_packages: ${watchlistState.manual_staging_packages}\n- resolution_files: ${watchlistState.resolution_files}` : '- Not available.'}
+${watchlistState ? `- candidate_queue_files: ${summaryValue(watchlistState.candidate_queue_files)}\n- raw_candidate_occurrences: ${summaryValue(watchlistState.raw_candidate_occurrences)}\n- unique_candidate_identities: ${summaryValue(watchlistState.unique_candidate_identities)}\n- repeated_occurrences_collapsed: ${summaryValue(watchlistState.repeated_occurrences_collapsed)}\n- class_A: ${watchlistState.watchlist_class_counts?.A || 0}\n- class_B: ${watchlistState.watchlist_class_counts?.B || 0}\n- class_C: ${watchlistState.watchlist_class_counts?.C || 0}\n- manual_staging_packages: ${summaryValue(watchlistState.manual_staging_packages)}\n- historical_resolution_files: ${summaryValue(watchlistState.historical_resolution_files)}\n- resolution_index_entries: ${summaryValue(watchlistState.resolution_index_entries)}\n- resolution_coverage_errors: ${summaryValue(watchlistState.resolution_coverage_errors)}` : '- Not available.'}
 
 ${sectionList(watchlistFindings, (finding) => `- [${finding.severity}] ${finding.title} — ${finding.recommended_action || 'review'}`)}
 

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -3,6 +3,7 @@ import { monitorRegistryNames, MONITOR_REGISTRY } from './core/monitor-registry.
 import { loadCanonicalData } from './core/load-canonical-data.mjs';
 import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
 import { buildSummaryMarkdown } from './core/summary-writer.mjs';
+import { extractCandidateNameFromNews } from './core/news-extract.mjs';
 import { normalizeSitemapUrl } from './adapters/sitemap-check.mjs';
 import { runReviewedBundleAggregationRegression } from '../test-reviewed-bundle-aggregation.mjs';
 import { buildRegistryMetrics, parseReviewMonth } from '../review/monthly-registry-core.mjs';
@@ -47,6 +48,12 @@ function runMonitoringOutputRegressions() {
     normalizeSitemapUrl('https://hei.badjoke-lab.com/') === 'https://hei.badjoke-lab.com/',
     'sitemap root URL must retain its slash',
   );
+
+  const extractedName = extractCandidateNameFromNews({
+    title: 'Oxium Shuts Down as Revenue Collapse Forces DEX Closure',
+    snippet: 'The Sei ecosystem exchange will close its interface.',
+  });
+  assert(extractedName === 'Oxium', `news extraction must identify Oxium instead of a headline fragment: ${extractedName}`);
 
   const summary = buildSummaryMarkdown({
     runId: '20260630-smoke',

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -2,6 +2,8 @@ import { MONITOR_NAMES } from './core/constants.mjs';
 import { monitorRegistryNames, MONITOR_REGISTRY } from './core/monitor-registry.mjs';
 import { loadCanonicalData } from './core/load-canonical-data.mjs';
 import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
+import { buildSummaryMarkdown } from './core/summary-writer.mjs';
+import { normalizeSitemapUrl } from './adapters/sitemap-check.mjs';
 import { runReviewedBundleAggregationRegression } from '../test-reviewed-bundle-aggregation.mjs';
 import { buildRegistryMetrics, parseReviewMonth } from '../review/monthly-registry-core.mjs';
 import { runMonthlyWatchlistBacklogRegression } from '../review/test-monthly-watchlist-core.mjs';
@@ -36,6 +38,47 @@ function validateMonitorResult(result, expectedName) {
   assert(Number.isInteger(result.summary.errors_count), `${expectedName} summary.errors_count must be integer`);
 }
 
+function runMonitoringOutputRegressions() {
+  assert(
+    normalizeSitemapUrl('https://hei.badjoke-lab.com/dead/') === normalizeSitemapUrl('https://hei.badjoke-lab.com/dead'),
+    'sitemap URL comparison must ignore a non-root trailing slash',
+  );
+  assert(
+    normalizeSitemapUrl('https://hei.badjoke-lab.com/') === 'https://hei.badjoke-lab.com/',
+    'sitemap root URL must retain its slash',
+  );
+
+  const summary = buildSummaryMarkdown({
+    runId: '20260630-smoke',
+    mode: 'smoke',
+    startedAt: '2026-06-30T00:00:00.000Z',
+    finishedAt: '2026-06-30T00:00:01.000Z',
+    hasMeaningfulFindings: false,
+    results: [
+      {
+        monitor: 'monitoring-health-watch',
+        findings: [],
+        candidates: [],
+        watchlist_state: {
+          candidate_queue_files: 2,
+          raw_candidate_occurrences: 12,
+          unique_candidate_identities: 9,
+          repeated_occurrences_collapsed: 3,
+          watchlist_class_counts: { A: 1, B: 7, C: 1 },
+          manual_staging_packages: 4,
+          historical_resolution_files: 5,
+          resolution_index_entries: 6,
+          resolution_coverage_errors: 0,
+        },
+      },
+    ],
+  });
+
+  assert(!summary.includes('undefined'), 'monitoring summary must not render undefined watchlist values');
+  assert(summary.includes('candidate_queue_files: 2'), 'monitoring summary must use the current watchlist state schema');
+  assert(summary.includes('unique_candidate_identities: 9'), 'monitoring summary must report deduplicated candidate identities');
+}
+
 async function main() {
   assertSameSet(MONITOR_NAMES, monitorRegistryNames(), 'MONITOR_NAMES and MONITOR_REGISTRY are out of sync');
 
@@ -62,6 +105,7 @@ async function main() {
   });
   validateMonitorResult(synthetic, 'smoke-synthetic');
 
+  runMonitoringOutputRegressions();
   runReviewedBundleAggregationRegression();
   runMonthlyWatchlistBacklogRegression();
   runMonthlyReviewBuilderRegression();


### PR DESCRIPTION
## Result

Fixes three monitoring regressions found in the 2026-06-29 report.

### Sitemap monitoring

- treats trailing-slash and non-trailing-slash static URLs as equivalent
- preserves the root URL slash
- prevents `/dead/`, `/active/`, `/stats/`, `/methodology/`, `/about/`, and `/donate/` from being falsely reported as absent when the generated sitemap already contains them

### Watchlist summary

- aligns summary rendering with the current `watchlist_state` schema
- replaces obsolete fields that rendered as `undefined`
- reports queue files, raw occurrences, unique identities, collapsed repeats, staging packages, and resolution counts

### News candidate extraction

- prioritizes entity names attached to shutdown/action verbs before generic `DEX <word>` matching
- rejects `Closure` as a generic headline fragment
- correctly extracts `Oxium` from `Oxium Shuts Down as Revenue Collapse Forces DEX Closure`

### Regression coverage

- adds trailing-slash normalization assertions
- adds a summary regression asserting that `undefined` is never rendered
- adds an Oxium/Closure headline-extraction regression

### Safety

- no canonical entity/event/evidence changes
- no Cloudflare configuration changes
- monitoring code and regression coverage only
