### PR TITLE
Rebase HEI product roadmap and add Explorer specification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,29 @@ Before changing code, data, workflows, build configuration, deployment behavior,
 1. `docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md`
 2. `config/cloudflare-pages-project.json`
 3. `docs/HEI_V1_EXECUTION_ROADMAP.md`
-4. the relevant schema, monitoring, record-growth, or machine-readable specification for the task
+4. `docs/HEI_PRODUCT_SURFACES_SPEC.md` when changing public product surfaces, routes, Explorer behavior, Change-layer output, Compare planning, AI-assisted query behavior, or related navigation
+5. the relevant schema, monitoring, record-growth, machine-readable, localization, audit, or other task-specific specification
 
 The Cloudflare deployment policy is the human-readable operational source of truth. The JSON project policy is the machine-readable authority for branch controls and build watch paths.
+
+The roadmap is the execution-order source of truth. The product-surfaces specification is the behavior and non-goal source of truth for public Registry, Analysis, Research, and Change layers.
+
+Repository state is authoritative when a document checkpoint and current GitHub state disagree. In that case, inspect current state first, then repair the stale checkpoint in the next appropriate PR.
+
+## Work-item traceability
+
+Every implementation pull request must identify:
+
+- the roadmap item being advanced;
+- the relevant specification section or task-specific source of truth;
+- canonical count impact;
+- deployment impact;
+- validation performed;
+- production verification plan when public output changes.
+
+Do not use remembered chat history as the implementation authority when repository documents and current GitHub state can be inspected.
+
+When a change materially alters phase order, active work, route contracts, Explorer query semantics, public publishing safety, or post-v1 priorities, update the roadmap and relevant specification together.
 
 ## Non-negotiable deployment rules
 
@@ -66,18 +86,24 @@ The canonical public data is:
 
 Monitoring and ingestion automation must not publish unreviewed candidates directly into canonical data. Staging and monitoring outputs remain non-canonical until reviewed and merged.
 
+Public product surfaces, Explorer results, Stats deep links, Timeline output, Registry Updates, monthly snapshots, and public feeds must preserve the reviewed-public boundary defined by the relevant specification.
+
 ## Pull request discipline
 
 Every PR must state:
 
-- canonical count impact
-- deployment impact
-- whether preview is required
-- GitHub validation performed
-- production verification plan when public output changes
+- roadmap item;
+- relevant specification reference;
+- canonical count impact;
+- deployment impact;
+- whether preview is required;
+- GitHub validation performed;
+- production verification plan when public output changes.
 
 Temporary scripts, workflows, audit files, and diagnostic branches must be removed or closed after use.
 
 ## Conflict rule
 
 If another instruction conflicts with `docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md` on deployment behavior, follow the deployment policy until a reviewed PR deliberately changes it.
+
+If a public product implementation conflicts with `docs/HEI_PRODUCT_SURFACES_SPEC.md`, stop that implementation path and reconcile the specification and roadmap in a reviewed PR before proceeding.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,6 +50,90 @@ Change
 
 These layers should feel like one registry system rather than separate microsites.
 
+## Layout rules
+
+### Registry pages
+- compact tool-like header
+- summary strip
+- controls
+- dense table/list
+- footer note
+
+### Detail pages
+- dossier-style layout
+- identity and status first
+- fact block
+- URL block
+- timeline
+- evidence
+- correction/disclaimer
+
+### Longform pages
+- readable stack
+- moderate width
+- plainspoken, research-like tone
+
+### Explorer pages
+- research-utility layout
+- visible active query state
+- restrained filter controls
+- explicit result count
+- dense result list or table
+- direct links into exchange dossiers and event context
+- mobile controls that preserve query visibility
+
+## Visual rules
+
+- desktop-first
+- tables preferred over oversized cards
+- compact clarity over decorative whitespace
+- borders matter
+- low-contrast surface separation
+- restrained depth
+- no glossy SaaS hero treatment
+- no crypto-neon styling
+- no trading-terminal chrome
+- no animated market counters
+- no synthetic risk-score gauges
+
+## Color roles
+
+- base background: deep charcoal / near-black
+- primary accent: muted bronze / aged gold
+- archive accent: soft archival blue
+- dead accent: muted red-brown
+- active accent: subdued green
+- limited accent: dusty amber
+- inactive accent: blue-gray
+- unknown accent: gray-violet
+
+## Header
+
+Must include:
+
+- HEI wordmark/title
+- primary nav
+- one utility-emphasis action
+
+It should feel like a tool header, not a launch header.
+
+## Registry tables
+
+- dense and legible
+- modest row height
+- subtle separators
+- name column strongest
+- archive access clearly scannable
+- mobile should collapse rows compactly, not explode into giant cards
+
+## Detail pages
+
+- should read like compact dossiers
+- original URL and archived URL must be visually separated
+- archived URL should feel like the safer historical action for dead-side entries
+- timeline should be factual and chronological
+- evidence should feel citation-like, not social
+
 ## Explorer direction
 
 Explorer must look like a research utility inside HEI.
@@ -101,3 +185,8 @@ Change surfaces should emphasize:
 - links back to canonical record context
 
 They must not resemble a breaking-news homepage or engagement feed.
+
+## Final sentence
+
+HEI should feel like a modern archival ledger for crypto exchange history:
+clean, restrained, data-dense, quietly authoritative, and visibly aware of uncertainty.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,6 +2,8 @@
 
 Historical Exchange Index (HEI) should feel like a quiet historical registry.
 
