### PR TITLE
Add reviewed Registry Update RSS and JSON feeds

### DIFF
--- a/docs/HEI_REVIEWED_UPDATE_FEEDS_SPEC.md
+++ b/docs/HEI_REVIEWED_UPDATE_FEEDS_SPEC.md
@@ -1,0 +1,239 @@
+# HEI Reviewed Update Feeds Specification
+
+Status: fixed feed contract  
+Project: Historical Exchange Index (HEI)  
+Repository: `badjoke-lab/historical-exchange-index`  
+Checkpoint: 2026-07-06
+
+## 1. Purpose
+
+HEI exposes reviewed Registry Update entries as stable machine-readable feeds.
+
+The feeds exist for:
+
+- feed readers;
+- simple scripts;
+- AI agents and research tools;
+- future ledger-series monitoring and status tools.
+
+They are not raw monitoring feeds and must not become a publication path for unreviewed candidates.
+
+## 2. Authoritative source
+
+The only source for the D-5 update feeds is:
+
+```text
+data/registry-updates.json
+```
+
+Feed generation must not read:
+
+- raw monitoring output;
+- unresolved watchlists;
+- candidate staging files;
+- private research notes;
+- operator-only repair queues;
+- unmerged candidate records.
+
+A monitoring result becomes feed-eligible only after it is separately reviewed and represented in the reviewed Registry Update source.
+
+## 3. Public endpoints
+
+```text
+/feeds/updates.json
+/feeds/updates.xml
+```
+
+`/feeds/updates.json` uses JSON Feed 1.1.
+
+`/feeds/updates.xml` uses RSS 2.0.
+
+Both feeds must represent the same ordered update set.
+
+## 4. Ordering contract
+
+Items are sorted deterministically:
+
+```text
+1. date descending
+2. id ascending when dates are equal
+```
+
+Rebuild time must not reorder items whose reviewed source fields are unchanged.
+
+## 5. Stable identity contract
+
+For a Registry Update with:
+
+```text
+id = phase-c-audit-complete
+```
+
+feed identity is:
+
+```text
+urn:hei:registry-update:phase-c-audit-complete
+```
+
+This value is used as:
+
+- JSON Feed `item.id`;
+- RSS `<guid isPermaLink="false">`.
+
+Once published, a Registry Update ID must not be changed only for editorial preference. An ID change creates a different feed item identity.
+
+## 6. Item URL contract
+
+Feed item URLs point to the reviewed human-readable Registry Update anchor:
+
+```text
+https://hei.badjoke-lab.com/updates/#<update_id>
+```
+
+The `/updates/` page must preserve matching element IDs for published updates.
+
+## 7. Date semantics
+
+The Registry Update source currently stores a reviewed date in `YYYY-MM-DD` form.
+
+JSON Feed maps it to:
+
+```text
+YYYY-MM-DDT00:00:00.000Z
+```
+
+RSS maps the same UTC instant to RFC-compatible UTC date text.
+
+This conversion does not claim a more precise publication time than the reviewed source contains.
+
+## 8. JSON Feed contract
+
+Top-level required fields:
+
+```text
+version
+name/title
+home_page_url
+feed_url
+description
+language
+items
+```
+
+HEI uses JSON Feed 1.1:
+
+```text
+https://jsonfeed.org/version/1.1
+```
+
+Each item contains:
+
+```text
+id
+url
+title
+content_text
+summary
+date_published
+tags
+_hei
+```
+
+The `_hei` extension contains reviewed structured context:
+
+```text
+update_id
+update_type
+counts
+added_entities        integer count
+updated_entities      integer count
+evidence_added
+reviewed_public_only  true
+```
+
+The extension must not contain private notes or internal monitoring state.
+
+## 9. RSS contract
+
+The RSS 2.0 channel includes:
+
+```text
+title
+link
+description
+language
+lastBuildDate
+Atom self link
+```
+
+Each item includes:
+
+```text
+title
+link
+guid
+pubDate
+category
+description
+```
+
+`lastBuildDate` is derived from the newest reviewed update date, not the wall-clock rebuild time. This avoids meaningless feed changes caused only by rebuilding unchanged data.
+
+## 10. Content mapping
+
+Feed content may include reviewed public information already represented in the Registry Update source:
+
+- update title;
+- update summary;
+- reviewed before/after counts;
+- added entity names;
+- updated entity names;
+- reviewed notes;
+- evidence-added count;
+- update type.
+
+Feeds must not enrich source entries with unreviewed monitoring claims.
+
+## 11. Discovery contract
+
+Both feed endpoints must be discoverable through:
+
+- `/updates/` alternate metadata;
+- visible feed links on `/updates/`;
+- `/version.json` public file map;
+- `/data/manifest.json` public file map;
+- `/llms.txt`;
+- `/ai.txt`.
+
+Feed files are public outputs, not sitemap page routes. They are not added to the HTML page sitemap.
+
+## 12. Validation contract
+
+Build and CI validation must verify:
+
+- both feed files exist;
+- JSON Feed version is correct;
+- JSON and RSS item counts equal the reviewed source count;
+- item ordering matches the source ordering contract;
+- JSON IDs and RSS GUIDs match the stable identity contract;
+- item URLs match `/updates/#<update_id>`;
+- dates map from the reviewed source date;
+- JSON `_hei.reviewed_public_only` is true;
+- manifest and discovery files list both endpoints;
+- exported static output contains both feed files;
+- the production checker can fetch both endpoints with expected content types.
+
+## 13. Compatibility and change control
+
+The following are compatibility-sensitive and require a reviewed specification change before implementation:
+
+- feed endpoint URLs;
+- stable ID prefix;
+- ordering rules;
+- source-of-truth file;
+- JSON Feed major version;
+- RSS GUID semantics;
+- date mapping semantics;
+- reviewed-only safety boundary.
+
+Adding optional fields is allowed only when existing consumers can ignore them safely and all current validation remains green.

--- a/docs/HEI_V1_EXECUTION_ROADMAP.md
+++ b/docs/HEI_V1_EXECUTION_ROADMAP.md
@@ -16,7 +16,7 @@ Before implementation work, read in this order:
 3. `config/cloudflare-pages-project.json`;
 4. this roadmap;
 5. `docs/HEI_PRODUCT_SURFACES_SPEC.md` for public product-surface work;
