### PR TITLE
Close verified-unadded range 0401-0450

### DIFF
--- a/docs/HEI_V1_EXECUTION_ROADMAP.md
+++ b/docs/HEI_V1_EXECUTION_ROADMAP.md
@@ -13,18 +13,16 @@ Repository state is authoritative when this checkpoint and GitHub disagree.
 - Automated monitoring must not directly edit canonical data.
 - Do not add thin records to satisfy a count target.
 - Preserve historical URLs and conservative status decisions.
-- Do not bypass frozen lineage reviews.
-- Treat maximum IDs as allocation markers, not record counts.
-- Confirm the full diff and all required checks before merge.
+- Confirm the full diff and required checks before merge.
 
 ## Current checkpoint
 
 ```text
-Last confirmed main SHA: c483db495733722b1a38df7ceeb9b85487d17df3
-Last merged PR: #530 Reach Phase C 550-entity milestone
-Current phase: Phase C milestone audit
-Current item: resolve milestone audit findings and document completion
-Next item: close range 0401-0450, then begin Phase D public update surfaces
+Last confirmed main SHA: 68ebe476e87d6ccb764bd51d52b94caf9638e039
+Last merged PR: #531 Complete Phase C milestone audit
+Current phase: Phase D — public update surfaces
+Current item: finalize range 0401-0450 closure
+Next item: HEI Registry Update surface
 Cloudflare changes: none
 Production deployment: none
 ```
@@ -40,37 +38,19 @@ Maximum event ID:    hei_ev_010080
 Maximum evidence ID: hei_src_011312
 ```
 
-```text
-Phase C entity target: 550
-Reviewed entities:     550
-Remaining to target:     0
-Progress:              100%
-```
-
-## Phase C milestone audit
-
-Milestone count consistency:
+## Phase C completion
 
 ```text
-Projected:   550 / 1004 / 2621
-Monitoring:  550 / 1004 / 2621
-Machine:     550 / 1004 / 2621
-Built:       550 / 1004 / 2621
-Detail pages: 550
-Sitemap exchange routes: 550
-Count semantics status: pass
+entity target:                     550 / 550
+count semantics:                   pass
+records validation:                pass
+country origin strict gate:        pass
+active CEX / DEX readiness:        pass
+watchlist resolution gate:         pass
+entity quality critical findings:  0
+entity quality high findings:      0
+Phase C status:                    complete
 ```
-
-Milestone entity-quality baseline:
-
-```text
-critical: 0
-high:     2
-medium:  17
-low:     60
-```
-
-The two high findings are resolved in the current audit branch by reclassifying BKEX and ZB.com from `limited` to `inactive`. Neither is marked dead because the reviewed evidence does not establish a sufficiently strong terminal closure marker.
 
 Audit source of truth:
 
@@ -78,65 +58,59 @@ Audit source of truth:
 docs/audits/HEI_PHASE_C_MILESTONE_AUDIT_2026-07-05.md
 ```
 
+Remaining quality queues are handled through reviewed repair batches and do not reopen count-driven growth as the primary milestone.
+
 ## Range 0401-0450
 
-The range remains open after the 550 milestone. Five research rows remain unresolved:
-
 ```text
-0403 CoinDeal
-0410 Coingi
-0419 CoinPlace
-0422 CoinsBank
-0447 Covesting
+range records:                 50
+promoted add_now:               7
+promoted research:             17
+existing duplicates consumed:   2
+unresolved add_now:              0
+unresolved needs_research:       0
+pending_thin:                   16
+out_of_scope_or_duplicate:       8
+range status:                   closed
 ```
 
-Range closure is operational cleanup and no longer a prerequisite for reaching the Phase C entity milestone.
+## Phase D execution order
 
-## Remaining execution order
+1. HEI Registry Update surface.
+2. Exchange Incident Timeline surface.
+3. Evidence Health and Data Quality public summary.
+4. Monthly historical exchange snapshot.
+5. RSS and JSON feed outputs for reviewed public updates.
+6. Continue quality repair batches in parallel.
 
-1. Validate and merge the Phase C milestone audit PR.
-2. Resolve the five remaining research rows and close range 0401-0450.
-3. Begin Phase D public update surfaces and publication-oriented registry outputs.
-4. Continue reviewed quality-repair batches for medium and low audit findings.
-5. Build Stats, SEO, Japanese routes, and final integration in the existing phase order.
+Public publication rules:
 
-## Phase C completion gate
-
-```text
-reviewed entities >= 550                    pass
-no thin count-filler records                pass through reviewed bundle policy
-all required CI checks green                milestone PR pass; audit PR pending
-public, monitoring, machine, built agree    pass
-record duplicate / ID collision checks      pass
-country/origin strict gate                  pass
-active CEX / DEX readiness gates            pass
-entity quality critical findings            0
-entity quality high findings                2 -> resolved in audit branch
-```
-
-Phase C becomes formally complete when the current audit PR passes all repository gates and merges.
+- only merged canonical changes are presented as official registry updates;
+- raw monitoring findings remain internal;
+- monitoring signals are not final status classifications;
+- public timeline items require reviewed canonical events or separately reviewed confirmed items.
 
 ## Later phases
 