+This file is the visual direction source of truth. Product behavior and route scope are defined in `docs/HEI_PRODUCT_SURFACES_SPEC.md`, while execution order is defined in `docs/HEI_V1_EXECUTION_ROADMAP.md`.
+
 ## Core direction
 
 - Vercel-led visual structure
@@ -28,79 +30,74 @@ Working phrase:
 
 - quiet registry
 
-## Layout rules
+## Surface hierarchy
 
-### Registry pages
-- compact tool-like header
-- summary strip
-- controls
-- dense table/list
-- footer note
+The visual system must support four connected public layers:
 
-### Detail pages
-- dossier-style layout
-- identity and status first
-- fact block
-- URL block
-- timeline
-- evidence
-- correction/disclaimer
+```text
+Registry
+  browse and inspect individual records
 
-### Longform pages
-- readable stack
-- moderate width
-- plainspoken, research-like tone
+Analysis
+  understand distributions, quality, and coverage
 
-## Visual rules
+Research
+  filter and search across reviewed entities and events
 
-- desktop-first
-- tables preferred over oversized cards
-- compact clarity over decorative whitespace
-- borders matter
-- low-contrast surface separation
-- restrained depth
-- no glossy SaaS hero treatment
-- no crypto-neon styling
+Change
+  follow reviewed registry updates and historical change surfaces
+```
 
-## Color roles
+These layers should feel like one registry system rather than separate microsites.
 
-- base background: deep charcoal / near-black
-- primary accent: muted bronze / aged gold
-- archive accent: soft archival blue
-- dead accent: muted red-brown
-- active accent: subdued green
-- limited accent: dusty amber
-- inactive accent: blue-gray
-- unknown accent: gray-violet
+## Explorer direction
 
-## Header
+Explorer must look like a research utility inside HEI.
 
-Must include:
+Prefer:
 
-- HEI wordmark/title
-- primary nav
-- one utility-emphasis action
+- dense, readable result lists and tables where appropriate
+- restrained filter controls
+- explicit result counts
+- compact metadata
+- stable labels
+- visible active-filter state
+- direct links into exchange dossiers and evidence context
+- strong keyboard and mobile usability
 
-It should feel like a tool header, not a launch header.
+Avoid:
 
-## Registry tables
+- exchange-logo walls as the primary information structure
+- trading-terminal chrome
+- red/green market semantics
+- score gauges
+- animated market counters
+- decorative dashboard widgets without research value
+- synthetic risk-score presentation
 
-- dense and legible
-- modest row height
-- subtle separators
-- name column strongest
-- archive access clearly scannable
-- mobile should collapse rows compactly, not explode into giant cards
+## Stats and Explorer relationship
 
-## Detail pages
+Stats shows aggregate patterns. Explorer shows the exact records behind those patterns.
 
-- should read like compact dossiers
-- original URL and archived URL must be visually separated
-- archived URL should feel like the safer historical action for dead-side entries
-- timeline should be factual and chronological
-- evidence should feel citation-like, not social
+Visual links between them should be direct and understated:
 
-## Final sentence
+```text
+Stats observation
+  -> Explore matching records
+```
 
-HEI should feel like a modern archival ledger for crypto exchange history:
-clean, restrained, data-dense, quietly authoritative, and visibly aware of uncertainty.
+The link should feel like a drilldown into the registry, not a marketing call to action.
+
+## Change-layer direction
+
+Registry Updates, Incident Timeline, quality summaries, monthly snapshots, and feeds must preserve the same restrained archival tone.
+
+Change surfaces should emphasize:
+
+- reviewed facts
+- chronology
+- provenance
+- clear update dates
+- links back to canonical record context
+
+They must not resemble a breaking-news homepage or engagement feed.