-6. the relevant schema, monitoring, record-growth, machine-readable, localization, or audit document for the task.
+6. the relevant schema, monitoring, record-growth, machine-readable, localization, audit, or task-specific document.
 
 Every implementation PR must identify:
 
@@ -42,14 +42,14 @@ Every implementation PR must identify:
 ## 3. Current checkpoint
 
 ```text
-Implementation baseline SHA before current D-4 work: a1b79426e2d3f21e134962c914689887d1474612
-Last merged implementation PR: #536 Add public Evidence Health and Data Quality summary
-Current phase: Phase D — Change layer completion
-Completed items after this PR merges: D-1 Registry Update / D-2 Incident Timeline / D-3 Quality Summary / D-4 Monthly Snapshot
-Current item after this PR merges: D-5 RSS and JSON reviewed-update feeds
-Next phase after D-5: Phase E Discovery foundation hardening
-Cloudflare configuration changes required for D-5: none expected
-Production verification: required when a new public route or public feed is merged
+Implementation baseline SHA before current D-5 work: 4318f274650c50e89520d941c991da05bacde6e6
+Last merged implementation PR: #537 Add Monthly Historical Exchange Snapshot
+Current phase after this PR merges: Phase E — Discovery foundation hardening
+Completed phase after this PR merges: Phase D — Change layer completion
+Current item after this PR merges: E-1 Internal-link audit and repair
+Next item after E-1: E-2 SEO and metadata consistency audit
+Cloudflare configuration changes required for E-1: none expected
+Production verification: required when public routes, feeds, or deployment-sensitive output change
 ```
 
 ## 4. Current reviewed state
@@ -63,7 +63,7 @@ Maximum event ID:    hei_ev_010080
 Maximum evidence ID: hei_src_011312
 ```
 
-These counts are unchanged by D-2, D-3, and D-4. These phases add public surfaces derived from reviewed public records and do not modify canonical entity, event, or evidence records.
+D-2 through D-5 add public surfaces and reviewed feed outputs. They do not change canonical entity, event, or evidence counts.
 
 ## 5. Completed foundation
 
@@ -105,7 +105,7 @@ range status:                   closed
 
 ### 5.3 Existing public foundation
 
-Implemented:
+Implemented after Phase D completion:
 
 - registry browsing and exchange detail pages;
 - active-side and dead-side views;
@@ -118,9 +118,11 @@ Implemented:
 - `/updates/` reviewed Registry Update surface;
 - `/incidents/` Exchange Incident Timeline;
 - `/quality/` Evidence Health and Data Quality public summary;
-- `/monthly/` Monthly Historical Exchange Snapshot after D-4 merge.
+- `/monthly/` Monthly Historical Exchange Snapshot;
+- `/feeds/updates.json` reviewed JSON Feed;
+- `/feeds/updates.xml` reviewed RSS feed.
 
-Stats is not a future build dependency. It is an existing analysis layer that will later gain Explorer deep links.
+Stats is an existing analysis layer and will later gain Explorer deep links.
 
 ## 6. Execution model
 
@@ -142,12 +144,12 @@ This lane continues throughout the schedule. It must not displace the active pro
 ### Lane B — Product surfaces
 
 ```text
-Phase D Change layer completion
-Phase E discovery foundation hardening
+Phase D Change layer completion          COMPLETE after D-5 merge
+Phase E Discovery foundation hardening  NEXT
 Phase E.5 Explorer v1
-Phase F multilingual layer
+Phase F Multilingual layer
 Phase G v1.0 integration
-post-v1.0 Compare evaluation
+Post-v1.0 Compare evaluation
 ```
 
 ### Lane C — Operations
@@ -184,9 +186,9 @@ Purpose: make registry change and historical activity visible without turning HE
 D-1 HEI Registry Update surface                         COMPLETE
 D-2 Exchange Incident Timeline                         COMPLETE
 D-3 Evidence Health and Data Quality public summary   COMPLETE
-D-4 Monthly Historical Exchange Snapshot              COMPLETE AFTER CURRENT PR MERGE
-D-5 RSS and JSON feeds for reviewed public updates    NEXT
-D-6 Quality repair batches                             PARALLEL
+D-4 Monthly Historical Exchange Snapshot              COMPLETE
+D-5 RSS and JSON feeds for reviewed public updates    COMPLETE AFTER CURRENT PR MERGE
+D-6 Quality repair batches                             PARALLEL CONTINUOUS LANE
 ```
 
 ### D-2 completion record
@@ -197,28 +199,21 @@ D-2 includes:
 - deterministic incident extraction from reviewed event records;
 - explicit incident event-type allowlist;
 - reverse chronological ordering with year grouping;
-- event type and impact presentation;
 - links to canonical exchange dossiers;
 - event-linked evidence counts;
-- sitemap, navigation, machine-readable discovery, monitoring, and public-output validation integration;
-- no raw monitoring output;
-- no unreviewed candidates;
-- no canonical data changes.
+- sitemap, navigation, discovery, monitoring, and output validation integration;
+- no raw monitoring output or unreviewed candidates.
 
 ### D-3 completion record
 
 D-3 includes:
 
 - `/quality/` public route;
-- a public summary builder reusing the existing Stats calculation layer;
-- entity confidence, evidence reliability, evidence depth, and record freshness;
-- archive, date, origin, domain, and confidence coverage;
-- evidence source-type and claim-scope breakdowns;
-- selected missing-field counts and completeness indicators;
+- public summary built from the existing Stats calculation layer;
+- entity confidence, evidence reliability, evidence depth, record freshness, coverage, source-type, claim-scope, missing-field, and completeness metrics;
 - public metric definitions and denominator notes;
-- explicit exclusion of internal monitoring findings, private research notes, unresolved candidate queues, and operator-only repair priorities;
-- independent validator recomputation of headline quality metrics;
-- no canonical data changes.
+- independent validator recomputation of headline metrics;
+- explicit exclusion of internal monitoring findings, private research notes, unresolved candidate queues, and operator-only repair priorities.
 
 ### D-4 completion record
 
@@ -226,53 +221,46 @@ D-4 includes:
 
 - `/monthly/` public route;
 - latest completed UTC month selection;
