### PR TITLE
Add reviewed Registry Updates public surface

### DIFF
--- a/data/registry-updates.json
+++ b/data/registry-updates.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "updates": [
+    {
+      "id": "phase-c-audit-complete",
+      "date": "2026-07-05",
+      "update_type": "quality_audit",
+      "title": "Phase C milestone audit completed",
+      "summary": "The 550-entity milestone audit completed with count surfaces aligned and the post-repair entity-quality audit reporting zero critical and zero high findings.",
+      "counts": {
+        "entities_before": 550,
+        "entities_after": 550,
+        "events_before": 1004,
+        "events_after": 1004,
+        "evidence_before": 2621,
+        "evidence_after": 2621
+      },
+      "added_entities": [],
+      "updated_entities": [
+        {
+          "name": "BKEX",
+          "slug": "bkex",
+          "change": "Status reclassified from limited to inactive after milestone quality review."
+        },
+        {
+          "name": "ZB.com",
+          "slug": "zb-com",
+          "change": "Status reclassified from limited to inactive after milestone quality review."
+        }
+      ],
+      "evidence_added": 0,
+      "notes": [
+        "No terminal closure date was asserted for BKEX or ZB.com.",
+        "The post-repair entity-quality audit reported 0 critical and 0 high findings."
+      ]
+    },
+    {
+      "id": "phase-c-550-milestone",
+      "date": "2026-07-05",
+      "update_type": "registry_growth",
+      "title": "HEI reaches 550 reviewed exchange entities",
+      "summary": "A sequence of reviewed growth batches expanded the projected public registry from 510 to 550 entities while events remained at 1,004 and evidence increased from 2,541 to 2,621 records.",
+      "counts": {
+        "entities_before": 510,
+        "entities_after": 550,
+        "events_before": 1004,
+        "events_after": 1004,
+        "evidence_before": 2541,
+        "evidence_after": 2621
+      },
+      "added_entities": [
+        { "name": "ChainEX", "slug": "chainex", "type": "cex", "status": "active" },
+        { "name": "Chainflip", "slug": "chainflip", "type": "dex", "status": "active" },
+        { "name": "Changelly PRO", "slug": "changelly-pro", "type": "cex", "status": "active" },
+        { "name": "Choice", "slug": "choice", "type": "dex", "status": "active" },
+        { "name": "Chronos", "slug": "chronos", "type": "dex", "status": "active" },
+        { "name": "ClaimSwap", "slug": "claimswap", "type": "dex", "status": "active" },
+        { "name": "Clipper", "slug": "clipper", "type": "dex", "status": "active" },
+        { "name": "CobaltX", "slug": "cobaltx", "type": "dex", "status": "active" },
+        { "name": "Chainge Finance", "slug": "chainge-finance", "type": "dex", "status": "limited" },
+        { "name": "ChampagneSwap", "slug": "champagneswap", "type": "dex", "status": "active" },
+        { "name": "CherrySwap", "slug": "cherryswap", "type": "dex", "status": "inactive" },
+        { "name": "ChimpX AI DEX", "slug": "chimpx-ai-dex", "type": "dex", "status": "active" },
+        { "name": "Clober", "slug": "clober", "type": "dex", "status": "active" },
+        { "name": "CITEX", "slug": "citex", "type": "cex", "status": "inactive" },
+        { "name": "Cleopatra", "slug": "cleopatra", "type": "dex", "status": "inactive" },
+        { "name": "CoinCasso", "slug": "coincasso", "type": "cex", "status": "inactive" },
+        { "name": "CoinCorner", "slug": "coincorner", "type": "cex", "status": "active" },
+        { "name": "Coinmate", "slug": "coinmate", "type": "cex", "status": "active" },
+        { "name": "CoinTR", "slug": "cointr", "type": "cex", "status": "active" },
+        { "name": "CoinUp.io", "slug": "coinup", "type": "cex", "status": "active" },
+        { "name": "CoinZoom", "slug": "coinzoom", "type": "cex", "status": "active" },
+        { "name": "Comet Swap", "slug": "comet-swap", "type": "dex", "status": "active" },
+        { "name": "Convergence Finance", "slug": "convergence-finance", "type": "dex", "status": "active" },
+        { "name": "Coinhain", "slug": "coinhain", "type": "dex", "status": "active" },
+        { "name": "CoinSwap Space", "slug": "coinswap-space", "type": "dex", "status": "active" },
+        { "name": "ColorPool", "slug": "colorpool", "type": "dex", "status": "inactive" },
+        { "name": "Cometh", "slug": "cometh", "type": "hybrid", "status": "active" },
+        { "name": "Complus Network", "slug": "complus-network", "type": "dex", "status": "active" },
+        { "name": "Concordex", "slug": "concordex", "type": "dex", "status": "active" },
+        { "name": "Cone", "slug": "cone", "type": "dex", "status": "active" },
+        { "name": "Swapscanner", "slug": "swapscanner", "type": "hybrid", "status": "active" },
+        { "name": "Coinhouse", "slug": "coinhouse", "type": "hybrid", "status": "active" },
+        { "name": "COINUT", "slug": "coinut", "type": "hybrid", "status": "active" },
+        { "name": "Counos", "slug": "counos", "type": "hybrid", "status": "active" },
+        { "name": "Coinsbit", "slug": "coinsbit", "type": "cex", "status": "inactive" },
+        { "name": "CoinField", "slug": "coinfield", "type": "cex", "status": "inactive" },
+        { "name": "CoinTiger", "slug": "cointiger", "type": "cex", "status": "inactive" },
+        { "name": "Coindelta", "slug": "coindelta", "type": "cex", "status": "inactive" },
+        { "name": "CPDAX", "slug": "cpdax", "type": "cex", "status": "inactive" },
+        { "name": "CoinZest", "slug": "coinzest", "type": "cex", "status": "inactive" }
+      ],
+      "updated_entities": [],
+      "evidence_added": 80,
+      "notes": [
+        "All additions were reviewed before canonical publication.",
+        "The milestone batches added no new event records."
+      ]
+    }
+  ]
+}