--- a/docs/HEI_PRODUCT_SURFACES_SPEC.md
+++ b/docs/HEI_PRODUCT_SURFACES_SPEC.md
@@ -1,0 +1,581 @@
+# HEI Product Surfaces Specification
+
+Status: fixed product specification  
+Project: Historical Exchange Index (HEI)  
+Repository: `badjoke-lab/historical-exchange-index`  
+Checkpoint: 2026-07-06  
+Scope: public registry, analysis, research, and change-tracking surfaces after the current Phase D work
+
+## 1. Authority and purpose
+
+This document is the product-surface source of truth for HEI after the initial registry, Stats, monitoring, and machine-readable layers are in place.
+
+It defines how HEI should expose the value of its reviewed `entity / event / evidence` data without turning the project into a trading dashboard, news site, risk-scoring product, or free-form AI answer engine.
+
+Implementation work must follow both:
+
+1. `docs/HEI_V1_EXECUTION_ROADMAP.md` for execution order and current phase;
+2. this file for product-surface behavior and non-goals.
+
+Repository state remains authoritative for actual merged implementation status.
+
+## 2. Product model
+
+HEI public output is organized into four layers.
+
+```text
+Registry layer
+  individual records and primary browsing
+
+Analysis layer
+  aggregate distributions, quality, and coverage
+
+Research layer
+  deterministic cross-record exploration
+
+Change layer
+  reviewed registry updates and historical change surfaces
+```
+
+The layers must reinforce each other rather than become isolated features.
+
+### 2.1 Registry layer
+
+Primary routes include:
+
+```text
+/
+/dead/
+/active/
+/exchange/[slug]/
+```
+
+Purpose:
+
+- browse reviewed exchange records;
+- inspect individual exchange identity and status;
+- read lifecycle timelines;
+- inspect supporting evidence;
+- preserve historical URLs and archive access.
+
+### 2.2 Analysis layer
+
+Primary route:
+
+```text
+/stats/
+```
+
+Purpose:
+
+- show registry scale and composition;
+- show status and type distributions;
+- show active-side and dead-side analysis;
+- show archive, confidence, completeness, origin, evidence-depth, and freshness metrics;
+- show historical distributions and snapshot growth where enough history exists.
+
+Stats answers:
+
+> What is common, rare, changing, complete, or missing across the registry?
+
+### 2.3 Research layer
+
+Primary route:
+
+```text
+/explore/
+```
+
+Initial modes:
+
+```text
+Entity Explorer
+Event Explorer
+```
+
+Purpose:
+
+- find the reviewed records matching explicit conditions;
+- search across entities and events;
+- preserve filter state in shareable URLs;
+- connect aggregate Stats observations to the exact records behind them;
+- provide deterministic results from reviewed data.
+
+Explorer answers:
+
+> Which exact records match this condition?
+
+### 2.4 Change layer
+
+Primary surfaces include:
+
+```text
+/updates/
+Exchange Incident Timeline
+Evidence Health and Data Quality summary
+Monthly Historical Exchange Snapshot
+RSS and JSON feeds for reviewed public updates
+```
+
+Purpose:
+
+- show that HEI remains actively maintained;
+- expose only reviewed changes and reviewed public summaries;
+- show what changed in the registry without publishing raw monitoring output;
+- preserve a historical interpretation rather than become a breaking-news feed.
+
+Change surfaces answer:
+
+> What was added, revised, confirmed, or historically recorded?
+
+## 3. Current implementation baseline
+
+At this specification checkpoint:
+
+- Registry browsing and exchange detail pages exist;
+- `/stats/` exists and already covers the main analysis categories;
+- the machine-readable public layer exists;
+- reviewed canonical datasets are publicly exposed under the project safety boundary;
+- `/updates/` and its reviewed Registry Update data surface are implemented;
+- the next execution item is the Exchange Incident Timeline.
+
+The roadmap, not this section, controls the active work item if implementation status changes later.
+
+## 4. Phase D — Change layer completion
+
+The current Phase D order is retained.
+
+```text
+D-1 Registry Update surface                         complete
+D-2 Exchange Incident Timeline                     next
+D-3 Evidence Health and Data Quality summary       pending
+D-4 Monthly Historical Exchange Snapshot           pending
+D-5 RSS and JSON reviewed-update feeds             pending
+D-6 Quality repair batches                         parallel continuous lane
+```
+
+### 4.1 Publication safety
+
+Public Change-layer content must obey all of the following:
+
+- merged canonical changes may be presented as official registry updates;
+- raw monitoring findings remain internal;
+- monitoring signals are not final classifications;
+- unmerged candidates must not appear as reviewed registry facts;
+- public incident items require reviewed canonical events or separately reviewed confirmed public items;
+- publication drafts may be generated automatically, but publication remains review-gated.
+
+### 4.2 HEI must not become a weekly news site
+
+HEI is history-first.
+
+The project may publish periodic reviewed update summaries, but it must not optimize for breaking-news volume or copy a general crypto-news workflow.
+
+The preferred progression is:
+
+```text
+Registry Update
+Monthly Snapshot
+optional Discovery Log trial after v1.0
+```
+
+A recurring Weekly Exchange Watch is not part of the active roadmap.
+
+## 5. Explorer v1
+
+Explorer v1 is a formal product phase after the current Phase D and Phase E discovery-foundation work.
+
+It must not interrupt the active Phase D sequence.
+
+### 5.1 Core rule
+
+Explorer is a deterministic query interface over reviewed public data.
+
+It must not:
+
+- invent classifications;
+- infer unreviewed status changes;
+- publish monitoring candidates;
+- create AI-generated exchange claims;
+- use hidden risk scoring;
+- return results outside the reviewed public registry boundary.
+
+### 5.2 Route model
+
+The initial route is:
+
+```text
+/explore/
+```
+
+The active mode is represented in URL state.
+
+Examples:
+
+```text
+/explore/?view=entities&type=cex&status=dead
+/explore/?view=events&event_type=regulatory_action&from=2024-01-01
+```
+
+A future route split may be considered only if implementation evidence shows that a single route harms usability or maintainability.
+
+### 5.3 Entity Explorer filters
+
+Explorer v1 should support these reviewed-data filters where the underlying canonical field or deterministic derived value exists:
+
+```text
+q
+type
+status
+death_reason
+launch_from
+launch_to
+death_from
+death_to
+official_url_status
+archive_available
+confidence
+country_or_origin
+sort
+```
+
+Filter semantics must be documented and tested.
+
+Unknown values must remain filterable where useful. They must not be silently dropped.
+
+### 5.4 Event Explorer filters
+
+Explorer v1 should support:
+
+```text
+q
+event_type
+date_from
+date_to
+impact_level
+event_status_effect
+confidence
+entity_type
+entity_status
+sort
+```
+
+Event Explorer results must retain clear links back to the parent exchange record and relevant evidence where available.
+
+### 5.5 Search scope
+
+`q` must use deterministic text matching over reviewed public fields.
+
+The first implementation may cover fields such as:
+
+- canonical name;
+- aliases;
+- slug;
+- summary;
+- event title;
+- event summary or description;
+- country or origin label.
+
+The exact indexed field set must be written into implementation documentation before merge.
+
+### 5.6 Sort contract
+
+Entity sort options should be limited to stable, understandable fields such as:
+
+```text
+name_asc
+name_desc
+launch_oldest
+launch_newest
+death_oldest
+death_newest
+last_verified_newest
+```
+
+Event sort options should include:
+
+```text
+date_newest
+date_oldest
+entity_name_asc
+```
+
+Unsupported or malformed sort values must fall back to a documented default.
+
+### 5.7 Shareable URL state
+
+Every user-visible filter and sort state must round-trip through the URL.
+
+Requirements:
+
+- opening a copied URL restores the same state;
+- removing a filter updates the URL;
+- browser back and forward navigation restore prior state;
+- URL serialization is stable and deterministic;
+- empty/default parameters should be omitted where practical;
+- parameter naming must remain backward-compatible after v1 release unless a migration or redirect plan exists.
+
+### 5.8 Stats to Explorer deep links
+
+Stats and Explorer must be connected.
+
+Examples:
+
+```text
+Stats: death reason = regulation
+  -> /explore/?view=entities&death_reason=regulation
+
+Stats: event type = hack
+  -> /explore/?view=events&event_type=hack
+
+Stats: type = dex
+  -> /explore/?view=entities&type=dex
+```
+
+The purpose is to let a user move from aggregate observation to exact records.
+
+### 5.9 Change surfaces to Explorer deep links
+
+Where useful, Update and Timeline surfaces should link to Explorer state.
+
+Examples:
+
+- an update summary may link to all entities added in a reviewed period if the query contract supports it safely;
+- an incident summary may link to all events of the same type in a date range;
+- a monthly snapshot may link to the underlying event subset.
+
+These links must use reviewed public data only.
+
+### 5.10 Evidence Explorer is not in v1
+
+Explorer v1 includes:
+
+```text
+Entity Explorer
+Event Explorer
+```
+
+A standalone Evidence Explorer is deferred.
+
+Evidence remains visible through exchange detail and event context until a concrete research use case justifies a dedicated evidence-wide search surface.
+
+### 5.11 SEO and crawl control
+
+Explorer must not create an uncontrolled indexed URL explosion.
+
+Default policy:
+
+- `/explore/` may be indexable;
+- arbitrary filtered query combinations should not be treated as separate canonical SEO landing pages;
+- canonical metadata should remain stable;
+- sitemap expansion must be deliberate, not generated from every possible filter combination;
+- shareable research URLs and SEO landing pages are separate concerns.
+
+Exact `robots` and canonical implementation must be decided during the Explorer specification PR before public rollout.
+
+### 5.12 Accessibility and responsive behavior
+
+Explorer must preserve the HEI quiet-registry direction.
+
+Requirements:
+
+- keyboard-accessible filter controls;
+- visible focus states;
+- labeled controls;
+- understandable empty states;
+- clear active-filter summary;
+- no color-only meaning;
+- mobile filter controls must not hide the active query state;
+- dense result presentation is allowed, but touch targets and text must remain usable.
+
+### 5.13 Visual direction
+
+Explorer must feel like a research utility inside HEI, not a trading terminal.
+
+Avoid:
+
+- exchange-logo walls as the primary information structure;
+- score gauges;
+- red/green trading semantics;
+- animated market-style counters;
+- dashboard decoration without research value.
+
+Prefer:
+
+- dense lists and tables where appropriate;
+- restrained filter panels;
+- explicit result counts;
+- stable labels;
+- compact metadata;
+- direct links to record dossiers and evidence context.
+
+## 6. Explorer implementation split
+
+Explorer work should be split into reviewable PRs.
+
+Recommended order:
+
+```text
+E5-1 Explorer implementation specification and query contract
+E5-2 Entity Explorer
+E5-3 Event Explorer
+E5-4 Stats -> Explorer deep links
+E5-5 Timeline / Updates -> Explorer cross-links
+E5-6 Explorer accessibility, URL-state, and regression audit
+```
+
+The exact PR count may change, but the dependency order should be preserved.
+
+## 7. Compare v1
+
+Compare is a post-v1.0 candidate.
+
+It must not precede Explorer v1.
+
+Possible comparison fields include:
+
+```text
+type
+launch date
+terminal date
+status
+death reason
+lifespan
+major events
+evidence count
+archive status
+country or origin
+confidence
+```
+
+Compare should use reviewed fields and deterministic derived values only.
+
+It must not introduce a synthetic risk score.
+
+## 8. Natural Language Filter Translator
+
+Natural-language filtering is optional and conditional.
+
+It is not part of HEI v1.0.
+
+If introduced later, its job is only to translate a natural-language request into validated Explorer parameters.
+
+Example:
+
+```text
+User request:
+  exchanges that died because of regulation after 2020
+
+Translator output:
+  view=entities
+  status=dead
+  death_reason=regulation
+  death_from=2020
+
+Result authority:
+  deterministic Explorer query over reviewed HEI data
+```
+
+The translator must not freely decide that an exchange failed for a reason not present in reviewed data.
+
+A free-form `Ask HEI` answer engine is not part of the active roadmap.
+
+## 9. API position
+
+A new API phase is not required before Explorer.
+
+Priority order:
+
+```text
+stable canonical JSON
+stable schema behavior
+stable URL contracts
+version and manifest integrity
+reviewed update feeds
+Explorer query contract
+conditional API expansion only when a real consumer need is demonstrated
+```
+
+The existing machine-readable public layer remains the public machine-use foundation.
+
+Potential future endpoints such as `/api/exchanges`, `/api/events`, or `/api/search` remain conditional and must not be created only for appearance.
+
+## 10. Explicit non-goals
+
+The following are not part of the active HEI roadmap:
+
+- exchange risk scores;
+- AI-generated exchange truth labels;
+- AI Summary vs Human Summary presentation;
+- free-form Ask HEI chat;
+- automated publication of raw monitoring findings;
+- general crypto breaking-news coverage;
+- a startup-style engagement dashboard;
+- rankings that imply exchange quality or investment safety.
+
+## 11. Public Comments
+
+Public Comments are moved to indefinite backlog.
+
+Reasons include:
+
+- moderation cost;
+- spam handling;
+- source-quality disputes;
+- defamation and accusation risk;
+- community-management burden;
+- weak direct contribution to core registry value.
+
+Comments must not displace:
+
+```text
+Phase D completion
+Phase E discovery foundation
+Explorer v1
+multilingual layer
+v1.0 integration
+post-v1.0 Compare evaluation
+```
+
+## 12. Post-v1.0 optional sequence
+
+Recommended evaluation order after v1.0:
+
+```text
+H. Compare v1
+I. Discovery Log trial
+J. Natural Language Filter Translator only if Explorer usage justifies it
+K. API expansion only if consumer demand justifies it
+```
+
+Public Comments remain indefinite backlog.
+
+## 13. Localization interaction
+
+The English-root and Japanese `/ja/` architecture remains a separate phase.
+
+Explorer implementation must avoid hard-coding user-facing labels into filter semantics.
+
+Requirements:
+
+- query parameter keys and enum values remain locale-independent;
+- UI labels may be localized;
+- canonical data remains single-source;
+- translation overlays must not create divergent factual records;
+- shared Explorer URLs must remain semantically stable across locales where practical.
+
+## 14. Change control
+
+Any change to the following requires this specification and the roadmap to be reviewed together:
+
+- Explorer route model;
+- query parameter names;
+- filter semantics;
+- indexed search fields;
+- public Change-layer safety rules;
+- Compare moving before v1.0;
+- Natural Language Filter Translator entering the active schedule;
+- API expansion entering the active schedule;
+- Public Comments returning to active planning.
+
+Implementation PRs must cite the relevant section of this document in their PR body and update the roadmap checkpoint when phase status changes.