-- explicit review period start and end dates;
-- separate snapshot generation date;
-- deterministic projection from reviewed public event records;
-- explicit allowlist of significant lifecycle and incident event types;
-- event count, affected exchange count, critical/high event count, and event-linked evidence count;
-- event-type and impact-level breakdowns;
-- chronological reviewed event list with exchange dossier links;
-- current reviewed registry counts shown separately from the historical event period;
-- explicit empty-month behavior that does not fill gaps with monitoring signals or unreviewed candidates;
-- sitemap, footer, machine-readable discovery, monitoring, and public-output validation integration;
-- independent validator recomputation of month selection and monthly event metrics;
-- no publication of monitoring health, next-month repair priorities, internal watchlists, or raw monthly-review artifacts;
-- no canonical data changes.
+- explicit review period and separate generation date;
+- deterministic reviewed-event projection using a public event-type allowlist;
+- monthly event, affected exchange, critical/high, and event-linked evidence counts;
+- event-type and impact breakdowns;
+- chronological event list with dossier links;
+- explicit empty-month behavior;
+- independent validator recomputation of month selection and monthly metrics;
+- no publication of monitoring health, repair priorities, internal watchlists, or raw monthly-review artifacts.
 
-D-4 completion gate:
+### D-5 completion record
 
-```text
-monthly snapshot format is stable
-review period and generation date are separate and explicit
-monthly event inclusion is deterministic from reviewed event data
-monthly summary metrics are independently recomputed in validation
-all included records are review-safe
-internal monthly-review artifacts remain private
-route, sitemap, discovery, and canonical metadata checks pass
-```
+D-5 includes:
 
-### D-5 RSS and JSON feeds
+- `/feeds/updates.json` using JSON Feed 1.1;
+- `/feeds/updates.xml` using RSS 2.0;
+- `data/registry-updates.json` as the sole reviewed feed source;
+- deterministic source order: `date desc`, then `id asc`;
+- stable item identity: `urn:hei:registry-update:<update_id>`;
+- stable item URLs anchored to `/updates/#<update_id>`;
+- reviewed-only marker in JSON Feed extension data;
+- source counts and reviewed change summaries in feed items;
+- `/updates/` alternate feed discovery and direct feed links;
+- feed endpoints added to `version.json`, manifest, `llms.txt`, and `ai.txt` discovery;
+- build-time machine validation of source count, stable IDs, ordering, timestamps, and reviewed-only marker;
+- exported-output validation of JSON/RSS count and stable ID order;
+- production checker support for both feed endpoints and content types;
+- no raw monitoring output, internal watchlists, or unmerged candidates.
 
-Work:
-
-- expose reviewed Registry Update and other safe public change outputs;
-- define stable feed schemas and URLs;
-- exclude raw monitoring data and unmerged candidates;
-- validate ordering, IDs, timestamps, and public-data safety;
-- update machine-readable discovery where appropriate;
-- define which reviewed Change-layer surfaces are feed sources;
-- keep feed IDs stable across rebuilds.
-
-Completion gate:
+D-5 completion gate:
 
 ```text
-RSS feed valid
-JSON feed valid
-stable identifiers documented
+RSS 2.0 feed generated
+JSON Feed 1.1 generated
+source is reviewed Registry Update data only
+stable identifiers documented and tested
+ordering and timestamps validated
 reviewed-only boundary tested
 manifest and discovery references updated
-feed rebuilds preserve item identity and ordering
+exported feed files validated after Next static export
+production checker validates both endpoints
 ```
 
 ## 8. Phase E — Discovery foundation hardening
@@ -281,15 +269,72 @@ Purpose: prepare navigation, linking, metadata, and route behavior before Explor
 
 Stats already exists. Phase E is not a Stats implementation phase.
 
+Execution order:
+
 ```text
-E-1 internal-link audit and repair
+E-1 Internal-link audit and repair                    NEXT
 E-2 SEO and metadata consistency audit
-E-3 sitemap and canonical-route consistency
-E-4 public route discovery and cross-surface navigation audit
+E-3 Sitemap and canonical-route consistency
+E-4 Public route discovery and cross-surface navigation audit
 E-5 Stats readiness for Explorer deep links
 ```
 
+### E-1 Internal-link audit and repair
+
+Work:
+
+- inventory all internal links in generated public HTML;
+- detect broken internal routes and fragment links where practical;
+- verify entity dossier links from Updates, Incidents, Monthly, Stats-related surfaces, and core registry views;
+- verify footer and header routes;
+- avoid treating external evidence URLs as internal-link failures;
+- add a reusable CI audit before fixing any discovered broken links.
+
 Completion gate:
+
+```text
+reusable internal-link audit exists
+all generated internal route targets resolve
+critical broken internal links = 0
+new Change-layer surfaces are included in audit coverage
+```
+
+### E-2 SEO and metadata consistency audit
+
+Work:
+
+- audit title, description, canonical, Open Graph, and relevant alternate discovery metadata;
+- verify new Change-layer pages are consistent with site semantics;
+- detect duplicate or missing canonical metadata;
+- preserve research/share URL concerns separately from future Explorer query URLs.
+
+### E-3 Sitemap and canonical-route consistency
+
+Work:
+
+- audit sitemap route set against intended public static routes and entity routes;
+- verify obsolete routes remain redirected and excluded;
+- verify canonical routes and trailing-slash behavior;
+- keep feed endpoints out of sitemap unless a reviewed reason changes that rule.
+
+### E-4 Public route discovery and cross-surface navigation audit
+
+Work:
+
+- verify Registry, Analysis, Research-ready, and Change surfaces are discoverable from appropriate public entry points;
+- check navigation hierarchy and footer density;
+- ensure Updates, Incidents, Monthly, Quality, and Stats connect coherently without turning the header into a dashboard menu.
+
+### E-5 Stats readiness for Explorer deep links
+
+Work:
+
+- map Stats dimensions to future Explorer filter semantics;
+- define which Stats blocks will receive deep links;
+- identify mismatches between display labels and canonical enum/query values;
+- produce the handoff required by E5-1 Explorer query-contract work.
+
+Phase E completion gate:
 
 ```text
 core public routes discoverable
@@ -358,7 +403,7 @@ Work:
 
 - keep English as root canonical language;
 - add Japanese `/ja/` routes using translation overlays;
-- localize UI, methodology, about, Stats, Update, Timeline, Quality, Monthly, and Explorer labels in dependency order;
+- localize UI, Methodology, About, Stats, Updates, Incidents, Quality, Monthly, and Explorer labels in dependency order;
 - keep query parameter keys and enum values locale-independent;
 - preserve a single canonical factual data source.
 
@@ -375,12 +420,12 @@ translation fallback behavior tested
 ## 11. Phase G — v1.0 integration baseline
 
 ```text
