### PR TITLE
Add Stats to Explorer deep links

### DIFF
--- a/config/stats-explorer-deep-link-map.json
+++ b/config/stats-explorer-deep-link-map.json
@@ -1,10 +1,10 @@
 {
   "version": 1,
-  "status": "mapped_to_fixed_explorer_v1_query_contract",
+  "status": "deep_links_enabled_on_fixed_explorer_v1_contract",
   "explorer_route": "/explore/",
   "rules": {
     "url_contract_finalized": true,
-    "stats_links_enabled": false,
+    "stats_links_enabled": true,
     "evidence_explorer_in_v1": false,
     "reviewed_public_data_only": true
   },

--- a/scripts/validate-explorer-query-contract.mjs
+++ b/scripts/validate-explorer-query-contract.mjs
@@ -53,32 +53,25 @@ for (const viewName of contract.view_parameter.values) {
   assert(view, `missing view contract: ${viewName}`)
   assert(typeof view.default_sort === 'string' && view.default_sort.length > 0, `default sort missing: ${viewName}`)
   assert(Array.isArray(view.parameters) && view.parameters.length > 0, `parameters missing: ${viewName}`)
-
   const keys = view.parameters.map((parameter) => parameter.key)
   assert(new Set(keys).size === keys.length, `duplicate parameter key in ${viewName}`)
   assert(keys[0] === 'q', `q must be first view parameter in ${viewName}`)
   assert(keys[keys.length - 1] === 'sort', `sort must be last view parameter in ${viewName}`)
-
   for (const parameter of view.parameters) {
-    assert(['text', 'enum', 'date', 'boolean', 'reviewed_value'].includes(parameter.kind), `unsupported kind ${viewName}:${parameter.key}`)
-    assert(['single', 'multi'].includes(parameter.cardinality), `unsupported cardinality ${viewName}:${parameter.key}`)
-    if (parameter.cardinality === 'multi') {
-      assert(['enum', 'reviewed_value'].includes(parameter.kind), `multi cardinality only supported for enum/reviewed_value: ${viewName}:${parameter.key}`)
-    }
+    assert(['text','enum','date','boolean','reviewed_value'].includes(parameter.kind), `unsupported kind ${viewName}:${parameter.key}`)
+    assert(['single','multi'].includes(parameter.cardinality), `unsupported cardinality ${viewName}:${parameter.key}`)
+    if (parameter.cardinality === 'multi') assert(['enum','reviewed_value'].includes(parameter.kind), `multi cardinality only supported for enum/reviewed_value: ${viewName}:${parameter.key}`)
     if (parameter.kind === 'enum' || parameter.kind === 'boolean') {
       assert(Array.isArray(parameter.values) && parameter.values.length > 0, `values missing: ${viewName}:${parameter.key}`)
       assert(new Set(parameter.values).size === parameter.values.length, `duplicate values: ${viewName}:${parameter.key}`)
     }
   }
-
   const sort = view.parameters.find((parameter) => parameter.key === 'sort')
   assert(sort?.kind === 'enum', `sort must be enum: ${viewName}`)
   assert(sort?.cardinality === 'single', `sort must be single: ${viewName}`)
   assert(sort.values.includes(view.default_sort), `default sort not allowed: ${viewName}:${view.default_sort}`)
   assert(view.sort_semantics?.[view.default_sort], `default sort semantics missing: ${viewName}:${view.default_sort}`)
-  for (const value of sort.values) {
-    assert(Array.isArray(view.sort_semantics?.[value]) && view.sort_semantics[value].length > 0, `sort semantics missing: ${viewName}:${value}`)
-  }
+  for (const value of sort.values) assert(Array.isArray(view.sort_semantics?.[value]) && view.sort_semantics[value].length > 0, `sort semantics missing: ${viewName}:${value}`)
 }
 
 assert(contract.crawl_policy?.base_route_indexable === true, 'base Explorer route must be indexable')
@@ -86,22 +79,17 @@ assert(contract.crawl_policy?.canonical_for_all_query_variants === '/explore/', 
 assert(contract.crawl_policy?.query_variants_in_sitemap === false, 'query variants must stay out of sitemap')
 assert(contract.crawl_policy?.generated_filter_landing_pages === false, 'generated filter landing pages must remain disabled')
 
-assert(handoff.status === 'mapped_to_fixed_explorer_v1_query_contract', 'Stats handoff status not advanced to fixed contract')
+assert(handoff.status === 'deep_links_enabled_on_fixed_explorer_v1_contract', 'Stats handoff status is not enabled')
 assert(handoff.explorer_route === contract.route, 'Stats handoff route differs from query contract')
 assert(handoff.rules?.url_contract_finalized === true, 'Stats handoff must mark URL contract finalized')
-assert(handoff.rules?.stats_links_enabled === false, 'Stats links must remain disabled until Explorer views exist')
+assert(handoff.rules?.stats_links_enabled === true, 'Stats Explorer links must be enabled')
 assert(handoff.rules?.evidence_explorer_in_v1 === false, 'Evidence Explorer must remain outside v1')
 assert(handoff.rules?.reviewed_public_data_only === true, 'reviewed public data boundary missing')
 
-const keysByView = Object.fromEntries(
-  Object.entries(contract.views).map(([viewName, view]) => [viewName, new Set(view.parameters.map((parameter) => parameter.key))]),
-)
-
+const keysByView = Object.fromEntries(Object.entries(contract.views).map(([viewName, view]) => [viewName, new Set(view.parameters.map((parameter) => parameter.key))]))
 for (const dimension of handoff.dimensions) {
   if (dimension.destination_view === 'entities' || dimension.destination_view === 'events') {
-    for (const key of dimension.query_keys) {
-      assert(keysByView[dimension.destination_view].has(key), `Stats handoff query key absent from fixed contract: ${dimension.id}:${key}`)
-    }
+    for (const key of dimension.query_keys) assert(keysByView[dimension.destination_view].has(key), `Stats handoff query key absent from fixed contract: ${dimension.id}:${key}`)
   } else {
     assert(dimension.query_keys.length === 0, `non-Explorer destination exposes query keys: ${dimension.id}`)
   }
@@ -111,4 +99,4 @@ const evidenceDimension = handoff.dimensions.find((dimension) => dimension.id ==
 assert(evidenceDimension?.destination_view === 'deferred_evidence', 'Evidence dimensions must remain deferred')
 assert(evidenceDimension?.query_keys.length === 0, 'Evidence dimensions must expose no query keys')
 
-console.log(`Validated Explorer query contract v${contract.version}: ${contract.views.entities.parameters.length} entity parameters, ${contract.views.events.parameters.length} event parameters, ${handoff.dimensions.length} Stats mappings checked.`)
+console.log(`Validated Explorer query contract v${contract.version}: Stats deep links enabled across ${handoff.dimensions.length} mapped dimensions.`)

--- a/scripts/validate-stats-explorer-handoff.mjs
+++ b/scripts/validate-stats-explorer-handoff.mjs
@@ -15,87 +15,20 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
 
-const ENTITY_QUERY_KEYS = new Set([
-  'q',
-  'type',
-  'status',
-  'death_reason',
-  'launch_from',
-  'launch_to',
-  'death_from',
-  'death_to',
-  'official_url_status',
-  'archive_available',
-  'confidence',
-  'country_or_origin',
-  'sort',
-])
-
-const EVENT_QUERY_KEYS = new Set([
-  'q',
-  'event_type',
-  'date_from',
-  'date_to',
-  'impact_level',
-  'event_status_effect',
-  'confidence',
-  'entity_type',
-  'entity_status',
-  'sort',
-])
-
-const ALLOWED_KINDS = new Set([
-  'direct',
-  'range_candidate',
-  'compound_candidate',
-  'derived_non_filter',
-  'aggregate_non_filter',
-  'deferred',
-])
-
-const ALLOWED_VIEWS = new Set(['entities', 'events', 'deferred_evidence', 'none'])
-
+const ENTITY_QUERY_KEYS = new Set(['q','type','status','death_reason','launch_from','launch_to','death_from','death_to','official_url_status','archive_available','confidence','country_or_origin','sort'])
+const EVENT_QUERY_KEYS = new Set(['q','event_type','date_from','date_to','impact_level','event_status_effect','confidence','entity_type','entity_status','sort'])
+const ALLOWED_KINDS = new Set(['direct','range_candidate','compound_candidate','derived_non_filter','aggregate_non_filter','deferred'])
+const ALLOWED_VIEWS = new Set(['entities','events','deferred_evidence','none'])
 const REQUIRED_STATS_PATHS = new Set([
-  'snapshot.by_status',
-  'snapshot.by_type',
-  'snapshot.dead_reason',
-  'snapshot.active_analysis.status_breakdown',
-  'snapshot.active_analysis.url_status_breakdown',
-  'snapshot.active_analysis.launch_year_histogram',
-  'snapshot.active_analysis.age_bands',
-  'snapshot.active_analysis.type_breakdown',
-  'snapshot.active_analysis.confidence_breakdown',
-  'snapshot.active_analysis.evidence_depth',
-  'snapshot.active_analysis.last_verified_recency',
-  'snapshot.dead_analysis.status_breakdown',
-  'snapshot.dead_analysis.death_reason_breakdown',
-  'snapshot.dead_analysis.death_year_histogram',
-  'snapshot.dead_analysis.evidence_depth',
-  'snapshot.dead_analysis.archive_coverage',
-  'snapshot.dead_analysis.average_lifespan_years',
-  'snapshot.quality.confidence_breakdown',
-  'snapshot.quality.unknown_field_rates',
-  'snapshot.quality.last_verified_recency',
-  'snapshot.coverage.archive',
-  'snapshot.coverage.url_status_breakdown',
-  'snapshot.coverage.date_known',
-  'snapshot.country_origin.strict_countries',
-  'snapshot.country_origin.origin_buckets',
-  'snapshot.country_origin.status_rows',
-  'snapshot.country_origin.type_rows',
-  'snapshot.country_origin.completeness',
-  'snapshot.events.event_type_breakdown',
-  'snapshot.events.impact_level_breakdown',
-  'snapshot.events.status_effect_breakdown',
-  'snapshot.events.averages',
-  'snapshot.evidence.source_type_breakdown',
-  'snapshot.evidence.reliability_breakdown',
-  'snapshot.evidence.claim_scope_breakdown',
-  'snapshot.evidence.averages',
-  'snapshot.completeness',
-  'history.snapshots',
-  'history.launch_year_counts',
-  'history.death_year_counts',
+  'snapshot.by_status','snapshot.by_type','snapshot.dead_reason',
+  'snapshot.active_analysis.status_breakdown','snapshot.active_analysis.url_status_breakdown','snapshot.active_analysis.launch_year_histogram','snapshot.active_analysis.age_bands','snapshot.active_analysis.type_breakdown','snapshot.active_analysis.confidence_breakdown','snapshot.active_analysis.evidence_depth','snapshot.active_analysis.last_verified_recency',
+  'snapshot.dead_analysis.status_breakdown','snapshot.dead_analysis.death_reason_breakdown','snapshot.dead_analysis.death_year_histogram','snapshot.dead_analysis.evidence_depth','snapshot.dead_analysis.archive_coverage','snapshot.dead_analysis.average_lifespan_years',
+  'snapshot.quality.confidence_breakdown','snapshot.quality.unknown_field_rates','snapshot.quality.last_verified_recency',
+  'snapshot.coverage.archive','snapshot.coverage.url_status_breakdown','snapshot.coverage.date_known',
+  'snapshot.country_origin.strict_countries','snapshot.country_origin.origin_buckets','snapshot.country_origin.status_rows','snapshot.country_origin.type_rows','snapshot.country_origin.completeness',
+  'snapshot.events.event_type_breakdown','snapshot.events.impact_level_breakdown','snapshot.events.status_effect_breakdown','snapshot.events.averages',
+  'snapshot.evidence.source_type_breakdown','snapshot.evidence.reliability_breakdown','snapshot.evidence.claim_scope_breakdown','snapshot.evidence.averages',
+  'snapshot.completeness','history.snapshots','history.launch_year_counts','history.death_year_counts',
 ])
 
 const map = readJson(mapPath)
@@ -103,10 +36,10 @@ const entities = readJson(entitiesPath)
 const events = readJson(eventsPath)
 
 assert(map.version === 1, 'unsupported mapping version')
-assert(map.status === 'mapped_to_fixed_explorer_v1_query_contract', 'handoff status is incorrect')
+assert(map.status === 'deep_links_enabled_on_fixed_explorer_v1_contract', 'handoff status is incorrect')
 assert(map.explorer_route === '/explore/', 'explorer route is incorrect')
-assert(map.rules?.url_contract_finalized === true, 'Explorer URL contract must be finalized at E5-1')
-assert(map.rules?.stats_links_enabled === false, 'Stats links must remain disabled until Explorer exists')
+assert(map.rules?.url_contract_finalized === true, 'Explorer URL contract must be finalized')
+assert(map.rules?.stats_links_enabled === true, 'Stats links must be enabled at E5-4')
 assert(map.rules?.evidence_explorer_in_v1 === false, 'Evidence Explorer must remain outside v1')
 assert(map.rules?.reviewed_public_data_only === true, 'reviewed public data boundary is missing')
 assert(Array.isArray(map.dimensions) && map.dimensions.length > 0, 'dimensions are missing')
@@ -119,7 +52,6 @@ for (const dimension of map.dimensions) {
   assert(typeof dimension.id === 'string' && dimension.id.length > 0, 'dimension id is missing')
   assert(!ids.has(dimension.id), `duplicate dimension id: ${dimension.id}`)
   ids.add(dimension.id)
-
   assert(ALLOWED_KINDS.has(dimension.mapping_kind), `unsupported mapping kind: ${dimension.id}:${dimension.mapping_kind}`)
   assert(ALLOWED_VIEWS.has(dimension.destination_view), `unsupported destination view: ${dimension.id}:${dimension.destination_view}`)
   assert(Array.isArray(dimension.stats_paths) && dimension.stats_paths.length > 0, `stats paths missing: ${dimension.id}`)
@@ -132,23 +64,18 @@ for (const dimension of map.dimensions) {
       ? EVENT_QUERY_KEYS
       : new Set()
 
-  for (const key of dimension.query_keys) {
-    assert(allowedQueryKeys.has(key), `query key outside product specification: ${dimension.id}:${key}`)
-  }
+  for (const key of dimension.query_keys) assert(allowedQueryKeys.has(key), `query key outside product specification: ${dimension.id}:${key}`)
 
-  if (['direct', 'range_candidate', 'compound_candidate'].includes(dimension.mapping_kind)) {
+  if (['direct','range_candidate','compound_candidate'].includes(dimension.mapping_kind)) {
     assert(dimension.destination_view === 'entities' || dimension.destination_view === 'events', `filter candidate has invalid destination: ${dimension.id}`)
     assert(dimension.query_keys.length > 0, `filter candidate has no query key: ${dimension.id}`)
   }
 
-  if (['derived_non_filter', 'aggregate_non_filter', 'deferred'].includes(dimension.mapping_kind)) {
+  if (['derived_non_filter','aggregate_non_filter','deferred'].includes(dimension.mapping_kind)) {
     assert(dimension.query_keys.length === 0, `non-filter mapping exposes query keys: ${dimension.id}`)
   }
 
-  if (dimension.destination_view === 'deferred_evidence') {
-    assert(dimension.mapping_kind === 'deferred', `evidence destination must be deferred: ${dimension.id}`)
-  }
-
+  if (dimension.destination_view === 'deferred_evidence') assert(dimension.mapping_kind === 'deferred', `evidence destination must be deferred: ${dimension.id}`)
   if (dimension.mapping_kind === 'direct') directSources.add(dimension.value_source)
 
   for (const statsPath of dimension.stats_paths) {
@@ -170,7 +97,6 @@ const entityValueSources = {
   'entity.confidence': new Set(entities.map((entity) => entity.confidence)),
   'entity.country_or_origin': new Set(entities.map((entity) => entity.country_or_origin).filter(Boolean)),
 }
-
 const eventValueSources = {
   'event.event_type': new Set(events.map((event) => event.event_type)),
   'event.impact_level': new Set(events.map((event) => event.impact_level)),
@@ -188,4 +114,4 @@ assert(evidenceDimension, 'evidence dimension handoff is missing')
 assert(evidenceDimension.destination_view === 'deferred_evidence', 'evidence dimensions must remain deferred')
 assert(evidenceDimension.query_keys.length === 0, 'evidence dimensions must not expose v1 query keys')
 
-console.log(`Validated Stats Explorer handoff: ${map.dimensions.length} dimensions, ${seenPaths.size} Stats paths, ${directSources.size} direct reviewed-data sources, fixed URL contract confirmed.`)
+console.log(`Validated enabled Stats Explorer links: ${map.dimensions.length} dimensions, ${seenPaths.size} Stats paths, ${directSources.size} direct reviewed-data sources.`)

--- a/src/app/stats/layout.tsx
+++ b/src/app/stats/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import RelatedSurfaceLinks from '../../components/navigation/related-surface-links'
+import StatsExplorerDeepLinks from '../../components/stats/stats-explorer-deep-links'
 import { buildRouteSocialMetadata } from '../../lib/metadata/build-route-social-metadata'
 
 export const metadata = buildRouteSocialMetadata({
@@ -10,9 +11,10 @@ export const metadata = buildRouteSocialMetadata({
 
 export default function StatsLayout({ children }: { children: ReactNode }) {
   return (
-    <>
+    <div>
       <RelatedSurfaceLinks links={[{ href: '/quality', label: 'Evidence Health & Data Quality' }]} />
+      <StatsExplorerDeepLinks />
       {children}
-    </>
+    </div>
   )
 }

--- a/src/components/stats/stats-explorer-deep-links.tsx
+++ b/src/components/stats/stats-explorer-deep-links.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link'
+import { buildStatsView } from '../../lib/stats/build-stats'
+
+function href(view: 'entities' | 'events', key: string, value: string) {
+  const params = new URLSearchParams()
+  params.set('view', view)
+  params.append(key, value)
+  return `/explore/?${params.toString()}`
+}
+
+function yearHref(keyFrom: string, keyTo: string, year: number) {
+  const params = new URLSearchParams()
+  params.set('view', 'entities')
+  params.set(keyFrom, `${year}-01-01`)
+  params.set(keyTo, `${year}-12-31`)
+  return `/explore/?${params.toString()}`
+}
+
+function compoundArchiveHref(statuses: string[]) {
+  const params = new URLSearchParams()
+  params.set('view', 'entities')
+  for (const status of statuses) params.append('status', status)
+  params.set('archive_available', 'true')
+  return `/explore/?${params.toString()}`
+}
+
+export default function StatsExplorerDeepLinks() {
+  const { snapshot, history } = buildStatsView()
+  const recentLaunchYears = [...history.launch_year_counts].sort((a, b) => b.year - a.year).slice(0, 5)
+  const recentDeathYears = [...history.death_year_counts].sort((a, b) => b.year - a.year).slice(0, 5)
+  const eventTypes = snapshot.events.event_type_breakdown.slice(0, 6)
+
+  return (
+    <section className="panel" style={{ padding: '18px', marginBottom: '18px' }}>
+      <div className="detail-header" style={{ marginBottom: '14px' }}>
+        <div>
+          <h2 style={{ margin: '0 0 6px', fontSize: '20px' }}>Explore these distributions</h2>
+          <p className="muted" style={{ margin: 0, lineHeight: 1.6 }}>
+            Open deterministic Entity or Event Explorer queries for direct, range, and reviewed compound Stats dimensions.
+          </p>
+        </div>
+      </div>
+
+      <div className="home-grid">
+        <div className="panel" style={{ padding: '14px' }}>
+          <h3 style={{ marginTop: 0 }}>Entity status &amp; type</h3>
+          <div className="record-meta">
+            {snapshot.by_status.map((item) => <Link className="btn btn-compact" href={href('entities', 'status', item.key)} key={`status-${item.key}`}>{item.label} · {item.count}</Link>)}
+            {snapshot.by_type.map((item) => <Link className="btn btn-compact" href={href('entities', 'type', item.key)} key={`type-${item.key}`}>{item.label} · {item.count}</Link>)}
+          </div>
+        </div>
+
+        <div className="panel" style={{ padding: '14px' }}>
+          <h3 style={{ marginTop: 0 }}>Death reasons &amp; archives</h3>
+          <div className="record-meta">
+            {snapshot.dead_analysis.death_reason_breakdown.slice(0, 6).map((item) => <Link className="btn btn-compact" href={href('entities', 'death_reason', item.key)} key={item.key}>{item.label} · {item.count}</Link>)}
+            <Link className="btn btn-compact" href={compoundArchiveHref(['active', 'limited', 'inactive'])}>Active-side with archive</Link>
+            <Link className="btn btn-compact" href={compoundArchiveHref(['dead', 'merged', 'acquired', 'rebranded'])}>Dead-side with archive</Link>
+          </div>
+        </div>
+
+        <div className="panel" style={{ padding: '14px' }}>
+          <h3 style={{ marginTop: 0 }}>Entity year ranges</h3>
+          <div className="record-meta">
+            {recentLaunchYears.map((item) => <Link className="btn btn-compact" href={yearHref('launch_from', 'launch_to', item.year)} key={`launch-${item.year}`}>Launch {item.year} · {item.count}</Link>)}
+            {recentDeathYears.map((item) => <Link className="btn btn-compact" href={yearHref('death_from', 'death_to', item.year)} key={`death-${item.year}`}>Death {item.year} · {item.count}</Link>)}
+          </div>
+        </div>
+
+        <div className="panel" style={{ padding: '14px' }}>
+          <h3 style={{ marginTop: 0 }}>Event dimensions</h3>
+          <div className="record-meta">
+            {eventTypes.map((item) => <Link className="btn btn-compact" href={href('events', 'event_type', item.key)} key={`event-${item.key}`}>{item.label} · {item.count}</Link>)}
+            {snapshot.events.impact_level_breakdown.map((item) => <Link className="btn btn-compact" href={href('events', 'impact_level', item.key)} key={`impact-${item.key}`}>{item.label} · {item.count}</Link>)}
+            {snapshot.events.status_effect_breakdown.map((item) => <Link className="btn btn-compact" href={href('events', 'event_status_effect', item.key)} key={`effect-${item.key}`}>{item.label} · {item.count}</Link>)}
+          </div>
+        </div>
+      </div>
+
+      <p className="muted" style={{ margin: '14px 0 0', fontSize: '12px' }}>
+        Derived metrics such as age bands, evidence depth, freshness, averages, and origin buckets remain analytical only and are not converted into Explorer filters.
+      </p>
+    </section>
+  )
+}


### PR DESCRIPTION
## Roadmap item
E5-4 — Stats to Explorer deep links.

## Summary
Adds a Stats research-link surface that opens fixed Entity/Event Explorer queries for direct, year-range, and reviewed compound dimensions.

Linked dimensions include entity status/type/death reason, launch/death years, active/dead archive compounds, event types, impact levels, and status effects.

Derived metrics such as age bands, evidence depth, freshness, averages, and origin buckets remain non-filter links by design.

The Stats handoff map now marks `stats_links_enabled=true`, and both Stats handoff and Explorer contract validators require the enabled state.

Canonical counts are unchanged: 550 entities, 1004 events, 2621 evidence.