--- a/docs/HEI_V1_EXECUTION_ROADMAP.md
+++ b/docs/HEI_V1_EXECUTION_ROADMAP.md
@@ -2,32 +2,57 @@
 
 Status: active execution source of truth  
 Repository: `badjoke-lab/historical-exchange-index`  
-Checkpoint: 2026-07-05  
+Checkpoint: 2026-07-06  
 Target: HEI v1.0 and recurring registry operations
 
 Repository state is authoritative when this checkpoint and GitHub disagree.
 
-## Operating rules
+## 1. Required reference set
+
+Before implementation work, read in this order:
+
+1. `AGENTS.md`;
+2. `docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md`;
+3. `config/cloudflare-pages-project.json`;
+4. this roadmap;
+5. `docs/HEI_PRODUCT_SURFACES_SPEC.md` for public product-surface work;
+6. the relevant schema, monitoring, record-growth, machine-readable, localization, or audit document for the task.
+
+Implementation pull requests must identify:
+
+- the roadmap item being advanced;
+- the relevant specification section;
+- canonical count impact;
+- deployment impact;
+- required validation;
+- production verification plan when public output changes.
+
+## 2. Operating rules
 
 - Canonical changes require reviewed pull requests.
 - Automated monitoring must not directly edit canonical data.
 - Do not add thin records to satisfy a count target.
 - Preserve historical URLs and conservative status decisions.
 - Confirm the full diff and required checks before merge.