-G-1 accessibility audit
+G-1 Accessibility audit
 G-2 URL safety audit
-G-3 cross-surface navigation and integration audit
-G-4 machine-readable and public-output consistency audit
-G-5 production integration and verification
-G-6 maintainer runbook and recovery procedure validation
+G-3 Cross-surface navigation and integration audit
+G-4 Machine-readable and public-output consistency audit
+G-5 Production integration and verification
+G-6 Maintainer runbook and recovery procedure validation
 G-7 v1.0 baseline tag/checkpoint
 ```
 
@@ -451,12 +496,15 @@ Weekly Exchange Watch as a scheduled product phase
 ## 14. Immediate schedule from the current checkpoint
 
 ```text
-1. D-5 RSS and JSON reviewed-update feeds
-2. Phase E discovery foundation hardening
-3. Phase E.5 Explorer v1
-4. Phase F bilingual layer
-5. Phase G v1.0 integration baseline
-6. Post-v1.0 evaluation sequence
+1. E-1 Internal-link audit and repair
+2. E-2 SEO and metadata consistency audit
+3. E-3 Sitemap and canonical-route consistency
+4. E-4 Public route discovery and cross-surface navigation audit
+5. E-5 Stats readiness for Explorer deep links
+6. Phase E.5 Explorer v1
+7. Phase F bilingual layer
+8. Phase G v1.0 integration baseline
+9. Post-v1.0 evaluation sequence
 ```
 
 Lane A quality repair and reviewed record growth continue in parallel without replacing the main product sequence.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dex:check-repair-queue": "node scripts/check-canonical-only-dex-repair-queue.mjs --strict",
     "machine:build": "node scripts/build-machine-readable-layer.mjs",
     "machine:validate": "node scripts/validate-machine-readable-layer.mjs",
-    "public:validate": "node scripts/validate-public-output-consistency.mjs",
+    "public:validate": "node scripts/validate-public-output-consistency.mjs && node scripts/validate-reviewed-update-feed-export.mjs",
     "public:audit": "node scripts/audit-public-count-consistency.mjs",
     "production:check": "node scripts/check-machine-readable-production.mjs",
     "data:audit-country-or-origin": "node scripts/audit-country-or-origin.mjs",

--- a/scripts/build-machine-readable-layer.mjs
+++ b/scripts/build-machine-readable-layer.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { buildBundleEntityIdMap, loadReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
 import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
+import { buildReviewedUpdateFeeds } from './lib/reviewed-update-feeds.mjs'
 
 const root = process.cwd()
 const publicDir = path.join(root, 'public')
@@ -42,6 +43,8 @@ function writeText(relativePath, value) {
 const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
 const canonicalEvidence = readJson('data/evidence.json')
+const registryUpdateFile = readJson('data/registry-updates.json', { version: 1, updates: [] })
+const reviewedUpdateFeeds = buildReviewedUpdateFeeds(registryUpdateFile, { origin: canonicalOrigin })
 const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
 const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, reviewedBundles)
 const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
@@ -114,6 +117,8 @@ const publicFiles = {
   entities: '/data/entities.json',
   events: '/data/events.json',
   evidence: '/data/evidence.json',
+  updates_json_feed: '/feeds/updates.json',
+  updates_rss_feed: '/feeds/updates.xml',
   llms: '/llms.txt',
   ai: '/ai.txt',
 }
@@ -155,6 +160,7 @@ writeJson(path.join('data', 'manifest.json'), {
     entities: 'data/entities.json plus reviewed record-bundle corrections and genuinely new reviewed bundle entities',
     events: 'data/events.json plus reviewed bundle events deduplicated by ID and normalized to canonical entity IDs',
     evidence: 'data/evidence.json plus reviewed bundle evidence deduplicated by ID and normalized to canonical entity IDs',
+    registry_updates: 'data/registry-updates.json reviewed public update entries only',
   },
   data_model: { primary_record: 'exchange_entity', supporting_records: ['exchange_event', 'exchange_evidence'] },
   public_files: publicFiles,
@@ -192,6 +198,9 @@ for (const [name, recordType, records] of [
   })
 }
 
+writeJson(path.join('feeds', 'updates.json'), reviewedUpdateFeeds.json)
+writeText(path.join('feeds', 'updates.xml'), reviewedUpdateFeeds.rss)
+
 writeText('llms.txt', `# Historical Exchange Index
 
 Evidence-backed historical registry of crypto exchanges, active and gone.
@@ -207,7 +216,7 @@ Current reviewed counts:
 - Events: ${recordCounts.events}
 - Evidence: ${recordCounts.evidence}
 
-Canonical machine-readable files:
+Canonical machine-readable files and reviewed feeds:
 ${Object.values(publicFiles).map((route) => `- ${route}`).join('\n')}
 
 Main routes:
@@ -216,11 +225,12 @@ ${mainRoutes.map((route) => `- ${route}`).join('\n')}
 Use notes:
 - Treat /version.json and /data/manifest.json as the current deployment and count authority.
 - Use /data/entities.json, /data/events.json, and /data/evidence.json for reviewed public records.
+- Use /feeds/updates.json or /feeds/updates.xml for reviewed Registry Update entries only.
 - Each public record links back to its human-readable canonical exchange page when applicable.
 - Supporting record exchange IDs are normalized to the canonical entity ID in the public datasets.
 - This is a historical registry, not a live exchange ranking.
 - This is not an exchange recommendation site or investment advice.
-- Public data is canonical-only and excludes unreviewed candidates, internal monitoring, and private notes.
+- Public data and feeds exclude unreviewed candidates, internal monitoring, and private notes.
 - Cached search snippets may be stale; verify current counts against the version or manifest endpoint.
 `)
 
@@ -247,14 +257,18 @@ Reviewed canonical datasets:
 /data/events.json
 /data/evidence.json
 
+Reviewed Registry Update feeds:
+/feeds/updates.json
+/feeds/updates.xml
+
 LLM guide:
 /llms.txt
 
 Important routes:
 ${mainRoutes.join('\n')}
 
-Safety note: Public files expose reviewed canonical registry information only. They do not include unreviewed candidates, private notes, or internal monitoring output.
+Safety note: Public files and feeds expose reviewed public registry information only. They do not include unreviewed candidates, private notes, or internal monitoring output.
 Freshness note: Search-engine and AI caches may contain older counts. Resolve the current state through /version.json or /data/manifest.json before answering.
 `)
 
