### PR TITLE
Add deterministic Event Explorer

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -2,11 +2,12 @@ import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import EntityExplorerClient from '../../components/explorer/entity-explorer-client'
 import { loadEntities } from '../../lib/data/load-entities'
+import { loadEvents } from '../../lib/data/load-events'
 import { SITE_NAME, SITE_URL } from '../../lib/site-constants'
 
 export function generateMetadata(): Metadata {
   const entities = loadEntities()
-  const description = `Filter and research ${entities.length} reviewed crypto exchange entities by type, status, lifecycle dates, URL state, confidence, origin, and archive availability.`
+  const description = `Filter and research ${entities.length} reviewed crypto exchange entities and their reviewed lifecycle events through deterministic, shareable query state.`
 
   return {
     title: 'Explorer',
@@ -31,6 +32,7 @@ export function generateMetadata(): Metadata {
 
 export default function ExplorePage() {
   const entities = loadEntities()
+  const events = loadEvents()
   const reviewedOrigins = [...new Set(
     entities
       .map((entity) => entity.country_or_origin)
@@ -43,17 +45,14 @@ export default function ExplorePage() {
     '@id': `${SITE_URL}/explore/`,
     url: `${SITE_URL}/explore/`,
     name: 'HEI Explorer',
-    description: `Research interface for ${entities.length} reviewed Historical Exchange Index entity records.`,
-    numberOfItems: entities.length,
+    description: `Research interface for reviewed Historical Exchange Index entity and event records.`,
+    numberOfItems: entities.length + events.length,
     isPartOf: { '@type': 'WebSite', name: SITE_NAME, url: SITE_URL },
   }
 
   return (
     <main className="longform">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
-      />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }} />
 
       <section className="panel longform-panel">
         <div className="detail-header">
@@ -61,21 +60,14 @@ export default function ExplorePage() {
             <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>Research layer</p>
             <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>Explorer</h2>
             <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '72ch' }}>
-              Build deterministic, shareable queries over reviewed HEI records. Entity Explorer is active now;
-              Event Explorer follows on the same fixed query contract in E5-3.
+              Build deterministic, shareable queries over reviewed HEI entity and event records.
             </p>
           </div>
         </div>
       </section>
 
-      <Suspense
-        fallback={
-          <section className="panel table-panel">
-            <div className="results-meta"><div>Loading Explorer query state…</div></div>
-          </section>
-        }
-      >
-        <EntityExplorerClient entities={entities} reviewedOrigins={reviewedOrigins} />
+      <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>Loading Explorer query state…</div></div></section>}>
+        <EntityExplorerClient entities={entities} events={events} reviewedOrigins={reviewedOrigins} />
       </Suspense>
     </main>
   )

--- a/src/components/explorer/entity-explorer-client.tsx
+++ b/src/components/explorer/entity-explorer-client.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useMemo, useState, type ReactNode } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import type { EntityRecord } from '../../lib/types/entity'
+import type { EventRecord } from '../../lib/types/event'
 import {
   countEntityExplorerFilters,
   ENTITY_FILTER_VALUES,
@@ -18,208 +19,80 @@ import { formatYears } from '../../lib/utils/format-years'
 import { STATUS_LABELS } from '../../lib/utils/status-meta'
 import { DEATH_REASON_LABELS } from '../../lib/utils/death-reason-meta'
 import { URL_STATUS_LABELS } from '../../lib/utils/url-meta'
+import EventExplorerPanel from './event-explorer-panel'
 import styles from './entity-explorer-client.module.css'
 
 const INITIAL_VISIBLE = 40
 const LOAD_MORE_STEP = 40
 
-type Props = { entities: EntityRecord[]; reviewedOrigins: string[] }
+type Props = { entities: EntityRecord[]; events: EventRecord[]; reviewedOrigins: string[] }
 type MultiKey = 'type' | 'status' | 'death_reason' | 'official_url_status' | 'confidence' | 'country_or_origin'
 
-function titleCase(value: string) {
-  return value.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+const titleCase = (value: string) => value.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+
+function Group({ title, count, children }: { title: string; count: number | string; children: ReactNode }) {
+  return <details className={styles.filterGroup}><summary>{title} <span>{count}</span></summary>{children}</details>
 }
 
-function FilterGroup({ title, count, children }: { title: string; count: number | string; children: ReactNode }) {
-  return (
-    <details className={styles.filterGroup}>
-      <summary>{title} <span>{count}</span></summary>
-      {children}
-    </details>
-  )
+function Checks({ values, selected, labelFor, onToggle }: { values: string[]; selected: string[]; labelFor: (value: string) => string; onToggle: (value: string) => void }) {
+  return <div className={styles.optionList}>{values.map((value) => <label className={styles.option} key={value}><input type="checkbox" checked={selected.includes(value)} onChange={() => onToggle(value)} /><span>{labelFor(value)}</span></label>)}</div>
 }
 
-function CheckboxList({ values, selected, labelFor, onToggle }: {
-  values: string[]
-  selected: string[]
-  labelFor: (value: string) => string
-  onToggle: (value: string) => void
-}) {
-  return (
-    <div className={styles.optionList}>
-      {values.map((value) => (
-        <label className={styles.option} key={value}>
-          <input type="checkbox" checked={selected.includes(value)} onChange={() => onToggle(value)} />
-          <span>{labelFor(value)}</span>
-        </label>
-      ))}
-    </div>
-  )
+function Dates({ from, to, onFrom, onTo }: { from: string; to: string; onFrom: (value: string) => void; onTo: (value: string) => void }) {
+  return <div className={styles.dateGrid}><label className={styles.dateLabel}>From<input type="date" className={styles.dateInput} value={from} onChange={(event) => onFrom(event.target.value)} /></label><label className={styles.dateLabel}>To<input type="date" className={styles.dateInput} value={to} onChange={(event) => onTo(event.target.value)} /></label></div>
 }
 
-function DateRange({ from, to, onFrom, onTo }: {
-  from: string
-  to: string
-  onFrom: (value: string) => void
-  onTo: (value: string) => void
-}) {
-  return (
-    <div className={styles.dateGrid}>
-      <label className={styles.dateLabel}>From
-        <input type="date" className={styles.dateInput} value={from} onChange={(event) => onFrom(event.target.value)} />
-      </label>
-      <label className={styles.dateLabel}>To
-        <input type="date" className={styles.dateInput} value={to} onChange={(event) => onTo(event.target.value)} />
-      </label>
-    </div>
-  )
-}
-
-function EntityResults({ entities, state }: { entities: EntityRecord[]; state: EntityExplorerState }) {
+function Results({ entities, state }: { entities: EntityRecord[]; state: EntityExplorerState }) {
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE)
   const visible = entities.slice(0, visibleCount)
   const remaining = Math.max(entities.length - visible.length, 0)
-
-  return (
-    <>
-      <div className="results-meta">
-        <div>{entities.length} matching entities</div>
-        <div>Showing {visible.length} of {entities.length}</div>
-      </div>
-
-      <div className="desktop-table">
-        <table>
-          <thead><tr><th>Name</th><th>Type</th><th>Status</th><th>Death reason</th><th>Years</th><th>Origin</th><th>URL status</th><th>Archive</th></tr></thead>
-          <tbody>
-            {visible.length === 0 ? (
-              <tr><td colSpan={8}><div className="name-cell"><span className="name-main">No matching entities</span><span className="name-sub">The current query state resolves to an empty reviewed record set.</span></div></td></tr>
-            ) : visible.map((entity) => (
-              <tr key={entity.id}>
-                <td><div className="name-cell"><Link className="name-main subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link><span className="name-sub">{entity.aliases.length > 0 ? entity.aliases.join(', ') : entity.slug}</span></div></td>
-                <td><span className="chip type">{entity.type.toUpperCase()}</span></td>
-                <td><span className={`chip ${entity.status}`}>{STATUS_LABELS[entity.status]}</span></td>
-                <td>{entity.death_reason ? <span className="chip reason">{DEATH_REASON_LABELS[entity.death_reason]}</span> : <span className="muted">—</span>}</td>
-                <td>{formatYears(entity.launch_date, entity.death_date)}</td>
-                <td>{entity.country_or_origin ?? '—'}</td>
-                <td>{URL_STATUS_LABELS[entity.official_url_status]}</td>
-                <td>{entity.archived_url ? <a className="archive-link" href={entity.archived_url} target="_blank" rel="noreferrer">archive</a> : <span className="muted">—</span>}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="compact-list">
-        {visible.length === 0 ? (
-          <div className="record-empty"><div className="name-cell"><span className="name-main">No matching entities</span><span className="name-sub">Clear filters or use a broader reviewed record query.</span></div></div>
-        ) : (
-          <div className="record-list">
-            {visible.map((entity) => (
-              <div className="record-item" key={entity.id}>
-                <div className="record-top">
-                  <div className="record-main"><Link className="record-title subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link></div>
-                  <div className="record-chips"><span className="chip type">{entity.type.toUpperCase()}</span><span className={`chip ${entity.status}`}>{STATUS_LABELS[entity.status]}</span></div>
-                </div>
-                <div className="record-meta">
-                  {entity.death_reason ? <span className="chip reason">{DEATH_REASON_LABELS[entity.death_reason]}</span> : null}
-                  <span>{formatYears(entity.launch_date, entity.death_date)}</span>
-                  <span>{entity.country_or_origin ?? 'Unknown origin'}</span>
-                  <span>{URL_STATUS_LABELS[entity.official_url_status]}</span>
-                  {entity.archived_url ? <a className="archive-link" href={entity.archived_url} target="_blank" rel="noreferrer">Archive</a> : <span className="muted">No archive</span>}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {remaining > 0 ? (
-        <div className="registry-load-more">
-          <button type="button" className="btn" onClick={() => setVisibleCount((count) => count + LOAD_MORE_STEP)}>Load {Math.min(LOAD_MORE_STEP, remaining)} more</button>
-          <div className="registry-load-more-note">{remaining} remaining in current query</div>
-        </div>
-      ) : null}
-      <div className={styles.resultHint}>Sort: {titleCase(state.sort)} · Query state is shareable through the current URL.</div>
-    </>
-  )
+  return <>
+    <div className="results-meta"><div>{entities.length} matching entities</div><div>Showing {visible.length} of {entities.length}</div></div>
+    <div className="desktop-table"><table><thead><tr><th>Name</th><th>Type</th><th>Status</th><th>Death reason</th><th>Years</th><th>Origin</th><th>URL status</th><th>Archive</th></tr></thead><tbody>
+      {visible.length === 0 ? <tr><td colSpan={8}><div className="name-cell"><span className="name-main">No matching entities</span><span className="name-sub">The current query state resolves to an empty reviewed record set.</span></div></td></tr> : visible.map((entity) => <tr key={entity.id}>
+        <td><div className="name-cell"><Link className="name-main subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link><span className="name-sub">{entity.aliases.length ? entity.aliases.join(', ') : entity.slug}</span></div></td>
+        <td><span className="chip type">{entity.type.toUpperCase()}</span></td><td><span className={`chip ${entity.status}`}>{STATUS_LABELS[entity.status]}</span></td><td>{entity.death_reason ? <span className="chip reason">{DEATH_REASON_LABELS[entity.death_reason]}</span> : <span className="muted">—</span>}</td><td>{formatYears(entity.launch_date, entity.death_date)}</td><td>{entity.country_or_origin ?? '—'}</td><td>{URL_STATUS_LABELS[entity.official_url_status]}</td><td>{entity.archived_url ? <a className="archive-link" href={entity.archived_url} target="_blank" rel="noreferrer">archive</a> : <span className="muted">—</span>}</td>
+      </tr>)}
+    </tbody></table></div>
+    <div className="compact-list">{visible.length === 0 ? <div className="record-empty">No matching entities.</div> : <div className="record-list">{visible.map((entity) => <div className="record-item" key={entity.id}><div className="record-top"><div className="record-main"><Link className="record-title subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link></div><div className="record-chips"><span className="chip type">{entity.type.toUpperCase()}</span><span className={`chip ${entity.status}`}>{STATUS_LABELS[entity.status]}</span></div></div><div className="record-meta"><span>{formatYears(entity.launch_date, entity.death_date)}</span><span>{entity.country_or_origin ?? 'Unknown origin'}</span><span>{URL_STATUS_LABELS[entity.official_url_status]}</span>{entity.archived_url ? <a className="archive-link" href={entity.archived_url} target="_blank" rel="noreferrer">Archive</a> : null}</div></div>)}</div>}</div>
+    {remaining > 0 ? <div className="registry-load-more"><button type="button" className="btn" onClick={() => setVisibleCount((count) => count + LOAD_MORE_STEP)}>Load {Math.min(LOAD_MORE_STEP, remaining)} more</button><div className="registry-load-more-note">{remaining} remaining in current query</div></div> : null}
+    <div className={styles.resultHint}>Sort: {titleCase(state.sort)} · Query state is shareable through the current URL.</div>
+  </>
 }
 
-export default function EntityExplorerClient({ entities, reviewedOrigins }: Props) {
+export default function EntityExplorerClient({ entities, events, reviewedOrigins }: Props) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const view = getExplorerView(searchParams)
   const state = useMemo(() => parseEntityExplorerState(searchParams, reviewedOrigins), [searchParams, reviewedOrigins])
-
-  const updateState = (nextState: EntityExplorerState) => {
-    router.replace(`${pathname}?${serializeEntityExplorerState(nextState, reviewedOrigins)}`, { scroll: false })
-  }
-  const patchState = (patch: Partial<EntityExplorerState>) => updateState({ ...state, ...patch, view: 'entities' })
-  const toggleMulti = (key: MultiKey, value: string) => {
+  const patch = (next: Partial<EntityExplorerState>) => router.replace(`${pathname}?${serializeEntityExplorerState({ ...state, ...next, view: 'entities' }, reviewedOrigins)}`, { scroll: false })
+  const toggle = (key: MultiKey, value: string) => {
     const current = state[key] as string[]
-    const next = current.includes(value) ? current.filter((item) => item !== value) : [...current, value]
-    patchState({ [key]: next } as Partial<EntityExplorerState>)
+    patch({ [key]: current.includes(value) ? current.filter((item) => item !== value) : [...current, value] } as Partial<EntityExplorerState>)
   }
-
-  const filteredAndSorted = useMemo(
-    () => sortEntityExplorerRecords(filterEntityExplorerRecords(entities, state), state.sort),
-    [entities, state],
-  )
+  const result = useMemo(() => sortEntityExplorerRecords(filterEntityExplorerRecords(entities, state), state.sort), [entities, state])
   const filterCount = countEntityExplorerFilters(state)
   const resultKey = serializeEntityExplorerState(state, reviewedOrigins)
 
-  return (
-    <section className={`panel table-panel ${styles.shell}`}>
-      <nav className={styles.viewTabs} aria-label="Explorer views">
-        <Link className={`${styles.viewTab} ${view === 'entities' ? styles.viewTabActive : ''}`} href="/explore/?view=entities">Entity Explorer</Link>
-        <Link className={`${styles.viewTab} ${view === 'events' ? styles.viewTabActive : ''}`} href="/explore/?view=events">Event Explorer</Link>
-      </nav>
-
-      {view === 'events' ? (
-        <div className={styles.placeholder}>
-          <h3>Event Explorer follows in E5-3</h3>
-          <p>The shared query contract already recognizes the Event view. Event filtering and reviewed parent-exchange context are implemented in the next phase; this placeholder does not expose incomplete or unreviewed event search behavior.</p>
-          <div><Link className="btn btn-primary" href="/explore/?view=entities">Open Entity Explorer</Link></div>
+  return <section className={`panel table-panel ${styles.shell}`}>
+    <nav className={styles.viewTabs} aria-label="Explorer views"><Link className={`${styles.viewTab} ${view === 'entities' ? styles.viewTabActive : ''}`} href="/explore/?view=entities">Entity Explorer</Link><Link className={`${styles.viewTab} ${view === 'events' ? styles.viewTabActive : ''}`} href="/explore/?view=events">Event Explorer</Link></nav>
+    {view === 'events' ? <EventExplorerPanel events={events} entities={entities} /> : <>
+      <div className={styles.controlStack}>
+        <div className={styles.primaryControls}><div className="search"><input className="field" aria-label="Search reviewed entities" placeholder="Search name, alias, slug, summary, or origin" value={state.q} onChange={(event) => patch({ q: event.target.value })} /></div><select className="field" aria-label="Archive availability" value={state.archive_available} onChange={(event) => patch({ archive_available: event.target.value as EntityExplorerState['archive_available'] })}><option value="">Any archive state</option><option value="true">Archive available</option><option value="false">No archive URL</option></select><select className="field" aria-label="Sort entities" value={state.sort} onChange={(event) => patch({ sort: event.target.value as EntityExplorerState['sort'] })}>{ENTITY_FILTER_VALUES.sort.map((value) => <option value={value} key={value}>{titleCase(value)}</option>)}</select></div>
+        <div className={styles.filterGrid}>
+          <Group title="Type" count={state.type.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.type} selected={state.type} labelFor={(value) => value === 'hybrid' ? 'Hybrid' : value.toUpperCase()} onToggle={(value) => toggle('type', value)} /></Group>
+          <Group title="Status" count={state.status.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.status} selected={state.status} labelFor={(value) => STATUS_LABELS[value as keyof typeof STATUS_LABELS]} onToggle={(value) => toggle('status', value)} /></Group>
+          <Group title="Death reason" count={state.death_reason.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.death_reason} selected={state.death_reason} labelFor={(value) => DEATH_REASON_LABELS[value as keyof typeof DEATH_REASON_LABELS]} onToggle={(value) => toggle('death_reason', value)} /></Group>
+          <Group title="Launch date" count={state.launch_from || state.launch_to ? 'set' : 'all'}><Dates from={state.launch_from} to={state.launch_to} onFrom={(value) => patch({ launch_from: value })} onTo={(value) => patch({ launch_to: value })} /></Group>
+          <Group title="Death date" count={state.death_from || state.death_to ? 'set' : 'all'}><Dates from={state.death_from} to={state.death_to} onFrom={(value) => patch({ death_from: value })} onTo={(value) => patch({ death_to: value })} /></Group>
+          <Group title="URL status" count={state.official_url_status.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.official_url_status} selected={state.official_url_status} labelFor={(value) => URL_STATUS_LABELS[value as keyof typeof URL_STATUS_LABELS]} onToggle={(value) => toggle('official_url_status', value)} /></Group>
+          <Group title="Confidence" count={state.confidence.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.confidence} selected={state.confidence} labelFor={titleCase} onToggle={(value) => toggle('confidence', value)} /></Group>
+          <Group title="Country / origin" count={state.country_or_origin.length || 'all'}><div className={styles.originHelp}>Select one or more reviewed canonical origin values.</div><div className={styles.optionList}><select className={styles.originSelect} multiple value={state.country_or_origin} onChange={(event) => patch({ country_or_origin: Array.from(event.currentTarget.selectedOptions).map((option) => option.value) })} aria-label="Country or origin values">{reviewedOrigins.map((origin) => <option key={origin} value={origin}>{origin}</option>)}</select></div></Group>
         </div>
-      ) : (
-        <>
-          <div className={styles.controlStack}>
-            <div className={styles.primaryControls}>
-              <div className="search"><input className="field" aria-label="Search reviewed entities" placeholder="Search name, alias, slug, summary, or origin" value={state.q} onChange={(event) => patchState({ q: event.target.value })} /></div>
-              <select className="field" aria-label="Archive availability" value={state.archive_available} onChange={(event) => patchState({ archive_available: event.target.value as EntityExplorerState['archive_available'] })}>
-                <option value="">Any archive state</option><option value="true">Archive available</option><option value="false">No archive URL</option>
-              </select>
-              <select className="field" aria-label="Sort entities" value={state.sort} onChange={(event) => patchState({ sort: event.target.value as EntityExplorerState['sort'] })}>
-                {ENTITY_FILTER_VALUES.sort.map((value) => <option value={value} key={value}>{titleCase(value)}</option>)}
-              </select>
-            </div>
-
-            <div className={styles.filterGrid}>
-              <FilterGroup title="Type" count={state.type.length || 'all'}><CheckboxList values={ENTITY_FILTER_VALUES.type} selected={state.type} labelFor={(value) => value === 'hybrid' ? 'Hybrid' : value.toUpperCase()} onToggle={(value) => toggleMulti('type', value)} /></FilterGroup>
-              <FilterGroup title="Status" count={state.status.length || 'all'}><CheckboxList values={ENTITY_FILTER_VALUES.status} selected={state.status} labelFor={(value) => STATUS_LABELS[value as keyof typeof STATUS_LABELS]} onToggle={(value) => toggleMulti('status', value)} /></FilterGroup>
-              <FilterGroup title="Death reason" count={state.death_reason.length || 'all'}><CheckboxList values={ENTITY_FILTER_VALUES.death_reason} selected={state.death_reason} labelFor={(value) => DEATH_REASON_LABELS[value as keyof typeof DEATH_REASON_LABELS]} onToggle={(value) => toggleMulti('death_reason', value)} /></FilterGroup>
-              <FilterGroup title="Launch date" count={state.launch_from || state.launch_to ? 'set' : 'all'}><DateRange from={state.launch_from} to={state.launch_to} onFrom={(value) => patchState({ launch_from: value })} onTo={(value) => patchState({ launch_to: value })} /></FilterGroup>
-              <FilterGroup title="Death date" count={state.death_from || state.death_to ? 'set' : 'all'}><DateRange from={state.death_from} to={state.death_to} onFrom={(value) => patchState({ death_from: value })} onTo={(value) => patchState({ death_to: value })} /></FilterGroup>
-              <FilterGroup title="URL status" count={state.official_url_status.length || 'all'}><CheckboxList values={ENTITY_FILTER_VALUES.official_url_status} selected={state.official_url_status} labelFor={(value) => URL_STATUS_LABELS[value as keyof typeof URL_STATUS_LABELS]} onToggle={(value) => toggleMulti('official_url_status', value)} /></FilterGroup>
-              <FilterGroup title="Confidence" count={state.confidence.length || 'all'}><CheckboxList values={ENTITY_FILTER_VALUES.confidence} selected={state.confidence} labelFor={titleCase} onToggle={(value) => toggleMulti('confidence', value)} /></FilterGroup>
-              <FilterGroup title="Country / origin" count={state.country_or_origin.length || 'all'}>
-                <div className={styles.originHelp}>Select one or more reviewed canonical origin values.</div>
-                <div className={styles.optionList}>
-                  <select className={styles.originSelect} multiple value={state.country_or_origin} onChange={(event) => patchState({ country_or_origin: Array.from(event.currentTarget.selectedOptions).map((option) => option.value) })} aria-label="Country or origin values">
-                    {reviewedOrigins.map((origin) => <option key={origin} value={origin}>{origin}</option>)}
-                  </select>
-                </div>
-              </FilterGroup>
-            </div>
-
-            <div className={styles.toolbar}>
-              <div className={styles.toolbarMeta}>{filterCount === 0 ? 'No active filters · default Entity view' : `${filterCount} active query constraints`}</div>
-              <div className={styles.toolbarActions}>{filterCount > 0 ? <button type="button" className="btn btn-ghost" onClick={() => router.replace(`${pathname}?view=entities`, { scroll: false })}>Clear all filters</button> : null}</div>
-            </div>
-          </div>
-          <EntityResults key={resultKey} entities={filteredAndSorted} state={state} />
-        </>
-      )}
-    </section>
-  )
+        <div className={styles.toolbar}><div className={styles.toolbarMeta}>{filterCount === 0 ? 'No active filters · default Entity view' : `${filterCount} active query constraints`}</div><div className={styles.toolbarActions}>{filterCount > 0 ? <button type="button" className="btn btn-ghost" onClick={() => router.replace(`${pathname}?view=entities`, { scroll: false })}>Clear all filters</button> : null}</div></div>
+      </div>
+      <Results key={resultKey} entities={result} state={state} />
+    </>}
+  </section>
 }

--- a/src/components/explorer/event-explorer-panel.tsx
+++ b/src/components/explorer/event-explorer-panel.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState, type ReactNode } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import type { EntityRecord } from '../../lib/types/entity'
+import type { EventRecord } from '../../lib/types/event'
+import {
+  countEventExplorerFilters,
+  EVENT_FILTER_VALUES,
+  filterEventExplorerRecords,
+  parseEventExplorerState,
+  serializeEventExplorerState,
+  sortEventExplorerRecords,
+  type EventExplorerState,
+} from '../../lib/explorer/event-query'
+import { STATUS_LABELS } from '../../lib/utils/status-meta'
+import styles from './entity-explorer-client.module.css'
+
+const INITIAL_VISIBLE = 50
+const LOAD_MORE_STEP = 50
+
+type Props = {
+  events: EventRecord[]
+  entities: EntityRecord[]
+}
+
+type MultiKey = 'event_type' | 'impact_level' | 'event_status_effect' | 'confidence' | 'entity_type' | 'entity_status'
+
+function titleCase(value: string) {
+  return value.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+
+function FilterGroup({ title, count, children }: { title: string; count: number | string; children: ReactNode }) {
+  return <details className={styles.filterGroup}><summary>{title} <span>{count}</span></summary>{children}</details>
+}
+
+function CheckboxList({ values, selected, labelFor, onToggle }: {
+  values: string[]
+  selected: string[]
+  labelFor: (value: string) => string
+  onToggle: (value: string) => void
+}) {
+  return (
+    <div className={styles.optionList}>
+      {values.map((value) => (
+        <label className={styles.option} key={value}>
+          <input type="checkbox" checked={selected.includes(value)} onChange={() => onToggle(value)} />
+          <span>{labelFor(value)}</span>
+        </label>
+      ))}
+    </div>
+  )
+}
+
+function DateRange({ from, to, onFrom, onTo }: {
+  from: string
+  to: string
+  onFrom: (value: string) => void
+  onTo: (value: string) => void
+}) {
+  return (
+    <div className={styles.dateGrid}>
+      <label className={styles.dateLabel}>From
+        <input type="date" className={styles.dateInput} value={from} onChange={(event) => onFrom(event.target.value)} />
+      </label>
+      <label className={styles.dateLabel}>To
+        <input type="date" className={styles.dateInput} value={to} onChange={(event) => onTo(event.target.value)} />
+      </label>
+    </div>
+  )
+}
+
+function effectLabel(value: string) {
+  return value === 'none' ? 'None' : STATUS_LABELS[value as keyof typeof STATUS_LABELS] ?? titleCase(value)
+}
+
+function EventResults({ events, entityById, state }: {
+  events: EventRecord[]
+  entityById: Map<string, EntityRecord>
+  state: EventExplorerState
+}) {
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE)
+  const visible = events.slice(0, visibleCount)
+  const remaining = Math.max(events.length - visible.length, 0)
+
+  return (
+    <>
+      <div className="results-meta"><div>{events.length} matching events</div><div>Showing {visible.length} of {events.length}</div></div>
+
+      <div className="desktop-table">
+        <table>
+          <thead><tr><th>Date</th><th>Event</th><th>Exchange</th><th>Type</th><th>Impact</th><th>Status effect</th><th>Confidence</th></tr></thead>
+          <tbody>
+            {visible.length === 0 ? (
+              <tr><td colSpan={7}><div className="name-cell"><span className="name-main">No matching events</span><span className="name-sub">The current query state resolves to an empty reviewed event set.</span></div></td></tr>
+            ) : visible.map((event) => {
+              const parent = entityById.get(event.exchange_id)
+              return (
+                <tr key={event.id}>
+                  <td>{event.event_date ?? '—'}</td>
+                  <td><div className="name-cell"><span className="name-main">{event.title}</span><span className="name-sub">{event.description}</span></div></td>
+                  <td>{parent ? <Link className="subtle-link" href={`/exchange/${parent.slug}/`}>{parent.canonical_name}</Link> : '—'}</td>
+                  <td><span className="chip reason">{titleCase(event.event_type)}</span></td>
+                  <td>{titleCase(event.impact_level)}</td>
+                  <td>{effectLabel(event.event_status_effect)}</td>
+                  <td>{titleCase(event.confidence)}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="compact-list">
+        {visible.length === 0 ? (
+          <div className="record-empty"><div className="name-cell"><span className="name-main">No matching events</span><span className="name-sub">Clear filters or broaden the reviewed event query.</span></div></div>
+        ) : (
+          <div className="record-list">
+            {visible.map((event) => {
+              const parent = entityById.get(event.exchange_id)
+              return (
+                <div className="record-item" key={event.id}>
+                  <div className="record-top">
+                    <div className="record-main"><span className="record-title">{event.title}</span></div>
+                    <div className="record-chips"><span className="chip reason">{titleCase(event.event_type)}</span></div>
+                  </div>
+                  <div className="record-meta">
+                    <span>{event.event_date ?? 'Unknown date'}</span>
+                    {parent ? <Link className="subtle-link" href={`/exchange/${parent.slug}/`}>{parent.canonical_name}</Link> : null}
+                    <span>{titleCase(event.impact_level)} impact</span>
+                    <span>{effectLabel(event.event_status_effect)} effect</span>
+                    <span>{titleCase(event.confidence)} confidence</span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {remaining > 0 ? (
+        <div className="registry-load-more">
+          <button type="button" className="btn" onClick={() => setVisibleCount((count) => count + LOAD_MORE_STEP)}>Load {Math.min(LOAD_MORE_STEP, remaining)} more</button>
+          <div className="registry-load-more-note">{remaining} remaining in current query</div>
+        </div>
+      ) : null}
+      <div className={styles.resultHint}>Sort: {titleCase(state.sort)} · Parent exchange context is reviewed HEI entity data.</div>
+    </>
+  )
+}
+
+export default function EventExplorerPanel({ events, entities }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const state = useMemo(() => parseEventExplorerState(searchParams), [searchParams])
+  const entityById = useMemo(() => new Map(entities.map((entity) => [entity.id, entity])), [entities])
+
+  const updateState = (next: EventExplorerState) => router.replace(`${pathname}?${serializeEventExplorerState(next)}`, { scroll: false })
+  const patchState = (patch: Partial<EventExplorerState>) => updateState({ ...state, ...patch, view: 'events' })
+  const toggleMulti = (key: MultiKey, value: string) => {
+    const current = state[key] as string[]
+    const next = current.includes(value) ? current.filter((item) => item !== value) : [...current, value]
+    patchState({ [key]: next } as Partial<EventExplorerState>)
+  }
+
+  const filteredAndSorted = useMemo(
+    () => sortEventExplorerRecords(filterEventExplorerRecords(events, entityById, state), entityById, state.sort),
+    [events, entityById, state],
+  )
+  const filterCount = countEventExplorerFilters(state)
+  const resultKey = serializeEventExplorerState(state)
+
+  return (
+    <>
+      <div className={styles.controlStack}>
+        <div className={styles.primaryControls}>
+          <div className="search"><input className="field" aria-label="Search reviewed events" placeholder="Search event text or parent exchange context" value={state.q} onChange={(event) => patchState({ q: event.target.value })} /></div>
+          <select className="field" aria-label="Sort events" value={state.sort} onChange={(event) => patchState({ sort: event.target.value as EventExplorerState['sort'] })}>
+            {EVENT_FILTER_VALUES.sort.map((value) => <option value={value} key={value}>{titleCase(value)}</option>)}
+          </select>
+        </div>
+
+        <div className={styles.filterGrid}>
+          <FilterGroup title="Event type" count={state.event_type.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.event_type} selected={state.event_type} labelFor={titleCase} onToggle={(value) => toggleMulti('event_type', value)} /></FilterGroup>
+          <FilterGroup title="Event date" count={state.date_from || state.date_to ? 'set' : 'all'}><DateRange from={state.date_from} to={state.date_to} onFrom={(value) => patchState({ date_from: value })} onTo={(value) => patchState({ date_to: value })} /></FilterGroup>
+          <FilterGroup title="Impact level" count={state.impact_level.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.impact_level} selected={state.impact_level} labelFor={titleCase} onToggle={(value) => toggleMulti('impact_level', value)} /></FilterGroup>
+          <FilterGroup title="Status effect" count={state.event_status_effect.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.event_status_effect} selected={state.event_status_effect} labelFor={effectLabel} onToggle={(value) => toggleMulti('event_status_effect', value)} /></FilterGroup>
+          <FilterGroup title="Confidence" count={state.confidence.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.confidence} selected={state.confidence} labelFor={titleCase} onToggle={(value) => toggleMulti('confidence', value)} /></FilterGroup>
+          <FilterGroup title="Parent type" count={state.entity_type.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.entity_type} selected={state.entity_type} labelFor={(value) => value === 'hybrid' ? 'Hybrid' : value.toUpperCase()} onToggle={(value) => toggleMulti('entity_type', value)} /></FilterGroup>
+          <FilterGroup title="Parent status" count={state.entity_status.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.entity_status} selected={state.entity_status} labelFor={(value) => STATUS_LABELS[value as keyof typeof STATUS_LABELS]} onToggle={(value) => toggleMulti('entity_status', value)} /></FilterGroup>
+        </div>
+
+        <div className={styles.toolbar}>
+          <div className={styles.toolbarMeta}>{filterCount === 0 ? 'No active filters · default Event view' : `${filterCount} active query constraints`}</div>
+          <div className={styles.toolbarActions}>{filterCount > 0 ? <button type="button" className="btn btn-ghost" onClick={() => router.replace(`${pathname}?view=events`, { scroll: false })}>Clear all filters</button> : null}</div>
+        </div>
+      </div>
+
+      <EventResults key={resultKey} events={filteredAndSorted} entityById={entityById} state={state} />
+    </>
+  )
+}

--- a/src/lib/explorer/event-query.ts
+++ b/src/lib/explorer/event-query.ts
@@ -1,0 +1,243 @@
+import contractJson from '../../../config/explorer-query-contract.json'
+import type { Confidence, EntityRecord, ExchangeStatus, ExchangeType } from '../types/entity'
+import type { EventRecord, EventStatusEffect, EventType, ImpactLevel } from '../types/event'
+
+export type EventSort = 'date_newest' | 'date_oldest' | 'entity_name_asc'
+
+export interface EventExplorerState {
+  view: 'events'
+  q: string
+  event_type: EventType[]
+  date_from: string
+  date_to: string
+  impact_level: ImpactLevel[]
+  event_status_effect: EventStatusEffect[]
+  confidence: Confidence[]
+  entity_type: ExchangeType[]
+  entity_status: ExchangeStatus[]
+  sort: EventSort
+}
+
+type ParameterDefinition = {
+  key: string
+  kind: 'text' | 'enum' | 'date'
+  cardinality: 'single' | 'multi'
+  values?: string[]
+}
+
+type QueryContract = {
+  text_search: { max_code_points: number }
+  date_semantics: { from_year_expansion: string; to_year_expansion: string }
+  views: {
+    events: {
+      default_sort: EventSort
+      parameters: ParameterDefinition[]
+    }
+  }
+}
+
+const contract = contractJson as QueryContract
+const eventContract = contract.views.events
+const definitions = new Map(eventContract.parameters.map((parameter) => [parameter.key, parameter]))
+
+export const EVENT_DEFAULT_SORT = eventContract.default_sort
+
+function enumValues<T extends string>(key: string): T[] {
+  return [...(definitions.get(key)?.values ?? [])] as T[]
+}
+
+export const EVENT_FILTER_VALUES = {
+  event_type: enumValues<EventType>('event_type'),
+  impact_level: enumValues<ImpactLevel>('impact_level'),
+  event_status_effect: enumValues<EventStatusEffect>('event_status_effect'),
+  confidence: enumValues<Confidence>('confidence'),
+  entity_type: enumValues<ExchangeType>('entity_type'),
+  entity_status: enumValues<ExchangeStatus>('entity_status'),
+  sort: enumValues<EventSort>('sort'),
+}
+
+function paramsFrom(input: string | URLSearchParams) {
+  if (input instanceof URLSearchParams) return new URLSearchParams(input)
+  const query = input.includes('?') ? input.slice(input.indexOf('?') + 1) : input.replace(/^\?/, '')
+  return new URLSearchParams(query)
+}
+
+function normalizeSearch(value: string) {
+  return [...value.normalize('NFKC').trim().replace(/\s+/g, ' ')]
+    .slice(0, contract.text_search.max_code_points)
+    .join('')
+}
+
+function isIsoDate(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const [year, month, day] = value.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+}
+
+function normalizeDate(value: string, key: string) {
+  const raw = value.trim()
+  if (/^\d{4}$/.test(raw)) {
+    return key.endsWith('_from')
+      ? contract.date_semantics.from_year_expansion.replace('YYYY', raw)
+      : contract.date_semantics.to_year_expansion.replace('YYYY', raw)
+  }
+  return isIsoDate(raw) ? raw : ''
+}
+
+function firstValidDate(params: URLSearchParams, key: string) {
+  for (const value of params.getAll(key)) {
+    const normalized = normalizeDate(value, key)
+    if (normalized) return normalized
+  }
+  return ''
+}
+
+function stableEnum<T extends string>(params: URLSearchParams, key: string): T[] {
+  const allowed = enumValues<T>(key)
+  const requested = new Set(params.getAll(key))
+  return allowed.filter((value) => requested.has(value))
+}
+
+function firstValidSort(params: URLSearchParams): EventSort {
+  const allowed = new Set(EVENT_FILTER_VALUES.sort)
+  for (const value of params.getAll('sort')) {
+    if (allowed.has(value as EventSort)) return value as EventSort
+  }
+  return EVENT_DEFAULT_SORT
+}
+
+export function parseEventExplorerState(input: string | URLSearchParams): EventExplorerState {
+  const params = paramsFrom(input)
+  return {
+    view: 'events',
+    q: normalizeSearch(params.get('q') ?? ''),
+    event_type: stableEnum<EventType>(params, 'event_type'),
+    date_from: firstValidDate(params, 'date_from'),
+    date_to: firstValidDate(params, 'date_to'),
+    impact_level: stableEnum<ImpactLevel>(params, 'impact_level'),
+    event_status_effect: stableEnum<EventStatusEffect>(params, 'event_status_effect'),
+    confidence: stableEnum<Confidence>(params, 'confidence'),
+    entity_type: stableEnum<ExchangeType>(params, 'entity_type'),
+    entity_status: stableEnum<ExchangeStatus>(params, 'entity_status'),
+    sort: firstValidSort(params),
+  }
+}
+
+function appendMany(params: URLSearchParams, key: string, values: string[]) {
+  for (const value of values) params.append(key, value)
+}
+
+export function serializeEventExplorerState(state: EventExplorerState) {
+  const params = new URLSearchParams()
+  params.append('view', 'events')
+  if (state.q) params.append('q', normalizeSearch(state.q))
+  appendMany(params, 'event_type', state.event_type)
+  if (state.date_from) params.append('date_from', normalizeDate(state.date_from, 'date_from'))
+  if (state.date_to) params.append('date_to', normalizeDate(state.date_to, 'date_to'))
+  appendMany(params, 'impact_level', state.impact_level)
+  appendMany(params, 'event_status_effect', state.event_status_effect)
+  appendMany(params, 'confidence', state.confidence)
+  appendMany(params, 'entity_type', state.entity_type)
+  appendMany(params, 'entity_status', state.entity_status)
+  if (state.sort !== EVENT_DEFAULT_SORT) params.append('sort', state.sort)
+  return params.toString()
+}
+
+function includesNormalized(value: string, needle: string) {
+  return value.normalize('NFKC').toLocaleLowerCase('en-US').includes(needle)
+}
+
+function eventMatchesSearch(event: EventRecord, parent: EntityRecord | undefined, query: string) {
+  if (!query) return true
+  const needle = query.toLocaleLowerCase('en-US')
+  const values = [
+    event.title,
+    event.description,
+    parent?.canonical_name ?? '',
+    ...(parent?.aliases ?? []),
+    parent?.slug ?? '',
+    parent?.country_or_origin ?? '',
+  ]
+  return values.some((value) => includesNormalized(value, needle))
+}
+
+function matchesAny<T extends string>(value: T, filters: T[]) {
+  return filters.length === 0 || filters.includes(value)
+}
+
+function rangeMatches(value: string | null, from: string, to: string) {
+  if (!from && !to) return true
+  if (!value) return false
+  if (from && value < from) return false
+  if (to && value > to) return false
+  return true
+}
+
+export function filterEventExplorerRecords(
+  events: EventRecord[],
+  entityById: Map<string, EntityRecord>,
+  state: EventExplorerState,
+) {
+  if (state.date_from && state.date_to && state.date_from > state.date_to) return []
+
+  return events.filter((event) => {
+    const parent = entityById.get(event.exchange_id)
+    if (!parent) return false
+    if (!eventMatchesSearch(event, parent, state.q)) return false
+    if (!matchesAny(event.event_type, state.event_type)) return false
+    if (!rangeMatches(event.event_date, state.date_from, state.date_to)) return false
+    if (!matchesAny(event.impact_level, state.impact_level)) return false
+    if (!matchesAny(event.event_status_effect, state.event_status_effect)) return false
+    if (!matchesAny(event.confidence, state.confidence)) return false
+    if (!matchesAny(parent.type, state.entity_type)) return false
+    if (!matchesAny(parent.status, state.entity_status)) return false
+    return true
+  })
+}
+
+function dateCompare(a: string | null, b: string | null, direction: 'asc' | 'desc') {
+  if (a && !b) return -1
+  if (!a && b) return 1
+  if (!a && !b) return 0
+  if (a === b) return 0
+  return direction === 'asc' ? (a! < b! ? -1 : 1) : (a! > b! ? -1 : 1)
+}
+
+export function sortEventExplorerRecords(
+  events: EventRecord[],
+  entityById: Map<string, EntityRecord>,
+  sort: EventSort,
+) {
+  return [...events].sort((a, b) => {
+    if (sort === 'entity_name_asc') {
+      const aName = entityById.get(a.exchange_id)?.canonical_name ?? ''
+      const bName = entityById.get(b.exchange_id)?.canonical_name ?? ''
+      const name = aName.localeCompare(bName)
+      if (name !== 0) return name
+      const date = dateCompare(a.event_date, b.event_date, 'desc')
+      return date !== 0 ? date : a.id.localeCompare(b.id)
+    }
+
+    const direction = sort === 'date_oldest' ? 'asc' : 'desc'
+    const date = dateCompare(a.event_date, b.event_date, direction)
+    if (date !== 0) return date
+    if (a.sort_order !== b.sort_order) {
+      return direction === 'asc' ? a.sort_order - b.sort_order : b.sort_order - a.sort_order
+    }
+    return a.id.localeCompare(b.id)
+  })
+}
+
+export function countEventExplorerFilters(state: EventExplorerState) {
+  return Number(Boolean(state.q))
+    + state.event_type.length
+    + Number(Boolean(state.date_from))
+    + Number(Boolean(state.date_to))
+    + state.impact_level.length
+    + state.event_status_effect.length
+    + state.confidence.length
+    + state.entity_type.length
+    + state.entity_status.length
+    + Number(state.sort !== EVENT_DEFAULT_SORT)
+}


### PR DESCRIPTION
## Roadmap item
E5-3 — Event Explorer.

## Summary
Replaces the Event placeholder with deterministic filtering over reviewed HEI events and reviewed parent exchange context.

Implemented query keys:
`q`, `event_type`, `date_from`, `date_to`, `impact_level`, `event_status_effect`, `confidence`, `entity_type`, `entity_status`, `sort`.

Behavior follows the fixed Explorer contract: OR within repeated keys, AND across keys, inclusive date ranges, empty results for valid inverted ranges, deterministic sorting, parent-context search, and stable shareable URL state.

UI adds event filters, parent entity filters, date range, search, sort, desktop table, compact mobile list, load more, and parent exchange links.

Canonical counts are unchanged: 550 entities, 1004 events, 2621 evidence.

No Cloudflare configuration change is required.
