### PR TITLE
Add Change-layer Explorer cross-links

### DIFF
--- a/src/app/incidents/page.tsx
+++ b/src/app/incidents/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import {
   buildIncidentTimeline,
+  INCIDENT_EVENT_TYPE_LABELS,
   incidentEventTypeLabel,
   type IncidentTimelineItem,
 } from '../../lib/data/build-incident-timeline'
@@ -17,15 +18,27 @@ export const metadata: Metadata = {
 
 function groupByYear(items: IncidentTimelineItem[]) {
   const grouped = new Map<string, IncidentTimelineItem[]>()
-
   for (const item of items) {
     const year = item.event.event_date?.slice(0, 4) ?? 'Unknown'
     const current = grouped.get(year) ?? []
     current.push(item)
     grouped.set(year, current)
   }
-
   return [...grouped.entries()]
+}
+
+function eventTypeHref(eventType: string) {
+  const params = new URLSearchParams()
+  params.set('view', 'events')
+  params.set('event_type', eventType)
+  return `/explore/?${params.toString()}`
+}
+
+function allIncidentEventsHref() {
+  const params = new URLSearchParams()
+  params.set('view', 'events')
+  for (const eventType of Object.keys(INCIDENT_EVENT_TYPE_LABELS)) params.append('event_type', eventType)
+  return `/explore/?${params.toString()}`
 }
 
 export default function ExchangeIncidentTimelinePage() {
@@ -34,13 +47,14 @@ export default function ExchangeIncidentTimelinePage() {
   const affectedExchanges = new Set(incidents.map((item) => item.entity.id)).size
   const criticalEvents = incidents.filter((item) => item.event.impact_level === 'critical').length
   const linkedSources = incidents.reduce((total, item) => total + item.evidence.length, 0)
-  const typeCounts = incidents.reduce<Map<string, number>>((counts, item) => {
+  const typeCounts = incidents.reduce<Map<string, { count: number; eventType: string }>>((counts, item) => {
     const label = incidentEventTypeLabel(item.event.event_type)
-    counts.set(label, (counts.get(label) ?? 0) + 1)
+    const current = counts.get(label)
+    counts.set(label, { count: (current?.count ?? 0) + 1, eventType: item.event.event_type })
     return counts
   }, new Map())
   const leadingTypes = [...typeCounts.entries()]
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .sort((a, b) => b[1].count - a[1].count || a[0].localeCompare(b[0]))
     .slice(0, 8)
 
   return (
@@ -55,6 +69,7 @@ export default function ExchangeIncidentTimelinePage() {
             </p>
           </div>
           <div className={styles.headerActions}>
+            <Link className="btn btn-primary" href={allIncidentEventsHref()}>Explore incident events</Link>
             <Link className="btn" href="/updates">Registry Updates</Link>
             <Link className="btn" href="/methodology">Methodology</Link>
             <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">Submit correction</a>
@@ -75,11 +90,11 @@ export default function ExchangeIncidentTimelinePage() {
           <h3>Incident mix</h3>
         </div>
         <div className={styles.breakdownList}>
-          {leadingTypes.map(([label, count]) => (
-            <span className={styles.breakdownItem} key={label}>
+          {leadingTypes.map(([label, value]) => (
+            <Link className={styles.breakdownItem} href={eventTypeHref(value.eventType)} key={label}>
               <span>{label}</span>
-              <strong>{count}</strong>
-            </span>
+              <strong>{value.count}</strong>
+            </Link>
           ))}
         </div>
       </section>
@@ -87,49 +102,20 @@ export default function ExchangeIncidentTimelinePage() {
       <section className={styles.timeline} aria-label="Exchange incident history">
         {groups.map(([year, items]) => (
           <section className={styles.yearGroup} key={year} aria-labelledby={`incident-year-${year}`}>
-            <div className={styles.yearHeader}>
-              <h2 id={`incident-year-${year}`}>{year}</h2>
-              <span>{items.length} events</span>
-            </div>
-
-            <div className={styles.yearItems}>
+            <div className={styles.yearHeader}><h3 id={`incident-year-${year}`}>{year}</h3><span>{items.length} event{items.length === 1 ? '' : 's'}</span></div>
+            <div className={styles.timelineList}>
               {items.map(({ event, entity, evidence }) => (
-                <article className={`panel ${styles.incidentCard}`} key={event.id} id={event.id}>
-                  <div className={styles.incidentMeta}>
-                    <time dateTime={event.event_date ?? undefined}>{event.event_date ? formatDate(event.event_date) : 'Unknown date'}</time>
-                    <span>{incidentEventTypeLabel(event.event_type)}</span>
-                    <span>{event.impact_level}</span>
-                  </div>
-
-                  <div className={styles.exchangeRow}>
-                    <Link href={`/exchange/${entity.slug}`}>{entity.canonical_name}</Link>
-                    <span>{entity.type.toUpperCase()}</span>
-                    <span>{entity.status}</span>
-                  </div>
-
-                  <h3>{event.title}</h3>
-                  <p className={styles.description}>{event.description}</p>
-
-                  <div className={styles.eventFacts}>
-                    <span>Status effect: <strong>{event.event_status_effect}</strong></span>
-                    <span>Confidence: <strong>{event.confidence}</strong></span>
-                    <span>Recorded source count: <strong>{event.source_count}</strong></span>
-                    <span>Direct event-linked evidence: <strong>{evidence.length}</strong></span>
-                  </div>
-
-                  <div className={styles.recordLinkRow}>
-                    <Link href={`/exchange/${entity.slug}`}>Open exchange dossier</Link>
-                    <a href={`#${event.id}`} aria-label={`Link to ${event.title}`}>Permalink</a>
-                  </div>
+                <article className={`panel ${styles.eventCard}`} key={event.id} id={event.id}>
+                  <div className={styles.eventMeta}><time dateTime={event.event_date ?? undefined}>{event.event_date ? formatDate(event.event_date) : 'Unknown date'}</time><Link href={eventTypeHref(event.event_type)}>{incidentEventTypeLabel(event.event_type)}</Link><span>{event.impact_level}</span></div>
+                  <div className={styles.exchangeRow}><Link href={`/exchange/${entity.slug}`}>{entity.canonical_name}</Link><span>{entity.type.toUpperCase()}</span><span>{entity.status}</span></div>
+                  <h3>{event.title}</h3><p>{event.description}</p>
+                  <div className={styles.factRow}><span>Status effect: <strong>{event.event_status_effect}</strong></span><span>Confidence: <strong>{event.confidence}</strong></span><span>Direct event-linked evidence: <strong>{evidence.length}</strong></span></div>
+                  <div className={styles.linkRow}><Link href={`/exchange/${entity.slug}`}>Open exchange dossier</Link><Link href={eventTypeHref(event.event_type)}>Explore this event type</Link><a href={`#${event.id}`}>Permalink</a></div>
                 </article>
               ))}
             </div>
           </section>
         ))}
-      </section>
-
-      <section className="callout">
-        This page is generated from reviewed HEI public event records. It is not a live alert feed, and internal monitoring output is not included.
       </section>
     </main>
   )

--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -12,8 +12,35 @@ export const metadata: Metadata = {
   alternates: { canonical: '/monthly' },
 }
 
+function monthlyExplorerHref(periodStart: string, periodEnd: string) {
+  const params = new URLSearchParams()
+  params.set('view', 'events')
+  params.set('date_from', periodStart)
+  params.set('date_to', periodEnd)
+  return `/explore/?${params.toString()}`
+}
+
+function monthlyEventTypeHref(periodStart: string, periodEnd: string, eventType: string) {
+  const params = new URLSearchParams()
+  params.set('view', 'events')
+  params.set('event_type', eventType)
+  params.set('date_from', periodStart)
+  params.set('date_to', periodEnd)
+  return `/explore/?${params.toString()}`
+}
+
+function monthlyImpactHref(periodStart: string, periodEnd: string, impact: string) {
+  const params = new URLSearchParams()
+  params.set('view', 'events')
+  params.set('date_from', periodStart)
+  params.set('date_to', periodEnd)
+  params.set('impact_level', impact)
+  return `/explore/?${params.toString()}`
+}
+
 export default function MonthlyHistoricalExchangeSnapshotPage() {
   const snapshot = buildMonthlyHistoricalSnapshot()
+  const allMonthEventsHref = monthlyExplorerHref(snapshot.periodStart, snapshot.periodEnd)
 
   return (
     <main className={styles.page}>
@@ -28,6 +55,7 @@ export default function MonthlyHistoricalExchangeSnapshotPage() {
             </p>
           </div>
           <div className={styles.headerActions}>
+            <Link className="btn btn-primary" href={allMonthEventsHref}>Explore this month</Link>
             <Link className="btn" href="/incidents">Incident Timeline</Link>
             <Link className="btn" href="/updates">Registry Updates</Link>
             <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">Submit correction</a>
@@ -49,73 +77,39 @@ export default function MonthlyHistoricalExchangeSnapshotPage() {
 
       <section className={styles.mixGrid}>
         <article className={`panel ${styles.mixPanel}`}>
-          <div>
-            <p className="muted">Recorded event types</p>
-            <h3>Monthly event mix</h3>
-          </div>
+          <div><p className="muted">Recorded event types</p><h3>Monthly event mix</h3></div>
           <div className={styles.pillList}>
             {snapshot.byEventType.length > 0 ? snapshot.byEventType.map((item) => (
-              <span className={styles.pill} key={item.key}><span>{item.label}</span><strong>{item.count}</strong></span>
+              <Link className={styles.pill} href={monthlyEventTypeHref(snapshot.periodStart, snapshot.periodEnd, item.key)} key={item.key}><span>{item.label}</span><strong>{item.count}</strong></Link>
             )) : <p className={styles.emptyText}>No qualifying reviewed events are recorded for this month.</p>}
           </div>
         </article>
 
         <article className={`panel ${styles.mixPanel}`}>
-          <div>
-            <p className="muted">Recorded impact levels</p>
-            <h3>Impact mix</h3>
-          </div>
+          <div><p className="muted">Recorded impact levels</p><h3>Impact mix</h3></div>
           <div className={styles.pillList}>
             {snapshot.byImpact.length > 0 ? snapshot.byImpact.map((item) => (
-              <span className={styles.pill} key={item.key}><span>{item.label}</span><strong>{item.count}</strong></span>
+              <Link className={styles.pill} href={monthlyImpactHref(snapshot.periodStart, snapshot.periodEnd, item.key)} key={item.key}><span>{item.label}</span><strong>{item.count}</strong></Link>
             )) : <p className={styles.emptyText}>No impact distribution is available for this month.</p>}
           </div>
         </article>
       </section>
 
       <section className={`panel ${styles.registryPanel}`}>
-        <div>
-          <p className="muted">Registry state at snapshot generation</p>
-          <h3>Current reviewed registry context</h3>
-        </div>
-        <div className={styles.registryCounts}>
-          <span>Entities <strong>{snapshot.registryState.entities}</strong></span>
-          <span>Events <strong>{snapshot.registryState.events}</strong></span>
-          <span>Evidence <strong>{snapshot.registryState.evidence}</strong></span>
-        </div>
+        <div><p className="muted">Registry state at snapshot generation</p><h3>Current reviewed registry context</h3></div>
+        <div className={styles.registryCounts}><span>Entities <strong>{snapshot.registryState.entities}</strong></span><span>Events <strong>{snapshot.registryState.events}</strong></span><span>Evidence <strong>{snapshot.registryState.evidence}</strong></span></div>
       </section>
 
       <section className={styles.eventList} aria-label={`${snapshot.monthLabel} reviewed exchange events`}>
         {snapshot.items.length > 0 ? snapshot.items.map(({ event, entity, evidenceCount }) => (
           <article className={`panel ${styles.eventCard}`} key={event.id} id={event.id}>
-            <div className={styles.eventMeta}>
-              <time dateTime={event.event_date ?? undefined}>{event.event_date ? formatDate(event.event_date) : 'Unknown date'}</time>
-              <span>{incidentEventTypeLabel(event.event_type)}</span>
-              <span>{event.impact_level}</span>
-            </div>
-            <div className={styles.exchangeRow}>
-              <Link href={`/exchange/${entity.slug}`}>{entity.canonical_name}</Link>
-              <span>{entity.type.toUpperCase()}</span>
-              <span>{entity.status}</span>
-            </div>
-            <h3>{event.title}</h3>
-            <p>{event.description}</p>
-            <div className={styles.factRow}>
-              <span>Status effect: <strong>{event.event_status_effect}</strong></span>
-              <span>Confidence: <strong>{event.confidence}</strong></span>
-              <span>Direct event-linked evidence: <strong>{evidenceCount}</strong></span>
-            </div>
-            <div className={styles.linkRow}>
-              <Link href={`/exchange/${entity.slug}`}>Open exchange dossier</Link>
-              <a href={`#${event.id}`}>Permalink</a>
-            </div>
+            <div className={styles.eventMeta}><time dateTime={event.event_date ?? undefined}>{event.event_date ? formatDate(event.event_date) : 'Unknown date'}</time><Link href={monthlyEventTypeHref(snapshot.periodStart, snapshot.periodEnd, event.event_type)}>{incidentEventTypeLabel(event.event_type)}</Link><span>{event.impact_level}</span></div>
+            <div className={styles.exchangeRow}><Link href={`/exchange/${entity.slug}`}>{entity.canonical_name}</Link><span>{entity.type.toUpperCase()}</span><span>{entity.status}</span></div>
+            <h3>{event.title}</h3><p>{event.description}</p>
+            <div className={styles.factRow}><span>Status effect: <strong>{event.event_status_effect}</strong></span><span>Confidence: <strong>{event.confidence}</strong></span><span>Direct event-linked evidence: <strong>{evidenceCount}</strong></span></div>
+            <div className={styles.linkRow}><Link href={`/exchange/${entity.slug}`}>Open exchange dossier</Link><Link href={monthlyEventTypeHref(snapshot.periodStart, snapshot.periodEnd, event.event_type)}>Explore this type in month</Link><a href={`#${event.id}`}>Permalink</a></div>
           </article>
-        )) : (
-          <section className={`panel ${styles.emptyPanel}`}>
-            <h3>No qualifying reviewed events recorded for {snapshot.monthLabel}</h3>
-            <p>The public snapshot remains explicit about an empty month rather than filling the page with monitoring signals or unreviewed candidates.</p>
-          </section>
-        )}
+        )) : <section className={`panel ${styles.emptyPanel}`}><h3>No qualifying reviewed events recorded for {snapshot.monthLabel}</h3><p>The public snapshot remains explicit about an empty month rather than filling the page with monitoring signals or unreviewed candidates.</p></section>}
       </section>
 
       <section className="callout">

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -43,11 +43,7 @@ function CountChange({ counts }: { counts: RegistryUpdateCounts }) {
 }
 
 function UpdateTypeLabel({ type }: { type: 'registry_growth' | 'quality_audit' }) {
-  return (
-    <span className={styles.typeLabel}>
-      {type === 'registry_growth' ? 'Registry growth' : 'Quality audit'}
-    </span>
-  )
+  return <span className={styles.typeLabel}>{type === 'registry_growth' ? 'Registry growth' : 'Quality audit'}</span>
 }
 
 export default function RegistryUpdatesPage() {
@@ -63,11 +59,11 @@ export default function RegistryUpdatesPage() {
             <p className="muted">Reviewed changelog</p>
             <h2 className={styles.pageTitle}>Registry Updates</h2>
             <p className={styles.lead}>
-              Canonical additions and reviewed corrections that have already passed HEI review and repository validation.
-              Internal monitoring signals and unmerged candidates are not published here.
+              Canonical additions and reviewed corrections that have already passed HEI review and repository validation. Internal monitoring signals and unmerged candidates are not published here.
             </p>
           </div>
           <div className={styles.headerActions}>
+            <Link className="btn btn-primary" href="/explore/?view=events">Explore reviewed events</Link>
             <a className="btn" href="/feeds/updates.xml">RSS</a>
             <a className="btn" href="/feeds/updates.json">JSON Feed</a>
             <Link className="btn" href="/methodology">Methodology</Link>
@@ -76,18 +72,9 @@ export default function RegistryUpdatesPage() {
         </div>
 
         <div className={styles.summaryStrip}>
-          <div>
-            <span className={styles.summaryLabel}>Published updates</span>
-            <strong>{updates.length}</strong>
-          </div>
-          <div>
-            <span className={styles.summaryLabel}>Entities added in listed updates</span>
-            <strong>{totalAdded}</strong>
-          </div>
-          <div>
-            <span className={styles.summaryLabel}>Evidence added in listed updates</span>
-            <strong>{totalEvidenceAdded}</strong>
-          </div>
+          <div><span className={styles.summaryLabel}>Published updates</span><strong>{updates.length}</strong></div>
+          <div><span className={styles.summaryLabel}>Entities added in listed updates</span><strong>{totalAdded}</strong></div>
+          <div><span className={styles.summaryLabel}>Evidence added in listed updates</span><strong>{totalEvidenceAdded}</strong></div>
         </div>
       </section>
 
@@ -96,78 +83,23 @@ export default function RegistryUpdatesPage() {
           <article className={`panel ${styles.updateCard}`} key={update.id} id={update.id}>
             <div className={styles.updateHeader}>
               <div>
-                <div className={styles.updateMeta}>
-                  <time dateTime={update.date}>{update.date}</time>
-                  <UpdateTypeLabel type={update.update_type} />
-                </div>
+                <div className={styles.updateMeta}><time dateTime={update.date}>{update.date}</time><UpdateTypeLabel type={update.type} /></div>
                 <h3>{update.title}</h3>
                 <p>{update.summary}</p>
               </div>
-              <a className={styles.anchorLink} href={`#${update.id}`} aria-label={`Link to ${update.title}`}>#</a>
+              <a className={styles.sourceLink} href={update.source.url} target="_blank" rel="noreferrer">{update.source.label}</a>
             </div>
 
             <CountChange counts={update.counts} />
 
-            {update.added_entities.length > 0 ? (
-              <div className={styles.sectionBlock}>
-                <div className={styles.sectionHeading}>
-                  <h4>Added</h4>
-                  <span>{update.added_entities.length} entities</span>
-                </div>
-                <div className={styles.tableWrap}>
-                  <table className={styles.entityTable}>
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Type</th>
-                        <th>Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {update.added_entities.map((entity) => (
-                        <tr key={entity.slug}>
-                          <td><Link href={`/exchange/${entity.slug}`}>{entity.name}</Link></td>
-                          <td><span className={styles.neutralChip}>{entity.type ?? '—'}</span></td>
-                          <td><span className={`${styles.statusChip} ${styles[`status_${entity.status ?? 'unknown'}`]}`}>{entity.status ?? 'unknown'}</span></td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            ) : null}
+            <div className={styles.detailGrid}>
+              <div><h4>Added entities</h4>{update.added_entities.length > 0 ? <ul>{update.added_entities.map((entity) => <li key={entity.slug}><Link href={`/exchange/${entity.slug}`}>{entity.name}</Link></li>)}</ul> : <p className="muted">No new entities in this update.</p>}</div>
+              <div><h4>Repairs and reviewed changes</h4>{update.repairs.length > 0 ? <ul>{update.repairs.map((repair) => <li key={repair}>{repair}</li>)}</ul> : <p className="muted">No repair notes in this update.</p>}</div>
+            </div>
 
-            {update.updated_entities.length > 0 ? (
-              <div className={styles.sectionBlock}>
-                <div className={styles.sectionHeading}>
-                  <h4>Updated</h4>
-                  <span>{update.updated_entities.length} entities</span>
-                </div>
-                <div className={styles.updatedList}>
-                  {update.updated_entities.map((entity) => (
-                    <div className={styles.updatedItem} key={entity.slug}>
-                      <Link href={`/exchange/${entity.slug}`}>{entity.name}</Link>
-                      <p>{entity.change}</p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-
-            {update.notes.length > 0 ? (
-              <div className={styles.notesBlock}>
-                <h4>Notes</h4>
-                <ul>
-                  {update.notes.map((note) => <li key={note}>{note}</li>)}
-                </ul>
-              </div>
-            ) : null}
+            <div className={styles.evidenceRow}><span>Evidence added</span><strong>{update.evidence_added}</strong></div>
           </article>
         ))}
-      </section>
-
-      <section className="callout">
-        Registry Updates and its RSS/JSON feeds only cover reviewed public changes. Monitoring candidates, unresolved watchlist items, and raw risk signals remain outside these public outputs until separately reviewed.
       </section>
     </main>
   )

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -43,7 +43,11 @@ function CountChange({ counts }: { counts: RegistryUpdateCounts }) {
 }
 
 function UpdateTypeLabel({ type }: { type: 'registry_growth' | 'quality_audit' }) {
-  return <span className={styles.typeLabel}>{type === 'registry_growth' ? 'Registry growth' : 'Quality audit'}</span>
+  return (
+    <span className={styles.typeLabel}>
+      {type === 'registry_growth' ? 'Registry growth' : 'Quality audit'}
+    </span>
+  )
 }
 
 export default function RegistryUpdatesPage() {
@@ -59,7 +63,8 @@ export default function RegistryUpdatesPage() {
             <p className="muted">Reviewed changelog</p>
             <h2 className={styles.pageTitle}>Registry Updates</h2>
             <p className={styles.lead}>
-              Canonical additions and reviewed corrections that have already passed HEI review and repository validation. Internal monitoring signals and unmerged candidates are not published here.
+              Canonical additions and reviewed corrections that have already passed HEI review and repository validation.
+              Internal monitoring signals and unmerged candidates are not published here.
             </p>
           </div>
           <div className={styles.headerActions}>
@@ -72,9 +77,18 @@ export default function RegistryUpdatesPage() {
         </div>
 
         <div className={styles.summaryStrip}>
-          <div><span className={styles.summaryLabel}>Published updates</span><strong>{updates.length}</strong></div>
-          <div><span className={styles.summaryLabel}>Entities added in listed updates</span><strong>{totalAdded}</strong></div>
-          <div><span className={styles.summaryLabel}>Evidence added in listed updates</span><strong>{totalEvidenceAdded}</strong></div>
+          <div>
+            <span className={styles.summaryLabel}>Published updates</span>
+            <strong>{updates.length}</strong>
+          </div>
+          <div>
+            <span className={styles.summaryLabel}>Entities added in listed updates</span>
+            <strong>{totalAdded}</strong>
+          </div>
+          <div>
+            <span className={styles.summaryLabel}>Evidence added in listed updates</span>
+            <strong>{totalEvidenceAdded}</strong>
+          </div>
         </div>
       </section>
 
@@ -83,23 +97,78 @@ export default function RegistryUpdatesPage() {
           <article className={`panel ${styles.updateCard}`} key={update.id} id={update.id}>
             <div className={styles.updateHeader}>
               <div>
-                <div className={styles.updateMeta}><time dateTime={update.date}>{update.date}</time><UpdateTypeLabel type={update.type} /></div>
+                <div className={styles.updateMeta}>
+                  <time dateTime={update.date}>{update.date}</time>
+                  <UpdateTypeLabel type={update.update_type} />
+                </div>
                 <h3>{update.title}</h3>
                 <p>{update.summary}</p>
               </div>
-              <a className={styles.sourceLink} href={update.source.url} target="_blank" rel="noreferrer">{update.source.label}</a>
+              <a className={styles.anchorLink} href={`#${update.id}`} aria-label={`Link to ${update.title}`}>#</a>
             </div>
 
             <CountChange counts={update.counts} />
 
-            <div className={styles.detailGrid}>
-              <div><h4>Added entities</h4>{update.added_entities.length > 0 ? <ul>{update.added_entities.map((entity) => <li key={entity.slug}><Link href={`/exchange/${entity.slug}`}>{entity.name}</Link></li>)}</ul> : <p className="muted">No new entities in this update.</p>}</div>
-              <div><h4>Repairs and reviewed changes</h4>{update.repairs.length > 0 ? <ul>{update.repairs.map((repair) => <li key={repair}>{repair}</li>)}</ul> : <p className="muted">No repair notes in this update.</p>}</div>
-            </div>
+            {update.added_entities.length > 0 ? (
+              <div className={styles.sectionBlock}>
+                <div className={styles.sectionHeading}>
+                  <h4>Added</h4>
+                  <span>{update.added_entities.length} entities</span>
+                </div>
+                <div className={styles.tableWrap}>
+                  <table className={styles.entityTable}>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {update.added_entities.map((entity) => (
+                        <tr key={entity.slug}>
+                          <td><Link href={`/exchange/${entity.slug}`}>{entity.name}</Link></td>
+                          <td><span className={styles.neutralChip}>{entity.type ?? '—'}</span></td>
+                          <td><span className={`${styles.statusChip} ${styles[`status_${entity.status ?? 'unknown'}`]}`}>{entity.status ?? 'unknown'}</span></td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : null}
 
-            <div className={styles.evidenceRow}><span>Evidence added</span><strong>{update.evidence_added}</strong></div>
+            {update.updated_entities.length > 0 ? (
+              <div className={styles.sectionBlock}>
+                <div className={styles.sectionHeading}>
+                  <h4>Updated</h4>
+                  <span>{update.updated_entities.length} entities</span>
+                </div>
+                <div className={styles.updatedList}>
+                  {update.updated_entities.map((entity) => (
+                    <div className={styles.updatedItem} key={entity.slug}>
+                      <Link href={`/exchange/${entity.slug}`}>{entity.name}</Link>
+                      <p>{entity.change}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {update.notes.length > 0 ? (
+              <div className={styles.notesBlock}>
+                <h4>Notes</h4>
+                <ul>
+                  {update.notes.map((note) => <li key={note}>{note}</li>)}
+                </ul>
+              </div>
+            ) : null}
           </article>
         ))}
+      </section>
+
+      <section className="callout">
+        Registry Updates and its RSS/JSON feeds only cover reviewed public changes. Monitoring candidates, unresolved watchlist items, and raw risk signals remain outside these public outputs until separately reviewed.
       </section>
     </main>
   )


### PR DESCRIPTION
## Roadmap item
E5-5 — Timeline / Updates to Explorer cross-links.

## Summary
Adds reviewed public Explorer query links from Registry Updates, Incident Timeline, and Monthly Snapshot.

Incidents links preserve the reviewed incident event-type set and per-type queries. Monthly links preserve the displayed period and optionally event type or impact. Updates links to the reviewed Event Explorer without exposing monitoring or staging data.

Canonical counts are unchanged: 550 entities, 1004 events, 2621 evidence.