-- Phase D: Registry Update, incident timeline, evidence health, monthly snapshot, feeds.
 - Phase E: Stats, internal links, SEO, metadata, sitemap.
 - Phase F: English root and Japanese `/ja/` routes with translation overlays.
 - Phase G: accessibility, URL safety, production integration, runbook, v1.0 baseline.
 
-## Schedule
+## Immediate schedule
 
-| Period | Work | Result |
+| Order | Work | Result |
 |---|---|---|
-| Immediate | merge milestone audit and close current research range | Phase C complete |
-| Next | Phase D public update surfaces | visible registry update layer |
-| Following | Stats / SEO / Japanese routes | analysis and discovery expansion |
-| Final | integration and v1.0 baseline | HEI v1.0 |
+| 1 | merge range-close checkpoint | current research range fully closed |
+| 2 | implement Registry Update | first Phase D public update surface |
+| 3 | implement Incident Timeline | canonical event history surface |
+| 4 | implement quality and monthly summaries | transparent maintenance outputs |
+| 5 | add feeds | machine-readable public update stream |
 
 GitHub-side work can continue without Cloudflare access.
 
 ## Recovery procedure
 
 1. Confirm current main, open PRs, and actual reviewed counts.
-2. Read the Phase C milestone audit document and latest workflow results.
-3. Resume the first incomplete item in the execution order above.
+2. Read the Phase C audit and latest range-close memo.
+3. Resume the first incomplete Phase D item above.
 4. Update this checkpoint whenever counts, phase, or execution order change.

--- a/docs/backlog/consumed/hei_unadded_0401-0450-final-research-close.md
+++ b/docs/backlog/consumed/hei_unadded_0401-0450-final-research-close.md
@@ -1,0 +1,28 @@
+# Range 0401-0450 final research close
+
+Reviewed at: 2026-07-05
+
+## Final research decisions
+
+- `0403` CoinDeal -> `pending_thin`; registry-level candidate signal remains insufficient for a public-quality HEI record.
+- `0410` Coingi -> `pending_thin`; no sufficiently strong operator, domain, lifecycle, or independent historical evidence was recovered in this review.
+- `0419` CoinPlace -> `pending_thin`; the former service identity is plausible and the current domain is repurposed, but the reviewed evidence is still too thin for a public-quality historical lifecycle record.
+- `0422` CoinsBank -> `pending_thin`; public identity and lifecycle evidence remain insufficient for canonical promotion.
+- `0447` Covesting -> `out_of_scope_or_duplicate`; the current first-party identity is a software and infrastructure provider for wallets, exchanges, and trading platforms rather than a distinct exchange entity for HEI.
+
+## Previously resolved duplicate in research queue
+
+- `0407` CoinExchange -> existing `hei_ex_000112` CoinExchange.io; no new entity.
+
+## Range output
+
+- promoted add-now records: 7
+- promoted research records: 17
+- existing duplicates consumed: 2
+- pending thin: 16
+- out of scope or duplicate: 8
+- unresolved add-now: 0
+- unresolved needs-research: 0
+- range status: closed
+
+No canonical record is added in this final close batch. No Cloudflare or production deployment changes are included.

--- a/docs/backlog/scans/hei_unadded_0401-0450-scan.md
+++ b/docs/backlog/scans/hei_unadded_0401-0450-scan.md
@@ -1,6 +1,6 @@
 # Scan: verified-unadded rows 0401-0450
 
-Status: reviewed initial scan / add-now queue consumed
+Status: closed / all add-now and research rows resolved
 
 ## Integrity binding
 
@@ -24,79 +24,81 @@ Status: reviewed initial scan / add-now queue consumed
 - `0416` Coinmate -> `hei_ex_000644`
 - `0427` CoinTR -> `hei_ex_000645`
 - `0429` CoinUp.io -> `hei_ex_000646`
-- `0433` Coinzoom -> `hei_ex_000647`
+- `0433` CoinZoom -> `hei_ex_000647`
 - `0436` Comet Swap -> `hei_ex_000648`
 - `0443` Convergence Finance -> `hei_ex_000649`
 
-## Existing duplicate consumed from add-now queue
+## Promoted research rows
 