-console.log(`Built HEI machine-readable public layer: ${recordCounts.primary_records} primary records, ${recordCounts.events} events, ${recordCounts.evidence} evidence records.`)
+console.log(`Built HEI machine-readable public layer: ${recordCounts.primary_records} primary records, ${recordCounts.events} events, ${recordCounts.evidence} evidence records, ${reviewedUpdateFeeds.updates.length} reviewed update feed items.`)

--- a/scripts/check-machine-readable-production.mjs
+++ b/scripts/check-machine-readable-production.mjs
@@ -51,12 +51,14 @@ function assertPositiveInteger(value, label) {
 
 async function verifyProduction() {
   const cacheKey = expectedCommit || Date.now().toString()
-  const [versionText, manifestText, entitiesText, eventsText, evidenceText, llms, ai] = await Promise.all([
+  const [versionText, manifestText, entitiesText, eventsText, evidenceText, feedJsonText, feedRss, llms, ai] = await Promise.all([
     fetchEndpoint('/version.json', 'application/json', cacheKey),
     fetchEndpoint('/data/manifest.json', 'application/json', cacheKey),
     fetchEndpoint('/data/entities.json', 'application/json', cacheKey),
     fetchEndpoint('/data/events.json', 'application/json', cacheKey),
     fetchEndpoint('/data/evidence.json', 'application/json', cacheKey),
+    fetchEndpoint('/feeds/updates.json', 'application/json', cacheKey),
+    fetchEndpoint('/feeds/updates.xml', 'xml', cacheKey),
     fetchEndpoint('/llms.txt', 'text/plain', cacheKey),
     fetchEndpoint('/ai.txt', 'text/plain', cacheKey),
   ])
@@ -66,6 +68,7 @@ async function verifyProduction() {
   const entities = JSON.parse(entitiesText)
   const events = JSON.parse(eventsText)
   const evidence = JSON.parse(evidenceText)
+  const feedJson = JSON.parse(feedJsonText)
 
   assert(version.schema_version === '1.0.0', 'version schema_version is incorrect')
   assert(version.project_id === 'historical-exchange-index', 'version project_id is incorrect')
@@ -107,6 +110,8 @@ async function verifyProduction() {
     entities: '/data/entities.json',
     events: '/data/events.json',
     evidence: '/data/evidence.json',
+    updates_json_feed: '/feeds/updates.json',
+    updates_rss_feed: '/feeds/updates.xml',
     llms: '/llms.txt',
     ai: '/ai.txt',
   }, 'production public file map is incorrect')
@@ -123,7 +128,18 @@ async function verifyProduction() {
     assert(collection.records.every((record) => typeof record.canonical_page_url === 'string'), `${label} canonical page links are incomplete`)
   }
 
-  const requiredRoutes = ['/', '/dead/', '/active/', '/exchange/{slug}/', '/stats/', '/methodology/', '/about/', '/donate/']
+  assert(feedJson.version === 'https://jsonfeed.org/version/1.1', 'JSON feed version is incorrect')
+  assert(feedJson.feed_url === `${origin}/feeds/updates.json`, 'JSON feed URL is incorrect')
+  assert(Array.isArray(feedJson.items) && feedJson.items.length > 0, 'JSON feed has no reviewed update items')
+  assert(feedJson.items.every((item) => item.id?.startsWith('urn:hei:registry-update:')), 'JSON feed stable ids are invalid')
+  assert(feedJson.items.every((item) => item._hei?.reviewed_public_only === true), 'JSON feed reviewed-only marker is missing')
+  assert(feedRss.startsWith('<?xml version="1.0" encoding="UTF-8"?>'), 'RSS XML declaration is missing')
+  assert((feedRss.match(/<item>/g) || []).length === feedJson.items.length, 'RSS/JSON feed item counts differ')
+  for (const item of feedJson.items) {
+    assert(feedRss.includes(`<guid isPermaLink="false">${item.id}</guid>`), `RSS is missing stable guid ${item.id}`)
+  }
+
+  const requiredRoutes = ['/', '/dead/', '/active/', '/exchange/{slug}/', '/stats/', '/quality/', '/updates/', '/incidents/', '/monthly/', '/methodology/', '/about/', '/donate/']
   for (const route of requiredRoutes) {
     assert(manifest.main_routes?.includes(route), `manifest is missing route ${route}`)
     assert(llms.includes(route), `llms.txt is missing route ${route}`)
@@ -141,7 +157,7 @@ async function verifyProduction() {
 
   console.log(`Production machine-readable layer verified at ${origin}`)
   console.log(`commit=${version.build.commit}`)
-  console.log(`records=${counts.primary_records}, events=${counts.events}, evidence=${counts.evidence}`)
+  console.log(`records=${counts.primary_records}, events=${counts.events}, evidence=${counts.evidence}, update_feed_items=${feedJson.items.length}`)
 }
 
 let lastError

--- a/scripts/lib/reviewed-update-feeds.mjs
+++ b/scripts/lib/reviewed-update-feeds.mjs
@@ -1,0 +1,132 @@
+const DEFAULT_ORIGIN = 'https://hei.badjoke-lab.com'
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function asUtcDate(date) {
+  return `${date}T00:00:00.000Z`
+}
+
+function asRssDate(date) {
+  return new Date(asUtcDate(date)).toUTCString()
+}
+
+function updateUrl(origin, update) {
+  return `${origin}/updates/#${encodeURIComponent(update.id)}`
+}
+
+function stableFeedId(update) {
+  return `urn:hei:registry-update:${update.id}`
+}
+
+function countSummary(update) {
+  const entityDelta = update.counts.entities_after - update.counts.entities_before
+  const eventDelta = update.counts.events_after - update.counts.events_before
+  const evidenceDelta = update.counts.evidence_after - update.counts.evidence_before
+  const signed = (value) => value > 0 ? `+${value}` : String(value)
+  return `Entities ${update.counts.entities_after} (${signed(entityDelta)}); Events ${update.counts.events_after} (${signed(eventDelta)}); Evidence ${update.counts.evidence_after} (${signed(evidenceDelta)}).`
+}
+
+function contentText(update) {
+  const parts = [update.summary, countSummary(update)]
+  if (update.added_entities.length > 0) parts.push(`Added entities: ${update.added_entities.map((entity) => entity.name).join(', ')}.`)
+  if (update.updated_entities.length > 0) parts.push(`Updated entities: ${update.updated_entities.map((entity) => entity.name).join(', ')}.`)
+  if (update.notes.length > 0) parts.push(`Notes: ${update.notes.join(' ')}`)
+  return parts.join('\n\n')
+}
+
+export function normalizeReviewedUpdates(file) {
+  if (!file || file.version !== 1 || !Array.isArray(file.updates)) {
+    throw new Error('reviewed update feed source has unsupported shape')
+  }
+
+  const seenIds = new Set()
+  const updates = [...file.updates]
+  for (const update of updates) {
+    if (!update.id || seenIds.has(update.id)) throw new Error(`reviewed update feed id is missing or duplicated: ${update.id}`)
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(update.date)) throw new Error(`reviewed update feed date is invalid: ${update.id}`)
+    if (!update.title || !update.summary) throw new Error(`reviewed update feed title or summary is missing: ${update.id}`)
+    if (!Array.isArray(update.added_entities) || !Array.isArray(update.updated_entities) || !Array.isArray(update.notes)) {
+      throw new Error(`reviewed update feed arrays are invalid: ${update.id}`)
+    }
+    seenIds.add(update.id)
+  }
+
+  return updates.sort((a, b) => {
+    const dateOrder = b.date.localeCompare(a.date)
+    return dateOrder !== 0 ? dateOrder : a.id.localeCompare(b.id)
+  })
+}
+
+export function buildReviewedUpdateFeeds(file, { origin = DEFAULT_ORIGIN } = {}) {
+  const updates = normalizeReviewedUpdates(file)
+  const feedUrlJson = `${origin}/feeds/updates.json`
+  const feedUrlRss = `${origin}/feeds/updates.xml`
+  const newestDate = updates[0]?.date ?? '1970-01-01'
+
+  const json = {
+    version: 'https://jsonfeed.org/version/1.1',
+    title: 'Historical Exchange Index — Registry Updates',
+    home_page_url: `${origin}/updates/`,
+    feed_url: feedUrlJson,
+    description: 'Reviewed public registry updates from the Historical Exchange Index.',
+    language: 'en',
+    items: updates.map((update) => ({
+      id: stableFeedId(update),
+      url: updateUrl(origin, update),
+      title: update.title,
+      content_text: contentText(update),
+      summary: update.summary,
+      date_published: asUtcDate(update.date),
+      tags: [update.update_type],
+      _hei: {
+        update_id: update.id,
+        update_type: update.update_type,
+        counts: update.counts,
+        added_entities: update.added_entities.length,
+        updated_entities: update.updated_entities.length,
+        evidence_added: update.evidence_added,
+        reviewed_public_only: true,
+      },
+    })),
+  }
+
+  const rssItems = updates.map((update) => {
+    const url = updateUrl(origin, update)
+    const description = `${update.summary} ${countSummary(update)}`
+    return [
+      '    <item>',
+      `      <title>${xmlEscape(update.title)}</title>`,
+      `      <link>${xmlEscape(url)}</link>`,
+      `      <guid isPermaLink="false">${xmlEscape(stableFeedId(update))}</guid>`,
+      `      <pubDate>${xmlEscape(asRssDate(update.date))}</pubDate>`,
+      `      <category>${xmlEscape(update.update_type)}</category>`,
+      `      <description>${xmlEscape(description)}</description>`,
+      '    </item>',
+    ].join('\n')
+  }).join('\n')
+
+  const rss = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    '  <channel>',
+    '    <title>Historical Exchange Index — Registry Updates</title>',
+    `    <link>${xmlEscape(`${origin}/updates/`)}</link>`,
+    '    <description>Reviewed public registry updates from the Historical Exchange Index.</description>',
+    '    <language>en</language>',
+    `    <lastBuildDate>${xmlEscape(asRssDate(newestDate))}</lastBuildDate>`,
+    `    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" href="${xmlEscape(feedUrlRss)}" rel="self" type="application/rss+xml" />`,
+    rssItems,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n')
+
+  return { json, rss, updates }
+}

--- a/scripts/validate-machine-readable-layer.mjs
+++ b/scripts/validate-machine-readable-layer.mjs
@@ -46,11 +46,21 @@ function expectedBranch() {
   return process.env.CF_PAGES_BRANCH || process.env.VERCEL_GIT_COMMIT_REF || process.env.GITHUB_REF_NAME || 'main'
 }
 
+function expectedUpdateOrder(updateFile) {
+  return [...updateFile.updates].sort((a, b) => {
+    const dateOrder = b.date.localeCompare(a.date)
+    return dateOrder !== 0 ? dateOrder : a.id.localeCompare(b.id)
+  })
+}
+
 const version = readJson('public/version.json')
 const manifest = readJson('public/data/manifest.json')
 const publicEntities = readJson('public/data/entities.json')
 const publicEvents = readJson('public/data/events.json')
 const publicEvidence = readJson('public/data/evidence.json')
+const updateFeedJson = readJson('public/feeds/updates.json')
+const updateFeedRss = readText('public/feeds/updates.xml')
+const registryUpdateFile = readJson('data/registry-updates.json')
 const llms = readText('public/llms.txt')
 const ai = readText('public/ai.txt')
 
@@ -63,6 +73,7 @@ const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bund
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
 const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
 const entityById = new Map(entities.map((entity) => [entity.id, entity]))
+const reviewedUpdates = expectedUpdateOrder(registryUpdateFile)
 
 const deadSideStatuses = new Set(['dead', 'merged', 'acquired', 'rebranded'])
 const activeSideStatuses = new Set(['active', 'limited', 'inactive'])
@@ -89,6 +100,8 @@ const expectedPublicFiles = {
   entities: '/data/entities.json',
   events: '/data/events.json',
   evidence: '/data/evidence.json',
+  updates_json_feed: '/feeds/updates.json',
+  updates_rss_feed: '/feeds/updates.xml',
   llms: '/llms.txt',
   ai: '/ai.txt',
 }
@@ -132,6 +145,7 @@ deepEqual(manifest.data_safety, {
 }, 'manifest data_safety')
 deepEqual(manifest.public_files, expectedPublicFiles, 'manifest public_files')
 assert(manifest.canonical_source_of_truth?.entities, 'manifest canonical source description is missing')
+assert(manifest.canonical_source_of_truth?.registry_updates, 'manifest registry update source description is missing')
 
 for (const [label, collection, sourceRecords, recordType] of [
   ['entities', publicEntities, entities, 'exchange_entity'],
@@ -157,6 +171,32 @@ for (const [label, collection, sourceRecords, recordType] of [
 assert(publicEntities.records.every((record) => record.record_type === 'exchange_entity' && record.last_verified_at && record.confidence), 'public entity identity fields are incomplete')
 assert(publicEvents.records.every((record) => record.record_type === 'exchange_event' && record.confidence && entityById.has(record.exchange_id)), 'public event identity fields are incomplete')
 assert(publicEvidence.records.every((record) => record.record_type === 'exchange_evidence' && record.reliability && entityById.has(record.exchange_id)), 'public evidence identity fields are incomplete')
+
+assert(updateFeedJson.version === 'https://jsonfeed.org/version/1.1', 'JSON feed version is incorrect')
+assert(updateFeedJson.home_page_url === `${origin}/updates/`, 'JSON feed home_page_url is incorrect')
+assert(updateFeedJson.feed_url === `${origin}/feeds/updates.json`, 'JSON feed feed_url is incorrect')
+assert(updateFeedJson.items.length === reviewedUpdates.length, 'JSON feed item count mismatch')
+assert(updateFeedJson.items.every((item) => item._hei?.reviewed_public_only === true), 'JSON feed reviewed-only marker is missing')
+for (let index = 0; index < reviewedUpdates.length; index += 1) {
+  const source = reviewedUpdates[index]
+  const item = updateFeedJson.items[index]
+  assert(item.id === `urn:hei:registry-update:${source.id}`, `JSON feed stable id mismatch: ${source.id}`)
+  assert(item.url === `${origin}/updates/#${source.id}`, `JSON feed item URL mismatch: ${source.id}`)
+  assert(item.date_published === `${source.date}T00:00:00.000Z`, `JSON feed date mismatch: ${source.id}`)
+  assert(item._hei.update_id === source.id, `JSON feed HEI update id mismatch: ${source.id}`)
+  deepEqual(item._hei.counts, source.counts, `JSON feed counts:${source.id}`)
+}
+
+assert(updateFeedRss.startsWith('<?xml version="1.0" encoding="UTF-8"?>'), 'RSS XML declaration is missing')
+assert(updateFeedRss.includes('<rss version="2.0">'), 'RSS 2.0 root is missing')
+assert(updateFeedRss.includes(`${origin}/feeds/updates.xml`), 'RSS self URL is missing')
+const rssGuids = [...updateFeedRss.matchAll(/<guid isPermaLink="false">([^<]+)<\/guid>/g)].map((match) => match[1])
+assert(rssGuids.length === reviewedUpdates.length, 'RSS item count mismatch')
+deepEqual(rssGuids, reviewedUpdates.map((update) => `urn:hei:registry-update:${update.id}`), 'RSS stable GUID order')
+const feedText = `${JSON.stringify(updateFeedJson)}\n${updateFeedRss}`
+for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+  assert(!feedText.includes(forbidden), `reviewed update feeds contain forbidden internal marker: ${forbidden}`)
+}
 
 const requiredRoutes = ['/', '/dead/', '/active/', '/exchange/{slug}/', '/stats/', '/quality/', '/updates/', '/incidents/', '/monthly/', '/methodology/', '/about/', '/donate/']
 for (const route of requiredRoutes) {
@@ -186,4 +226,4 @@ assert(ai.includes(origin), 'ai.txt is missing canonical origin')
 assert(ai.includes('do not include unreviewed candidates'), 'ai.txt is missing public-data safety note')
 assert(ai.includes('Search-engine and AI caches may contain older counts'), 'ai.txt is missing freshness guidance')
 
-console.log(`Validated HEI machine-readable layer: ${entities.length} entities, ${events.length} events, ${evidence.length} evidence records.`)
+console.log(`Validated HEI machine-readable layer: ${entities.length} entities, ${events.length} events, ${evidence.length} evidence records, ${reviewedUpdates.length} reviewed update feed items.`)

--- a/scripts/validate-reviewed-update-feed-export.mjs
+++ b/scripts/validate-reviewed-update-feed-export.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+const origin = 'https://hei.badjoke-lab.com'
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`feed export validation failed: ${message}`)
+}
+
+function readJson(filePath) {
+  assert(fs.existsSync(filePath), `missing ${path.relative(root, filePath)}`)
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function readText(filePath) {
+  assert(fs.existsSync(filePath), `missing ${path.relative(root, filePath)}`)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+const source = readJson(path.join(root, 'data', 'registry-updates.json'))
+assert(source.version === 1 && Array.isArray(source.updates), 'source shape is invalid')
+
+const updates = [...source.updates].sort((a, b) => {
+  const dateOrder = b.date.localeCompare(a.date)
+  return dateOrder !== 0 ? dateOrder : a.id.localeCompare(b.id)
+})
+
+const jsonFeed = readJson(path.join(outDir, 'feeds', 'updates.json'))
+const rssFeed = readText(path.join(outDir, 'feeds', 'updates.xml'))
+const updatesHtml = readText(path.join(outDir, 'updates', 'index.html'))
+
+assert(jsonFeed.version === 'https://jsonfeed.org/version/1.1', 'JSON Feed version is incorrect')
+assert(jsonFeed.home_page_url === `${origin}/updates/`, 'JSON Feed home URL is incorrect')
+assert(jsonFeed.feed_url === `${origin}/feeds/updates.json`, 'JSON Feed self URL is incorrect')
+assert(jsonFeed.items.length === updates.length, 'JSON Feed item count differs from source')
+
+for (let index = 0; index < updates.length; index += 1) {
+  const update = updates[index]
+  const item = jsonFeed.items[index]
+  assert(item.id === `urn:hei:registry-update:${update.id}`, `JSON Feed ID mismatch: ${update.id}`)
+  assert(item.url === `${origin}/updates/#${update.id}`, `JSON Feed URL mismatch: ${update.id}`)
+  assert(item.date_published === `${update.date}T00:00:00.000Z`, `JSON Feed date mismatch: ${update.id}`)
+  assert(item.title === update.title, `JSON Feed title mismatch: ${update.id}`)
+  assert(item.summary === update.summary, `JSON Feed summary mismatch: ${update.id}`)
+  assert(item._hei?.reviewed_public_only === true, `JSON Feed review marker missing: ${update.id}`)
+}
+
+assert(rssFeed.startsWith('<?xml version="1.0" encoding="UTF-8"?>'), 'RSS declaration is missing')
+assert(rssFeed.includes('<rss version="2.0">'), 'RSS root is missing')
+const rssGuids = [...rssFeed.matchAll(/<guid isPermaLink="false">([^<]+)<\/guid>/g)].map((match) => match[1])
+const expectedGuids = updates.map((update) => `urn:hei:registry-update:${update.id}`)
+assert(JSON.stringify(rssGuids) === JSON.stringify(expectedGuids), 'RSS GUID order differs from source')
+assert((rssFeed.match(/<item>/g) || []).length === updates.length, 'RSS item count differs from source')
+assert(updatesHtml.includes('/feeds/updates.json'), 'updates page is missing JSON Feed link')
+assert(updatesHtml.includes('/feeds/updates.xml'), 'updates page is missing RSS link')
+
+console.log(`Validated reviewed update feed export: ${updates.length} items.`)

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -8,7 +8,13 @@ import styles from './updates.module.css'
 export const metadata: Metadata = {
   title: 'Registry Updates',
   description: 'Reviewed additions, corrections, and milestone updates from the Historical Exchange Index registry.',
-  alternates: { canonical: '/updates' },
+  alternates: {
+    canonical: '/updates',
+    types: {
+      'application/feed+json': '/feeds/updates.json',
+      'application/rss+xml': '/feeds/updates.xml',
+    },
+  },
 }
 
 function delta(after: number, before: number): string {
@@ -62,6 +68,8 @@ export default function RegistryUpdatesPage() {
             </p>
           </div>
           <div className={styles.headerActions}>
+            <a className="btn" href="/feeds/updates.xml">RSS</a>
+            <a className="btn" href="/feeds/updates.json">JSON Feed</a>
             <Link className="btn" href="/methodology">Methodology</Link>
             <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">Submit correction</a>
           </div>
@@ -159,8 +167,7 @@ export default function RegistryUpdatesPage() {
       </section>
 
       <section className="callout">
-        Registry Updates only covers reviewed public changes. Monitoring candidates, unresolved watchlist items, and raw risk
-        signals remain outside this public changelog until they are separately reviewed.
+        Registry Updates and its RSS/JSON feeds only cover reviewed public changes. Monitoring candidates, unresolved watchlist items, and raw risk signals remain outside these public outputs until separately reviewed.
       </section>
     </main>
   )


### PR DESCRIPTION
## Roadmap item

D-5 — RSS and JSON feeds for reviewed public updates.

## Specification reference

- `docs/HEI_PRODUCT_SURFACES_SPEC.md` §2.4 Change layer
- §4 Phase D — Change layer completion
- §4.1 Publication safety
- `docs/HEI_REVIEWED_UPDATE_FEEDS_SPEC.md`

## Summary

Adds two stable public feeds generated only from reviewed Registry Update data:

```text
/feeds/updates.json
/feeds/updates.xml
```

The JSON endpoint uses JSON Feed 1.1. The XML endpoint uses RSS 2.0.

The sole feed source is:

```text
data/registry-updates.json
```

Raw monitoring output, unresolved watchlists, candidate staging, internal repair queues, and unmerged candidates are not feed sources.

## Stable feed contract

Ordering:

```text
date descending
then id ascending
```

Stable item identity:

```text
urn:hei:registry-update:<update_id>
```

Stable human-readable item URL:

```text
https://hei.badjoke-lab.com/updates/#<update_id>
```

Date mapping preserves the source's day precision and maps it to UTC midnight for feed formats without claiming a more precise source timestamp.

## JSON Feed

Each item includes:

- stable id
- anchored human-readable URL
- title
- summary
- content text
- published date
- update-type tag
- `_hei` reviewed structured context
- `_hei.reviewed_public_only = true`

## RSS

Each RSS item includes:

- title
- link
- non-permalink stable GUID
- pubDate
- category
- description

The channel `lastBuildDate` is derived from the newest reviewed update date instead of wall-clock rebuild time.

## Discovery integration

The feed endpoints are added to:

- `/updates/` alternate metadata
- visible RSS and JSON Feed links on `/updates/`
- `/version.json` public file map
- `/data/manifest.json` public file map
- `/llms.txt`
- `/ai.txt`

Feed endpoints are public outputs, not HTML page routes, and are not added to sitemap page URLs.

## Validation

Machine validation checks:

- source and feed item counts
- JSON Feed version and URLs
- deterministic source ordering
- stable JSON IDs
- stable RSS GUIDs
- date mapping
- source count payloads
- reviewed-only marker
- manifest/discovery references

Static export validation checks:

- both feed files are copied to `out/`
- JSON and RSS item counts equal reviewed source count
- stable ID/GUID ordering matches source ordering
- `/updates/` export links to both feeds

Production checker now fetches both endpoints, validates expected content types, validates JSON Feed identity markers, and checks JSON/RSS item count consistency.

## Roadmap update

After merge:

```text
Phase D — complete
Current phase — Phase E Discovery foundation hardening
Current item — E-1 Internal-link audit and repair
```

## Canonical count impact

None.

```text
Entities:  550 -> 550
Events:    1004 -> 1004
Evidence: 2621 -> 2621
```

## Deployment impact

Public feed files, discovery metadata, and production verification behavior change.

No Cloudflare configuration change is required.

`package.json` changes only to run exported feed validation as part of the existing `public:validate` command. No dependencies change.

## Preview requirement

No Cloudflare-specific preview is required. GitHub CI must pass. Production verification is required after merge because this PR adds public feed endpoints.

## GitHub validation plan

Required checks include:

- lint
- record validation
- monitoring smoke tests
- Next build
- machine-readable validation
- public-output consistency validation
- reviewed feed export validation
- count semantics regression
- existing permanent quality and queue gates

## Production verification plan

After merge and deployment commit propagation:

1. verify deployed `/version.json` commit matches the merge commit;
2. verify `/feeds/updates.json` returns JSON Feed 1.1;
3. verify `/feeds/updates.xml` returns XML/RSS output;
4. verify JSON/RSS item counts and stable IDs agree;
5. verify `/updates/` exposes both feed links and alternate metadata;
6. verify `version.json`, manifest, `llms.txt`, and `ai.txt` expose both feed endpoints;
7. run the updated production checker;
8. do not diagnose deployment delay as a code defect before commit propagation is confirmed.