+- Raw monitoring findings remain internal unless reviewed into a safe public form.
+- Public product features must query reviewed public data only.
+- Do not introduce risk scores, free-form AI truth claims, or unreviewed candidate exposure.
+- Update this checkpoint when counts, phase state, active item, or execution order materially changes.
 
-## Current checkpoint
+## 3. Current checkpoint
 
 ```text
-Last confirmed main SHA: 68ebe476e87d6ccb764bd51d52b94caf9638e039
-Last merged PR: #531 Complete Phase C milestone audit
-Current phase: Phase D — public update surfaces
-Current item: finalize range 0401-0450 closure
-Next item: HEI Registry Update surface
-Cloudflare changes: none
-Production deployment: none
+Implementation baseline SHA: 00e532ae8f0ff85918690b4fc4ea11f82dd1b112
+Last merged implementation PR: #533 Add reviewed Registry Updates public surface
+Current phase: Phase D — Change layer completion
+Completed item: D-1 HEI Registry Update surface
+Current item: D-2 Exchange Incident Timeline
+Next item after D-2: D-3 Evidence Health and Data Quality public summary
+Cloudflare configuration changes required for current item: none expected
+Production verification: required when a new public route or public feed is merged
 ```
 
-## Current reviewed state
+## 4. Current reviewed state
 
 ```text
 Entities:  550
@@ -38,7 +63,11 @@ Maximum event ID:    hei_ev_010080
 Maximum evidence ID: hei_src_011312
 ```
 