-- `0424` coinsph / Coins.ph -> existing `hei_ex_000043`; no new entity
+- `0405` Coindelta -> `hei_ex_000664`
+- `0408` CoinField -> `hei_ex_000662`
+- `0411` Coinhain -> `hei_ex_000650`
+- `0412` Coinhouse -> `hei_ex_000658`
+- `0423` Coinsbit -> `hei_ex_000661`
+- `0425` CoinSwap Space -> `hei_ex_000651`
+- `0426` CoinTiger -> `hei_ex_000663`
+- `0430` COINUT -> `hei_ex_000659`
+- `0432` CoinZest -> `hei_ex_000666`
+- `0435` ColorPool -> `hei_ex_000652`
+- `0437` Cometh -> `hei_ex_000653`
+- `0439` Complus Network -> `hei_ex_000654`
+- `0440` Concordex -> `hei_ex_000655`
+- `0441` Cone -> `hei_ex_000656`
+- `0442` Consensus Liquidity DEX -> parent Swapscanner `hei_ex_000657`
+- `0445` Counos Exchange -> parent Counos `hei_ex_000660`
+- `0449` CPDAX -> `hei_ex_000665`
 
-## Needs-research queue
+## Existing duplicates consumed
 
-- `0403` CoinDeal
-- `0405` Coindelta
-- `0407` CoinExchange
-- `0408` CoinField
-- `0410` Coingi
-- `0411` Coinhain
-- `0412` Coinhouse
-- `0419` CoinPlace
-- `0422` CoinsBank
-- `0423` Coinsbit
-- `0425` CoinSwap Space
-- `0426` CoinTiger
-- `0430` Coinut
-- `0432` CoinZest
-- `0435` ColorPool
-- `0437` Cometh parent identity review
-- `0439` Complus Network
-- `0440` Concordex
-- `0441` Cone
-- `0442` Consensus Liquidity DEX
-- `0445` Counos Exchange
-- `0447` Covesting
-- `0449` CPDAX
+- `0407` CoinExchange -> existing `hei_ex_000112` CoinExchange.io
+- `0424` coinsph / Coins.ph -> existing `hei_ex_000043`
 
 ## Pending thin
 
 - `0401` CoinChangeX
+- `0403` CoinDeal
 - `0409` Coingarage
+- `0410` Coingi
 - `0413` Coinhub
 - `0414` Coinlogy
 - `0415` CoinMargin
 - `0417` CoinMex
+- `0419` CoinPlace
 - `0420` Coinquista
 - `0421` Coinrate
+- `0422` CoinsBank
 - `0428` Cointradecx
 - `0431` Coiny
 - `0448` COXI
 - `0450` Cratex
 
+These rows remain non-canonical because the reviewed evidence is too thin, lifecycle status is unresolved, or identity cannot yet be established at public-record quality.
+
 ## Out of scope or duplicate rows
 
-- `0404` CoinDeal Derivatives — product surface under parent identity review `0403`
+- `0404` CoinDeal Derivatives — product surface under CoinDeal review
 - `0406` CoinEx Market — market/product row under existing `hei_ex_000418` CoinEx
 - `0418` CoinOne Swap — product row under existing `hei_ex_000035` Coinone
 - `0434` Collector Crypt — Physical TCG marketplace, outside HEI exchange scope
-- `0438` ComethSwap — product/version row under parent identity review `0437`
+- `0438` ComethSwap — product/version row under `hei_ex_000653` Cometh
 - `0444` Copump — launchpad category, outside HEI exchange scope
 - `0446` Courtyard — Physical TCG marketplace, outside HEI exchange scope
+- `0447` Covesting — software and exchange-infrastructure provider rather than a distinct HEI exchange entity
 
 ## Current range position
 
 ```text
 range records:                 50
 promoted add_now:               7
-promoted research:              0
-existing duplicate consumed:    1
-unresolved add_now:             0
-unresolved needs_research:     23
-pending_thin:                  12
-out_of_scope_or_duplicate:      7
-range status:                  open
+promoted research:             17
+existing duplicates consumed:   2
+unresolved add_now:              0
+unresolved needs_research:       0
+pending_thin:                   16
+out_of_scope_or_duplicate:       8
+range status:                   closed
 ```
 
 ## Next step
 
-Process the twenty-three needs-research rows in evidence-backed clusters and close the range when every research row is resolved.
+Phase C is complete. Begin Phase D public update surfaces while continuing medium- and low-severity quality repairs in reviewed batches.


### PR DESCRIPTION
Closes candidate range 0401 through 0450 after all add-now and research rows were resolved. The final five research rows produce no new canonical records: four remain pending thin and Covesting is classified out of scope for HEI as a software and exchange-infrastructure provider rather than a distinct exchange entity.

Final range position:

```text
promoted add_now:               7
promoted research:             17
existing duplicates consumed:   2
unresolved add_now:              0
unresolved needs_research:       0
pending_thin:                   16
out_of_scope_or_duplicate:       8
range status:                   closed
```

The roadmap advances to Phase D public update surfaces. No canonical record counts or deployment configuration change in this PR.