--- a/scripts/validate-public-output-consistency.mjs
+++ b/scripts/validate-public-output-consistency.mjs
@@ -88,6 +88,7 @@ const home = readOut('index.html')
 const dead = readOut(path.join('dead', 'index.html'))
 const active = readOut(path.join('active', 'index.html'))
 const stats = readOut(path.join('stats', 'index.html'))
+const updates = readOut(path.join('updates', 'index.html'))
 const firstEntity = entities[0]
 const detail = readOut(path.join('exchange', firstEntity.slug, 'index.html'))
 
@@ -101,12 +102,14 @@ assertTextCount(stats, 'Dead-side', expected.deadSide, '/stats/')
 assertTextCount(stats, 'Active-side', expected.activeSide, '/stats/')
 assertTextCount(stats, 'Total events', expected.events, '/stats/')
 assertTextCount(stats, 'Total evidence', expected.evidence, '/stats/')
+assert(stripHtml(updates).includes('Registry Updates'), '/updates/ does not expose Registry Updates heading')
 
 for (const [route, html, canonical] of [
   ['/', home, `${origin}/`],
   ['/dead/', dead, `${origin}/dead/`],
   ['/active/', active, `${origin}/active/`],
   ['/stats/', stats, `${origin}/stats/`],
+  ['/updates/', updates, `${origin}/updates/`],
   [`/exchange/${firstEntity.slug}/`, detail, `${origin}/exchange/${firstEntity.slug}/`],
 ]) {
   assertCanonical(html, canonical, route)
@@ -176,7 +179,8 @@ for (const [label, count] of [
 
 const sitemap = readOut('sitemap.xml')
 const sitemapLocations = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])
-assert(sitemapLocations.length === entities.length + 7, `sitemap URL count mismatch: ${sitemapLocations.length}`)
+assert(sitemapLocations.length === entities.length + 8, `sitemap URL count mismatch: ${sitemapLocations.length}`)
+assert(sitemapLocations.includes(`${origin}/updates/`), 'sitemap is missing /updates/')
 for (const entity of entities) {
   assert(sitemapLocations.includes(`${origin}/exchange/${entity.slug}/`), `sitemap missing ${entity.slug}`)
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -178,6 +178,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
               <Link className="nav-link" href="/dead">Dead</Link>
               <Link className="nav-link" href="/active">Active</Link>
               <Link className="nav-link" href="/stats">Stats</Link>
+              <Link className="nav-link" href="/updates">Updates</Link>
               <Link className="nav-link nav-secondary" href="/methodology">Methodology</Link>
               <Link className="nav-link nav-secondary" href="/about">About</Link>
               <Link className="utility" href={DONATE_HREF}>Donate</Link>
@@ -196,6 +197,8 @@ export default function RootLayout({ children }: RootLayoutProps) {
               <a className="archive-link" href={ISSUES_HREF} target="_blank" rel="noreferrer">
                 GitHub Issues
               </a>
+              <span className="muted footer-sep"> · </span>
+              <Link className="archive-link" href="/updates">Updates</Link>
               <span className="muted footer-sep"> · </span>
               <Link className="archive-link" href="/stats">Stats</Link>
               <span className="muted footer-sep"> · </span>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${SITE_URL}/dead/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${SITE_URL}/active/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${SITE_URL}/stats/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${SITE_URL}/updates/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.8 },
     { url: `${SITE_URL}/methodology/`, lastModified: registryLastModified, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${SITE_URL}/about/`, lastModified: registryLastModified, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${SITE_URL}/donate/`, lastModified: registryLastModified, changeFrequency: 'monthly', priority: 0.4 },

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -1,0 +1,167 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { loadRegistryUpdates } from '../../lib/data/load-registry-updates'
+import type { RegistryUpdateCounts } from '../../lib/types/registry-update'
+import { CONTACT_HREF } from '../../lib/site-constants'
+import styles from './updates.module.css'
+
+export const metadata: Metadata = {
+  title: 'Registry Updates',
+  description: 'Reviewed additions, corrections, and milestone updates from the Historical Exchange Index registry.',
+  alternates: { canonical: '/updates' },
+}
+
+function delta(after: number, before: number): string {
+  const value = after - before
+  return value > 0 ? `+${value}` : String(value)
+}
+
+function CountChange({ counts }: { counts: RegistryUpdateCounts }) {
+  const items = [
+    ['Entities', counts.entities_before, counts.entities_after],
+    ['Events', counts.events_before, counts.events_after],
+    ['Evidence', counts.evidence_before, counts.evidence_after],
+  ] as const
+
+  return (
+    <div className={styles.countGrid}>
+      {items.map(([label, before, after]) => (
+        <div className={styles.countItem} key={label}>
+          <span className={styles.countLabel}>{label}</span>
+          <strong className={styles.countValue}>{after}</strong>
+          <span className={styles.countDelta}>{delta(after, before)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function UpdateTypeLabel({ type }: { type: 'registry_growth' | 'quality_audit' }) {
+  return (
+    <span className={styles.typeLabel}>
+      {type === 'registry_growth' ? 'Registry growth' : 'Quality audit'}
+    </span>
+  )
+}
+
+export default function RegistryUpdatesPage() {
+  const updates = loadRegistryUpdates()
+  const totalAdded = updates.reduce((sum, update) => sum + update.added_entities.length, 0)
+  const totalEvidenceAdded = updates.reduce((sum, update) => sum + update.evidence_added, 0)
+
+  return (
+    <main className={styles.page}>
+      <section className="panel longform-panel">
+        <div className={styles.headerRow}>
+          <div>
+            <p className="muted">Reviewed changelog</p>
+            <h2 className={styles.pageTitle}>Registry Updates</h2>
+            <p className={styles.lead}>
+              Canonical additions and reviewed corrections that have already passed HEI review and repository validation.
+              Internal monitoring signals and unmerged candidates are not published here.
+            </p>
+          </div>
+          <div className={styles.headerActions}>
+            <Link className="btn" href="/methodology">Methodology</Link>
+            <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">Submit correction</a>
+          </div>
+        </div>
+
+        <div className={styles.summaryStrip}>
+          <div>
+            <span className={styles.summaryLabel}>Published updates</span>
+            <strong>{updates.length}</strong>
+          </div>
+          <div>
+            <span className={styles.summaryLabel}>Entities added in listed updates</span>
+            <strong>{totalAdded}</strong>
+          </div>
+          <div>
+            <span className={styles.summaryLabel}>Evidence added in listed updates</span>
+            <strong>{totalEvidenceAdded}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.updateList} aria-label="Registry update history">
+        {updates.map((update) => (
+          <article className={`panel ${styles.updateCard}`} key={update.id} id={update.id}>
+            <div className={styles.updateHeader}>
+              <div>
+                <div className={styles.updateMeta}>
+                  <time dateTime={update.date}>{update.date}</time>
+                  <UpdateTypeLabel type={update.update_type} />
+                </div>
+                <h3>{update.title}</h3>
+                <p>{update.summary}</p>
+              </div>
+              <a className={styles.anchorLink} href={`#${update.id}`} aria-label={`Link to ${update.title}`}>#</a>
+            </div>
+
+            <CountChange counts={update.counts} />
+
+            {update.added_entities.length > 0 ? (
+              <div className={styles.sectionBlock}>
+                <div className={styles.sectionHeading}>
+                  <h4>Added</h4>
+                  <span>{update.added_entities.length} entities</span>
+                </div>
+                <div className={styles.tableWrap}>
+                  <table className={styles.entityTable}>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {update.added_entities.map((entity) => (
+                        <tr key={entity.slug}>
+                          <td><Link href={`/exchange/${entity.slug}`}>{entity.name}</Link></td>
+                          <td><span className={styles.neutralChip}>{entity.type ?? '—'}</span></td>
+                          <td><span className={`${styles.statusChip} ${styles[`status_${entity.status ?? 'unknown'}`]}`}>{entity.status ?? 'unknown'}</span></td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : null}
+
+            {update.updated_entities.length > 0 ? (
+              <div className={styles.sectionBlock}>
+                <div className={styles.sectionHeading}>
+                  <h4>Updated</h4>
+                  <span>{update.updated_entities.length} entities</span>
+                </div>
+                <div className={styles.updatedList}>
+                  {update.updated_entities.map((entity) => (
+                    <div className={styles.updatedItem} key={entity.slug}>
+                      <Link href={`/exchange/${entity.slug}`}>{entity.name}</Link>
+                      <p>{entity.change}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {update.notes.length > 0 ? (
+              <div className={styles.notesBlock}>
+                <h4>Notes</h4>
+                <ul>
+                  {update.notes.map((note) => <li key={note}>{note}</li>)}
+                </ul>
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </section>
+
+      <section className="callout">
+        Registry Updates only covers reviewed public changes. Monitoring candidates, unresolved watchlist items, and raw risk
+        signals remain outside this public changelog until they are separately reviewed.
+      </section>
+    </main>
+  )
+}

--- a/src/app/updates/updates.module.css
+++ b/src/app/updates/updates.module.css
@@ -3,7 +3,7 @@
 .pageTitle{margin:0;font-size:36px}
 .lead{max-width:82ch;color:var(--muted);line-height:1.7}
 .headerActions{display:flex;gap:8px;flex-wrap:wrap}
-.summaryStrip,.countGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;margin-top:20px;border:1px solid var(--border);background:var(--border)}
+.summaryStrip,.countGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;margin-top:20px;border:1px solid var(--line);background:var(--line)}
 .summaryStrip>div,.countItem{padding:14px;background:var(--panel)}
 .summaryStrip>div{display:flex;flex-direction:column;gap:6px}
 .summaryStrip strong{font-size:24px}
@@ -14,7 +14,7 @@
 .updateHeader h3{margin:8px 0;font-size:24px}
 .updateHeader p{color:var(--muted);line-height:1.65}
 .updateMeta{display:flex;gap:10px;color:var(--muted);font-size:12px}
-.typeLabel,.neutralChip,.statusChip{display:inline-flex;border:1px solid var(--border);border-radius:999px;padding:3px 8px;font-size:11px;text-transform:uppercase}
+.typeLabel,.neutralChip,.statusChip{display:inline-flex;border:1px solid var(--line);border-radius:999px;padding:3px 8px;font-size:11px;text-transform:uppercase}
 .typeLabel{color:var(--archive)}
 .neutralChip{color:var(--muted)}
 .status_active{color:var(--active)}
@@ -26,16 +26,16 @@
 .countItem{display:grid;grid-template-columns:1fr auto auto;gap:10px}
 .countValue{font-size:20px}
 .countDelta{color:var(--archive);font-size:12px}
-.sectionBlock,.notesBlock{margin-top:20px;padding-top:18px;border-top:1px solid var(--border)}
+.sectionBlock,.notesBlock{margin-top:20px;padding-top:18px;border-top:1px solid var(--line)}
 .sectionHeading{display:flex;justify-content:space-between;gap:12px;margin-bottom:10px}
 .sectionHeading h4,.notesBlock h4{margin:0}
-.tableWrap{overflow-x:auto;border:1px solid var(--border)}
+.tableWrap{overflow-x:auto;border:1px solid var(--line)}
 .entityTable{width:100%;border-collapse:collapse;font-size:13px}
-.entityTable th,.entityTable td{padding:9px 12px;border-bottom:1px solid var(--border);text-align:left}
+.entityTable th,.entityTable td{padding:9px 12px;border-bottom:1px solid var(--line);text-align:left}
 .entityTable th{color:var(--muted);font-size:11px;text-transform:uppercase}
 .entityTable a,.updatedItem a{color:var(--text);font-weight:600;text-decoration:none}
-.updatedList{display:grid;border:1px solid var(--border)}
-.updatedItem{display:grid;grid-template-columns:180px 1fr;gap:18px;padding:12px 14px;border-bottom:1px solid var(--border)}
+.updatedList{display:grid;border:1px solid var(--line)}
+.updatedItem{display:grid;grid-template-columns:180px 1fr;gap:18px;padding:12px 14px;border-bottom:1px solid var(--line)}
 .updatedItem p{margin:0;color:var(--muted)}
 .notesBlock ul{color:var(--muted)}
 @media(max-width:820px){.headerRow{flex-direction:column}.summaryStrip,.countGrid{grid-template-columns:1fr}.updatedItem{grid-template-columns:1fr}}

--- a/src/app/updates/updates.module.css
+++ b/src/app/updates/updates.module.css
@@ -3,8 +3,39 @@
 .pageTitle{margin:0;font-size:36px}
 .lead{max-width:82ch;color:var(--muted);line-height:1.7}
 .headerActions{display:flex;gap:8px;flex-wrap:wrap}
+.summaryStrip,.countGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:1px;margin-top:20px;border:1px solid var(--border);background:var(--border)}
+.summaryStrip>div,.countItem{padding:14px;background:var(--panel)}
+.summaryStrip>div{display:flex;flex-direction:column;gap:6px}
+.summaryStrip strong{font-size:24px}
+.summaryLabel,.countLabel,.sectionHeading span{color:var(--muted);font-size:12px}
 .updateList{display:grid;gap:16px}
 .updateCard{padding:22px}
 .updateHeader{display:flex;justify-content:space-between;gap:16px}
 .updateHeader h3{margin:8px 0;font-size:24px}
 .updateHeader p{color:var(--muted);line-height:1.65}
+.updateMeta{display:flex;gap:10px;color:var(--muted);font-size:12px}
+.typeLabel,.neutralChip,.statusChip{display:inline-flex;border:1px solid var(--border);border-radius:999px;padding:3px 8px;font-size:11px;text-transform:uppercase}
+.typeLabel{color:var(--archive)}
+.neutralChip{color:var(--muted)}
+.status_active{color:var(--active)}
+.status_limited{color:var(--limited)}
+.status_inactive{color:var(--inactive)}
+.status_dead{color:var(--dead)}
+.status_unknown{color:var(--unknown)}
+.anchorLink{color:var(--muted);text-decoration:none}
+.countItem{display:grid;grid-template-columns:1fr auto auto;gap:10px}
+.countValue{font-size:20px}
+.countDelta{color:var(--archive);font-size:12px}
+.sectionBlock,.notesBlock{margin-top:20px;padding-top:18px;border-top:1px solid var(--border)}
+.sectionHeading{display:flex;justify-content:space-between;gap:12px;margin-bottom:10px}
+.sectionHeading h4,.notesBlock h4{margin:0}
+.tableWrap{overflow-x:auto;border:1px solid var(--border)}
+.entityTable{width:100%;border-collapse:collapse;font-size:13px}
+.entityTable th,.entityTable td{padding:9px 12px;border-bottom:1px solid var(--border);text-align:left}
+.entityTable th{color:var(--muted);font-size:11px;text-transform:uppercase}
+.entityTable a,.updatedItem a{color:var(--text);font-weight:600;text-decoration:none}
+.updatedList{display:grid;border:1px solid var(--border)}
+.updatedItem{display:grid;grid-template-columns:180px 1fr;gap:18px;padding:12px 14px;border-bottom:1px solid var(--border)}
+.updatedItem p{margin:0;color:var(--muted)}
+.notesBlock ul{color:var(--muted)}
+@media(max-width:820px){.headerRow{flex-direction:column}.summaryStrip,.countGrid{grid-template-columns:1fr}.updatedItem{grid-template-columns:1fr}}

--- a/src/app/updates/updates.module.css
+++ b/src/app/updates/updates.module.css
@@ -1,0 +1,10 @@
+.page{display:grid;gap:18px}
+.headerRow{display:flex;justify-content:space-between;gap:24px}
+.pageTitle{margin:0;font-size:36px}
+.lead{max-width:82ch;color:var(--muted);line-height:1.7}
+.headerActions{display:flex;gap:8px;flex-wrap:wrap}
+.updateList{display:grid;gap:16px}
+.updateCard{padding:22px}
+.updateHeader{display:flex;justify-content:space-between;gap:16px}
+.updateHeader h3{margin:8px 0;font-size:24px}
+.updateHeader p{color:var(--muted);line-height:1.65}

--- a/src/lib/data/load-registry-updates.ts
+++ b/src/lib/data/load-registry-updates.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { RegistryUpdate, RegistryUpdateFile } from '../types/registry-update'
+
+const UPDATE_TYPES = new Set(['registry_growth', 'quality_audit'])
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+function readUpdateFile(): RegistryUpdateFile {
+  const filePath = path.join(process.cwd(), 'data/registry-updates.json')
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as RegistryUpdateFile
+}
+
+function assertUpdate(update: RegistryUpdate, seenIds: Set<string>) {
+  if (!update.id || seenIds.has(update.id)) throw new Error(`registry update id is missing or duplicated: ${update.id}`)
+  if (!DATE_RE.test(update.date)) throw new Error(`registry update has invalid date: ${update.id}`)
+  if (!UPDATE_TYPES.has(update.update_type)) throw new Error(`registry update has invalid type: ${update.id}`)
+  if (!update.title || !update.summary) throw new Error(`registry update is missing title or summary: ${update.id}`)
+  if (!Array.isArray(update.added_entities) || !Array.isArray(update.updated_entities) || !Array.isArray(update.notes)) {
+    throw new Error(`registry update arrays are invalid: ${update.id}`)
+  }
+
+  const countKeys = [
+    'entities_before',
+    'entities_after',
+    'events_before',
+    'events_after',
+    'evidence_before',
+    'evidence_after',
+  ] as const
+  for (const key of countKeys) {
+    if (!Number.isInteger(update.counts[key]) || update.counts[key] < 0) {
+      throw new Error(`registry update count is invalid: ${update.id}:${key}`)
+    }
+  }
+  if (!Number.isInteger(update.evidence_added) || update.evidence_added < 0) {
+    throw new Error(`registry update evidence_added is invalid: ${update.id}`)
+  }
+
+  seenIds.add(update.id)
+}
+
+export function loadRegistryUpdates(): RegistryUpdate[] {
+  const file = readUpdateFile()
+  if (file.version !== 1 || !Array.isArray(file.updates)) {
+    throw new Error('data/registry-updates.json has unsupported shape')
+  }
+
+  const seenIds = new Set<string>()
+  file.updates.forEach((update) => assertUpdate(update, seenIds))
+
+  return [...file.updates].sort((a, b) => {
+    const dateOrder = b.date.localeCompare(a.date)
+    return dateOrder !== 0 ? dateOrder : a.id.localeCompare(b.id)
+  })
+}

--- a/src/lib/types/registry-update.ts
+++ b/src/lib/types/registry-update.ts
@@ -1,0 +1,41 @@
+export type RegistryUpdateType = 'registry_growth' | 'quality_audit'
+
+export type RegistryUpdateEntity = {
+  name: string
+  slug: string
+  type?: 'cex' | 'dex' | 'hybrid'
+  status?: string
+}
+
+export type RegistryUpdatedEntity = {
+  name: string
+  slug: string
+  change: string
+}
+
+export type RegistryUpdateCounts = {
+  entities_before: number
+  entities_after: number
+  events_before: number
+  events_after: number
+  evidence_before: number
+  evidence_after: number
+}
+
+export type RegistryUpdate = {
+  id: string
+  date: string
+  update_type: RegistryUpdateType
+  title: string
+  summary: string
+  counts: RegistryUpdateCounts
+  added_entities: RegistryUpdateEntity[]
+  updated_entities: RegistryUpdatedEntity[]
+  evidence_added: number
+  notes: string[]
+}
+
+export type RegistryUpdateFile = {
+  version: number
+  updates: RegistryUpdate[]
+}


### PR DESCRIPTION
Implements Phase D-1: a reviewed Registry Updates surface.

Adds:
- `/updates` static public page
- reviewed `data/registry-updates.json` publication data
- build-time loader validation
- navigation and footer links
- sitemap route

The public page only reads reviewed update data. Raw monitoring findings and unmerged candidates are not surfaced. Initial entries cover the 550-entity milestone growth and the completed Phase C quality audit.

No canonical entity, event, or evidence records change in this PR.