-## Phase C completion
+These are reviewed public-layer counts and sequence maxima at the Phase C completion checkpoint. A later merged canonical change overrides these values and requires this section to be refreshed.
+
+## 5. Completed foundation
+
+### 5.1 Phase C milestone
 
 ```text
 entity target:                     550 / 550
@@ -58,9 +87,9 @@ Audit source of truth:
 docs/audits/HEI_PHASE_C_MILESTONE_AUDIT_2026-07-05.md
 ```
 
-Remaining quality queues are handled through reviewed repair batches and do not reopen count-driven growth as the primary milestone.
+Remaining quality queues continue through reviewed repair batches. They do not reopen count-driven growth as the primary project milestone.
 
-## Range 0401-0450
+### 5.2 Verified-unadded range 0401-0450
 
 ```text
 range records:                 50
@@ -74,43 +103,401 @@ out_of_scope_or_duplicate:       8
 range status:                   closed
 ```
 
-## Phase D execution order
+### 5.3 Existing product foundation
 
-1. HEI Registry Update surface.
-2. Exchange Incident Timeline surface.
-3. Evidence Health and Data Quality public summary.
-4. Monthly historical exchange snapshot.
-5. RSS and JSON feed outputs for reviewed public updates.
-6. Continue quality repair batches in parallel.
+Already implemented before the remaining schedule below:
 
-Public publication rules:
+- registry browsing and exchange detail pages;
+- active-side and dead-side views;
+- exchange timeline and evidence presentation;
+- `/stats/` analysis surface;
+- monitoring and recurring review infrastructure;
+- machine-readable public layer;
+- reviewed canonical entity, event, and evidence JSON publication;
+- public HTML / JSON / metadata consistency validation;
+- `/updates/` reviewed Registry Update surface.
 
-- only merged canonical changes are presented as official registry updates;
-- raw monitoring findings remain internal;
-- monitoring signals are not final status classifications;
-- public timeline items require reviewed canonical events or separately reviewed confirmed items.
+Stats is not a future build dependency. It is an existing analysis layer that will later gain deep links into Explorer.
 
-## Later phases
+## 6. Execution model
 
-- Phase E: Stats, internal links, SEO, metadata, sitemap.
-- Phase F: English root and Japanese `/ja/` routes with translation overlays.
-- Phase G: accessibility, URL safety, production integration, runbook, v1.0 baseline.
+HEI now proceeds through four coordinated lanes.
 
-## Immediate schedule
+### Lane A — Data and quality
 
-| Order | Work | Result |
-|---|---|---|
-| 1 | merge range-close checkpoint | current research range fully closed |
-| 2 | implement Registry Update | first Phase D public update surface |
-| 3 | implement Incident Timeline | canonical event history surface |
-| 4 | implement quality and monthly summaries | transparent maintenance outputs |
-| 5 | add feeds | machine-readable public update stream |
+```text
+continuous candidate discovery
+reviewed record additions
+existing entity/event/evidence strengthening
+status and lifecycle updates
+medium/low quality repair batches
+archive and evidence improvements
+```
 
-GitHub-side work can continue without Cloudflare access.
+This lane continues throughout the schedule. It must not block product work unless a product phase depends on unresolved data-contract problems.
 
-## Recovery procedure
+### Lane B — Product surfaces
 
-1. Confirm current main, open PRs, and actual reviewed counts.
-2. Read the Phase C audit and latest range-close memo.
-3. Resume the first incomplete Phase D item above.
-4. Update this checkpoint whenever counts, phase, or execution order change.
+```text
+Phase D Change layer completion
+Phase E discovery foundation hardening
+Phase E.5 Explorer v1
+Phase F multilingual layer
+Phase G v1.0 integration
+post-v1.0 Compare evaluation
+```
+
+### Lane C — Operations
+
+```text
+monitoring
+quality monitoring
+canonical update tracking
+reviewed Registry Updates
+monthly reviewed snapshots
+optional post-v1.0 Discovery Log trial
+```
+
+Monitoring output remains internal until reviewed into a public-safe form.
+
+### Lane D — Machine use
+
+```text
+stable canonical JSON
+schema stability
+version and manifest integrity
+machine-readable public layer
+reviewed update feeds
+conditional API expansion only if consumer need is demonstrated
+```
+
+A new API phase does not precede Explorer.
+
+## 7. Phase D — Change layer completion
+
+Purpose: make registry change and historical activity visible without turning HEI into a breaking-news site.
+
+Execution order:
+
+```text
+D-1 HEI Registry Update surface                         COMPLETE
+D-2 Exchange Incident Timeline                         NEXT
+D-3 Evidence Health and Data Quality public summary   PENDING
+D-4 Monthly Historical Exchange Snapshot              PENDING
+D-5 RSS and JSON feeds for reviewed public updates    PENDING
+D-6 Quality repair batches                             PARALLEL
+```
+
+### D-2 Exchange Incident Timeline
+
+Work:
+
+- define the public incident event subset;
+- build a chronological public surface from reviewed canonical events or separately reviewed confirmed items;
+- link incidents back to exchange dossiers and supporting evidence context;
+- preserve conservative event wording and status effects;
+- add route, sitemap, metadata, and regression validation as required.
+
+Completion gate:
+
+```text
+public timeline surface exists
+all displayed incidents satisfy reviewed-public boundary
+entity links resolve
+no raw monitoring findings are exposed
+route and output checks pass
+```
+
+### D-3 Evidence Health and Data Quality public summary
+
+Work:
+
+- summarize reviewed public quality and coverage metrics;
+- expose aggregate evidence health, not internal raw repair queues;
+- reuse stable quality data where possible;
+- clearly separate coverage metrics from claims of completeness.
+
+Completion gate:
+
+```text
+public quality summary exists
+no private monitoring or research notes are exposed
+metric definitions are documented
+counts are validated against reviewed public data
+```
+
+### D-4 Monthly Historical Exchange Snapshot
+
+Work:
+
+- present a reviewed monthly historical snapshot;
+- summarize relevant shutdown, hack, exploit, withdrawal suspension, regulatory action, acquisition, merger, and rebrand events where represented in reviewed data;
+- preserve historical context rather than imitate general news coverage.
+
+Completion gate:
+
+```text
+monthly snapshot format is stable
+period and snapshot time are explicit
+all included records are review-safe
+links resolve to canonical public context where available
+```
+
+### D-5 RSS and JSON feeds
+
+Work:
+
+- expose reviewed Registry Update and related safe public change outputs;
+- define stable feed schemas and URLs;
+- exclude raw monitoring data and unmerged candidates;
+- add validation for ordering, IDs, timestamps, and public-data safety.
+
+Completion gate:
+
+```text
+RSS feed valid
+JSON feed valid
+stable identifiers documented
+reviewed-only boundary tested
+machine-readable manifest/discovery references updated where appropriate
+```
+
+## 8. Phase E — Discovery foundation hardening
+
+Purpose: prepare navigation, linking, metadata, and route behavior before Explorer v1.
+
+Stats already exists. Phase E is not a Stats implementation phase.
+
+Work:
+
+```text
+E-1 internal-link audit and repair
+E-2 SEO and metadata consistency audit
+E-3 sitemap and canonical-route consistency
+E-4 public route discovery and cross-surface navigation audit
+E-5 Stats readiness for Explorer deep links
+```
+
+Completion gate:
+
+```text
+core public routes discoverable
+internal links valid
+canonical metadata coherent
+sitemap aligned with intended public routes
+Stats dimensions mapped to planned Explorer query semantics
+```
+
+## 9. Phase E.5 — Explorer v1
+
+Product source of truth:
+
+```text
+docs/HEI_PRODUCT_SURFACES_SPEC.md
+```
+
+Purpose: move HEI from record browsing alone to deterministic cross-record research.
+
+Explorer v1 includes:
+
+```text
+Entity Explorer
+Event Explorer
+shareable URL query state
+Stats -> Explorer deep links
+Timeline / Updates -> Explorer cross-links where useful
+```
+
+Explorer v1 excludes:
+
+```text
+Evidence Explorer
+risk scores
+free-form Ask HEI
+AI-generated classifications
+Natural Language Filter Translator
+Compare view
+```
+
+Recommended implementation order:
+
+```text
+E5-1 Explorer implementation specification and query contract
+E5-2 Entity Explorer
+E5-3 Event Explorer
+E5-4 Stats -> Explorer deep links
+E5-5 Timeline / Updates -> Explorer cross-links
+E5-6 accessibility, URL-state, crawl-control, and regression audit
+```
+
+Completion gate:
+
+```text
+entity filters deterministic and tested
+event filters deterministic and tested
+query state round-trips through shareable URLs
+malformed query values fail safely or fall back predictably
+Stats deep links resolve to correct Explorer states
+reviewed public data boundary enforced
+SEO/crawl behavior does not create uncontrolled query-URL indexation
+keyboard and mobile interaction audited
+```
+
+## 10. Phase F — English root and Japanese `/ja/`
+
+Purpose: introduce the planned bilingual public layer without duplicating canonical facts.
+
+Work:
+
+- keep English as root canonical language;
+- add Japanese `/ja/` routes using translation overlays;
+- localize UI, methodology, about, Stats, Update, Timeline, and Explorer labels in dependency order;
+- keep query parameter keys and enum values locale-independent;
+- preserve a single canonical data source.
+
+Completion gate:
+
+```text
+English root stable
+Japanese route structure stable
+no divergent factual datasets
+locale-independent Explorer query semantics
+translation fallback behavior tested
+```
+
+## 11. Phase G — v1.0 integration baseline
+
+Purpose: complete HEI v1.0 as a coherent public registry system.
+
+Work:
+
+```text
+G-1 accessibility audit
+G-2 URL safety audit
+G-3 cross-surface navigation and integration audit
+G-4 machine-readable and public-output consistency audit
+G-5 production integration and verification
+G-6 maintainer runbook and recovery procedure validation
+G-7 v1.0 baseline tag/checkpoint
+```
+
+Completion gate:
+
+```text
+critical accessibility issues = 0
+critical URL-safety issues = 0
+critical public-data consistency issues = 0
+all required public routes verified
+machine-readable outputs match reviewed public data
+runbook can recover current phase and next action from repository documents
+v1.0 baseline recorded
+```
+
+## 12. Post-v1.0 sequence
+
+Post-v1.0 work is not allowed to displace the active v1.0 path.
+
+Recommended evaluation order:
+
+```text
+Phase H   Compare v1
+Phase I   Discovery Log trial
+Phase J   Natural Language Filter Translator, only if Explorer usage justifies it
+Phase K   API expansion, only if consumer demand justifies it
+```
+
+### H — Compare v1
+
+Compare follows Explorer and v1.0.
+
+It may compare reviewed facts such as:
+
+```text
+type
+launch date
+terminal date
+status
+death reason
+lifespan
+major events
+evidence count
+archive status
+country or origin
+confidence
+```
+
+No synthetic risk score is allowed.
+
+### I — Discovery Log trial
+
+A reviewed Discovery Log may be tested as an operations/content surface after v1.0.
+
+It should summarize research activity such as reviewed promotions, pending-thin outcomes, duplicates, and out-of-scope decisions without exposing private research notes or raw monitoring data.
+
+### J — Natural Language Filter Translator
+
+Conditional only.
+
+Its role is limited to translating user language into validated Explorer parameters. Deterministic Explorer results remain authoritative.
+
+Free-form AI classification of exchange history is not part of the plan.
+
+### K — API expansion
+
+Conditional only.
+
+Do not add API endpoints merely for appearance. Stable JSON, schema behavior, manifests, feeds, and Explorer contracts come first.
+
+## 13. Indefinite backlog and rejected active priorities
+
+### Indefinite backlog
+
+```text
+Public Comments
+```
+
+Comments remain deferred because moderation, spam, source disputes, legal risk, and community-management cost do not currently justify displacement of core registry work.
+
+### Not part of the active roadmap
+
+```text
+Risk Score
+AI Summary vs Human Summary
+free-form Ask HEI
+raw monitoring publication
+general crypto breaking-news operation
+Weekly Exchange Watch as a scheduled product phase
+```
+
+## 14. Immediate schedule from the current checkpoint
+
+```text
+1. D-2 Exchange Incident Timeline
+2. D-3 Evidence Health and Data Quality public summary
+3. D-4 Monthly Historical Exchange Snapshot
+4. D-5 RSS and JSON reviewed-update feeds
+5. Phase E discovery foundation hardening
+6. Phase E.5 Explorer v1
+7. Phase F bilingual layer
+8. Phase G v1.0 integration baseline
+9. Post-v1.0 evaluation sequence
+```
+
+Lane A quality repair and reviewed record growth continue in parallel without replacing the main product sequence.
+
+GitHub-side work can continue without Cloudflare access unless a task specifically requires deployment configuration or production verification.
+
+## 15. Recovery procedure
+
+When resuming HEI work:
+
+1. Confirm current `main`, open PRs, and actual reviewed counts.
+2. Read `AGENTS.md` and the Cloudflare deployment policy.
+3. Read this roadmap.
+4. Read `docs/HEI_PRODUCT_SURFACES_SPEC.md` for Phase D, E, E.5, post-v1 product-surface work, or any related route/feature decision.
+5. Read the task-specific schema, monitoring, machine-readable, localization, or audit document.
+6. Resume the first incomplete item in the active phase.
+7. In the PR body, cite the roadmap item and relevant specification section.
+8. Update this checkpoint whenever counts, phase, active item, or execution order materially changes.
+
+Do not use remembered chat history as the execution source of truth when repository documents and current GitHub state can be inspected directly.


### PR DESCRIPTION
## Purpose

Rebase HEI planning documents onto the actual post-PR #533 repository state and formalize the future product-surface plan without interrupting the current Phase D sequence.

## Roadmap effect

- records Phase D-1 Registry Update as complete
- sets D-2 Exchange Incident Timeline as the current implementation item
- keeps D-3 quality summary, D-4 monthly snapshot, and D-5 feeds in the existing order
- reframes Phase E as discovery/navigation/SEO hardening because Stats already exists
- adds Phase E.5 Explorer v1 after Phase E
- keeps multilingual work in Phase F and v1.0 integration in Phase G
- moves Compare, Discovery Log, Natural Language Filter Translator, and API expansion to post-v1.0 conditional work
- moves Public Comments to indefinite backlog

## Specification effect

Adds `docs/HEI_PRODUCT_SURFACES_SPEC.md` as the product-surface source of truth for:

- Registry / Analysis / Research / Change layer model
- Entity Explorer and Event Explorer scope
- deterministic reviewed-data filtering
- shareable URL query state
- Stats -> Explorer deep links
- Timeline / Updates -> Explorer cross-links
- SEO/crawl control
- accessibility and visual constraints
- Compare sequencing
- conditional natural-language filter translation
- conditional API expansion
- explicit non-goals including risk scores and free-form Ask HEI

## Operating discipline

Updates `AGENTS.md` so future implementation PRs must cite the roadmap item and relevant specification section. Updates `DESIGN.md` without removing existing design rules and adds Explorer/Change-layer visual guidance.

## Canonical count impact

None.

```text
Entities:  unchanged
Events:    unchanged
Evidence:  unchanged
```

## Deployment impact

Documentation and contributor-instruction changes only. No runtime, route, build, workflow, Cloudflare configuration, or canonical data changes.

## Preview requirement

Not required. This PR does not change public runtime output.

## Validation performed

- compared branch against `main`
- confirmed branch is ahead of `00e532ae8f0ff85918690b4fc4ea11f82dd1b112` with no unrelated file changes
- confirmed only `AGENTS.md`, `DESIGN.md`, the new product-surface specification, and the execution roadmap are changed
- re-read the roadmap and product specification on the branch after write
- preserved the pre-existing `DESIGN.md` content while adding new surface guidance

## Production verification plan

None required for this documentation-only PR. The next public-output implementation item remains D-2 Exchange Incident Timeline and must include its own production verification plan.
