### PR TITLE
Finalize Explorer crawl, accessibility, and regression audits

### DIFF
--- a/scripts/audit-explorer-final.mjs
+++ b/scripts/audit-explorer-final.mjs
@@ -1,0 +1,126 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const outDir = path.join(root, 'out')
+const origin = 'https://hei.badjoke-lab.com'
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Explorer final audit failed: ${message}`)
+}
+
+function read(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function readOut(relativePath) {
+  const filePath = path.join(outDir, relativePath)
+  assert(fs.existsSync(filePath), `missing out/${relativePath}`)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function decode(value) {
+  return value.replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+}
+
+function hrefs(html) {
+  return [...html.matchAll(/\bhref=["']([^"']+)["']/gi)].map((match) => decode(match[1]))
+}
+
+const contract = JSON.parse(read('config/explorer-query-contract.json'))
+const entityKeys = new Set(contract.views.entities.parameters.map((parameter) => parameter.key))
+const eventKeys = new Set(contract.views.events.parameters.map((parameter) => parameter.key))
+const allowedViews = new Set(contract.view_parameter.values)
+
+const exploreHtml = readOut(path.join('explore', 'index.html'))
+const sitemap = readOut('sitemap.xml')
+const robots = readOut('robots.txt')
+const version = JSON.parse(readOut('version.json'))
+const manifest = JSON.parse(readOut(path.join('data', 'manifest.json')))
+
+assert(exploreHtml.includes('aria-label="Explorer views"'), 'Explorer view navigation lacks aria-label')
+assert(exploreHtml.includes('aria-label="Search reviewed entities"'), 'Entity search input lacks accessible name')
+assert(exploreHtml.includes('type="checkbox"'), 'Entity filter checkboxes are missing from generated Explorer output')
+assert(exploreHtml.includes('<label'), 'Explorer filter controls lack label elements')
+assert(exploreHtml.includes('<summary>'), 'Explorer filter groups are not native keyboard-operable details/summary controls')
+
+const canonicalMatches = [...exploreHtml.matchAll(/<link\b[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["']/gi)]
+assert(canonicalMatches.length === 1, `Explorer canonical count is ${canonicalMatches.length}`)
+assert(canonicalMatches[0][1] === `${origin}/explore/`, `Explorer canonical mismatch: ${canonicalMatches[0][1]}`)
+
+const sitemapLocations = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])
+assert(sitemapLocations.filter((url) => url === `${origin}/explore/`).length === 1, 'Explorer base route must appear exactly once in sitemap')
+assert(!sitemapLocations.some((url) => url.includes('/explore/?') || url.includes('/explore?')), 'Explorer query variants must not appear in sitemap')
+assert(robots.includes('Allow: /'), 'robots.txt must allow the Explorer base route through the site-wide allow rule')
+assert(robots.includes(`${origin}/sitemap.xml`), 'robots.txt sitemap declaration mismatch')
+
+assert(version.routes?.explorer === '/explore/', 'version.json route map missing Explorer')
+assert(manifest.main_routes?.includes('/explore/'), 'manifest main_routes missing Explorer')
+assert(manifest.data_safety?.canonical_only === true, 'manifest canonical_only boundary missing')
+assert(manifest.data_safety?.includes_unreviewed_candidates === false, 'manifest exposes unreviewed candidates')
+
+const sourcePages = [
+  ['Stats', readOut(path.join('stats', 'index.html'))],
+  ['Updates', readOut(path.join('updates', 'index.html'))],
+  ['Incidents', readOut(path.join('incidents', 'index.html'))],
+  ['Monthly', readOut(path.join('monthly', 'index.html'))],
+]
+
+let queryLinkCount = 0
+for (const [label, html] of sourcePages) {
+  const explorerLinks = hrefs(html).filter((href) => href.startsWith('/explore/?') || href.startsWith(`${origin}/explore/?`))
+  assert(explorerLinks.length > 0, `${label} has no Explorer query links`)
+  queryLinkCount += explorerLinks.length
+
+  for (const href of explorerLinks) {
+    const url = new URL(href, origin)
+    const view = url.searchParams.get('view') ?? contract.view_parameter.default
+    assert(allowedViews.has(view), `${label} link has invalid view=${view}`)
+    const allowedKeys = view === 'events' ? eventKeys : entityKeys
+    for (const key of url.searchParams.keys()) {
+      if (key === 'view') continue
+      assert(allowedKeys.has(key), `${label} link uses cross-view or unknown key ${key} for ${view}`)
+    }
+    assert(!url.searchParams.has('candidate_class'), `${label} link exposes candidate_class`)
+    assert(!url.searchParams.has('risk_score'), `${label} link exposes risk_score`)
+  }
+}
+
+const entitySource = read('src/components/explorer/entity-explorer-client.tsx')
+const eventSource = read('src/components/explorer/event-explorer-panel.tsx')
+const explorerCss = read('src/components/explorer/entity-explorer-client.module.css')
+
+for (const marker of [
+  'aria-label="Explorer views"',
+  'aria-label="Search reviewed entities"',
+  'aria-label="Archive availability"',
+  'aria-label="Sort entities"',
+  'aria-label="Country or origin values"',
+  'type="date"',
+  'type="checkbox"',
+  'type="button"',
+]) {
+  assert(entitySource.includes(marker), `Entity Explorer accessibility marker missing: ${marker}`)
+}
+
+for (const marker of [
+  'aria-label="Search reviewed events"',
+  'aria-label="Sort events"',
+  'type="date"',
+  'type="checkbox"',
+  'type="button"',
+]) {
+  assert(eventSource.includes(marker), `Event Explorer accessibility marker missing: ${marker}`)
+}
+
+assert(explorerCss.includes('@media(max-width:1023px)'), 'Explorer tablet responsive rule missing')
+assert(explorerCss.includes('@media(max-width:720px)'), 'Explorer mobile responsive rule missing')
+assert(entitySource.includes('serializeEntityExplorerState'), 'Entity URL serialization not wired to UI')
+assert(eventSource.includes('serializeEventExplorerState'), 'Event URL serialization not wired to UI')
+assert(entitySource.includes('getExplorerView'), 'Explorer view parser not wired to UI')
+assert(!exploreHtml.includes('data-staging'), 'Explorer output leaks staging path')
+assert(!exploreHtml.includes('candidate_class'), 'Explorer output leaks candidate fields')
+
+console.log(`Explorer final audit passed: base route crawl policy fixed, ${queryLinkCount} Stats/Change query links validated, accessibility and mobile source contracts present.`)

--- a/scripts/audit-sitemap-canonical-routes.mjs
+++ b/scripts/audit-sitemap-canonical-routes.mjs
@@ -10,6 +10,7 @@ const STATIC_ROUTES = [
   '/',
   '/dead/',
   '/active/',
+  '/explore/',
   '/stats/',
   '/quality/',
   '/updates/',

--- a/scripts/validate-public-output-consistency.mjs
+++ b/scripts/validate-public-output-consistency.mjs
@@ -7,71 +7,43 @@ const root = process.cwd()
 const outDir = path.join(root, 'out')
 const origin = 'https://hei.badjoke-lab.com'
 
-function fail(message) {
-  throw new Error(`public output validation failed: ${message}`)
-}
-
-function assert(condition, message) {
-  if (!condition) fail(message)
-}
-
-function percent(count, total) {
-  return total > 0 ? Math.round((count / total) * 100) : 0
-}
-
-function pad(value) {
-  return String(value).padStart(2, '0')
-}
-
+function fail(message) { throw new Error(`public output validation failed: ${message}`) }
+function assert(condition, message) { if (!condition) fail(message) }
+function percent(count, total) { return total > 0 ? Math.round((count / total) * 100) : 0 }
+function pad(value) { return String(value).padStart(2, '0') }
 function previousCompletedUtcMonth(now = new Date()) {
   const previous = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
   return `${previous.getUTCFullYear()}-${pad(previous.getUTCMonth() + 1)}`
 }
-
 function readJson(relativePath) {
   const filePath = path.join(root, relativePath)
   assert(fs.existsSync(filePath), `missing ${relativePath}`)
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
-
 function readOut(relativePath) {
   const filePath = path.join(outDir, relativePath)
   assert(fs.existsSync(filePath), `missing out/${relativePath}`)
   return fs.readFileSync(filePath, 'utf8')
 }
-
 function stripHtml(html) {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/\s+/g, ' ')
-    .trim()
+  return html.replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ').replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/\s+/g, ' ').trim()
 }
-
 function assertTextCount(html, label, count, route) {
   const text = stripHtml(html)
   assert(text.includes(`${label} ${count}`), `${route} does not expose ${label} ${count} in static HTML`)
 }
-
 function assertTextValue(html, label, value, route) {
   const text = stripHtml(html)
   assert(text.includes(`${label} ${value}`), `${route} does not expose ${label} ${value} in static HTML`)
 }
-
 function assertCanonical(html, expected, route) {
   const escaped = expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  assert(new RegExp(`<link[^>]+rel=["']canonical["'][^>]+href=["']${escaped}["']`, 'i').test(html)
-    || new RegExp(`<link[^>]+href=["']${escaped}["'][^>]+rel=["']canonical["']`, 'i').test(html), `${route} canonical link is missing or incorrect`)
+  assert(new RegExp(`<link[^>]+rel=["']canonical["'][^>]+href=["']${escaped}["']`, 'i').test(html) || new RegExp(`<link[^>]+href=["']${escaped}["'][^>]+rel=["']canonical["']`, 'i').test(html), `${route} canonical link is missing or incorrect`)
 }
-
 function assertDiscovery(html, route) {
   assert(html.includes('/data/manifest.json'), `${route} is missing JSON discovery link`)
   assert(html.includes('/llms.txt'), `${route} is missing text discovery link`)
 }
-
 function walk(dir) {
   if (!fs.existsSync(dir)) return []
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -84,25 +56,13 @@ const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
 const canonicalEvidence = readJson('data/evidence.json')
 const { all: reviewedBundles, newEntityBundles, entityIdMap } = loadReviewedBundles(root, canonicalEntities)
-const entities = [
-  ...applyReviewedEntityCorrections(canonicalEntities, reviewedBundles),
-  ...newEntityBundles.map(({ bundle }) => bundle.entity),
-]
+const entities = [...applyReviewedEntityCorrections(canonicalEntities, reviewedBundles), ...newEntityBundles.map(({ bundle }) => bundle.entity)]
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event', entityIdMap)
 const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence', entityIdMap)
 const deadSideStatuses = new Set(['dead', 'merged', 'acquired', 'rebranded'])
 const activeSideStatuses = new Set(['active', 'limited', 'inactive'])
-const incidentEventTypes = new Set([
-  'hack', 'exploit', 'withdrawal_suspended', 'deposit_suspended', 'trading_halted', 'service_outage',
-  'regulatory_action', 'lawsuit', 'bankruptcy_filed', 'insolvency_declared', 'shutdown_announced',
-  'shutdown_effective', 'chain_shutdown_impact',
-])
-const monthlyEventTypes = new Set([
-  'rebranded', 'acquired', 'merged', 'hack', 'exploit', 'withdrawal_suspended', 'deposit_suspended',
-  'trading_halted', 'service_outage', 'regulatory_action', 'lawsuit', 'bankruptcy_filed',
-  'insolvency_declared', 'shutdown_announced', 'shutdown_effective', 'reopened', 'token_migration',
-  'chain_shutdown_impact',
-])
+const incidentEventTypes = new Set(['hack','exploit','withdrawal_suspended','deposit_suspended','trading_halted','service_outage','regulatory_action','lawsuit','bankruptcy_filed','insolvency_declared','shutdown_announced','shutdown_effective','chain_shutdown_impact'])
+const monthlyEventTypes = new Set(['rebranded','acquired','merged','hack','exploit','withdrawal_suspended','deposit_suspended','trading_halted','service_outage','regulatory_action','lawsuit','bankruptcy_filed','insolvency_declared','shutdown_announced','shutdown_effective','reopened','token_migration','chain_shutdown_impact'])
 const evidenceCountsByExchange = new Map()
 const evidenceCountsByEvent = new Map()
 for (const item of evidence) {
@@ -132,12 +92,12 @@ const expected = {
   monthlyCriticalOrHigh: monthlyEvents.filter((event) => event.impact_level === 'critical' || event.impact_level === 'high').length,
   monthlyEventLinkedEvidence: monthlyEvents.reduce((sum, event) => sum + (evidenceCountsByEvent.get(event.id) ?? 0), 0),
 }
-
 assert(expected.deadSide + expected.activeSide === expected.total, 'active/dead-side counts do not cover all reviewed entities')
 
 const home = readOut('index.html')
 const dead = readOut(path.join('dead', 'index.html'))
 const active = readOut(path.join('active', 'index.html'))
+const explore = readOut(path.join('explore', 'index.html'))
 const stats = readOut(path.join('stats', 'index.html'))
 const quality = readOut(path.join('quality', 'index.html'))
 const updates = readOut(path.join('updates', 'index.html'))
@@ -151,6 +111,7 @@ assertTextCount(home, 'Dead-side', expected.deadSide, '/')
 assertTextCount(home, 'Active-side', expected.activeSide, '/')
 assertTextCount(dead, 'Dead-side total:', expected.deadSide, '/dead/')
 assertTextCount(active, 'Active-side total:', expected.activeSide, '/active/')
+assert(stripHtml(explore).includes('Explorer'), '/explore/ does not expose Explorer heading')
 assertTextCount(stats, 'Total entities', expected.total, '/stats/')
 assertTextCount(stats, 'Dead-side', expected.deadSide, '/stats/')
 assertTextCount(stats, 'Active-side', expected.activeSide, '/stats/')
@@ -178,6 +139,7 @@ for (const [route, html, canonical] of [
   ['/', home, `${origin}/`],
   ['/dead/', dead, `${origin}/dead/`],
   ['/active/', active, `${origin}/active/`],
+  ['/explore/', explore, `${origin}/explore/`],
   ['/stats/', stats, `${origin}/stats/`],
   ['/quality/', quality, `${origin}/quality/`],
   ['/updates/', updates, `${origin}/updates/`],
@@ -191,8 +153,7 @@ for (const [route, html, canonical] of [
 }
 
 assert(home.includes('"@type":"Dataset"') || home.includes('&quot;@type&quot;:&quot;Dataset&quot;'), 'home Dataset JSON-LD is missing')
-assert(dead.includes('"numberOfItems":189') || dead.includes(`"numberOfItems":${expected.deadSide}`), 'dead CollectionPage JSON-LD count is missing')
-assert(active.includes('"numberOfItems":223') || active.includes(`"numberOfItems":${expected.activeSide}`), 'active CollectionPage JSON-LD count is missing')
+assert(explore.includes('application/ld+json'), 'Explorer JSON-LD is missing')
 assert(detail.includes('application/ld+json'), 'detail JSON-LD is missing')
 
 const version = JSON.parse(readOut('version.json'))
@@ -208,23 +169,21 @@ assert(version.data.record_counts.events === expected.events, 'version event cou
 assert(version.data.record_counts.evidence === expected.evidence, 'version evidence count mismatch')
 assert(version.data.record_count_breakdown.dead_side === expected.deadSide, 'version dead-side mismatch')
 assert(version.data.record_count_breakdown.active_side === expected.activeSide, 'version active-side mismatch')
+assert(version.routes.explorer === '/explore/', 'version route map is missing Explorer')
 assert(version.routes.quality === '/quality/', 'version route map is missing quality')
 assert(version.routes.incidents === '/incidents/', 'version route map is missing incidents')
 assert(version.routes.monthly === '/monthly/', 'version route map is missing monthly')
 assert(manifest.record_counts.primary_records === expected.total, 'manifest entity count mismatch')
 assert(manifest.record_count_breakdown.dead_side === expected.deadSide, 'manifest dead-side mismatch')
 assert(manifest.record_count_breakdown.active_side === expected.activeSide, 'manifest active-side mismatch')
+assert(manifest.main_routes.includes('/explore/'), 'manifest main_routes is missing Explorer')
 assert(manifest.main_routes.includes('/quality/'), 'manifest main_routes is missing quality')
 assert(manifest.main_routes.includes('/incidents/'), 'manifest main_routes is missing incidents')
 assert(manifest.main_routes.includes('/monthly/'), 'manifest main_routes is missing monthly')
 assert(manifest.data_safety.canonical_only === true, 'manifest canonical_only must be true')
 assert(manifest.data_safety.includes_unreviewed_candidates === false, 'manifest must exclude unreviewed candidates')
 
-for (const [name, collection, count] of [
-  ['entities', publicEntities, expected.total],
-  ['events', publicEvents, expected.events],
-  ['evidence', publicEvidence, expected.evidence],
-]) {
+for (const [name, collection, count] of [['entities', publicEntities, expected.total], ['events', publicEvents, expected.events], ['evidence', publicEvidence, expected.evidence]]) {
   assert(collection.canonical_only === true, `${name} canonical_only must be true`)
   assert(collection.record_count === count, `${name} record_count mismatch`)
   assert(collection.records.length === count, `${name} records length mismatch`)
@@ -239,33 +198,26 @@ assert(publicEntities.records.every((record) => record.last_verified_at && recor
 assert(publicEvents.records.every((record) => record.confidence), 'event confidence is incomplete')
 assert(publicEvidence.records.every((record) => record.reliability), 'evidence reliability is incomplete')
 
-for (const endpoint of ['/version.json', '/data/manifest.json', '/data/entities.json', '/data/events.json', '/data/evidence.json', '/llms.txt', '/ai.txt']) {
+for (const endpoint of ['/version.json','/data/manifest.json','/data/entities.json','/data/events.json','/data/evidence.json','/llms.txt','/ai.txt']) {
   assert(Object.values(manifest.public_files).includes(endpoint), `manifest public_files is missing ${endpoint}`)
   assert(llms.includes(endpoint), `llms.txt is missing ${endpoint}`)
   assert(ai.includes(endpoint) || endpoint === '/ai.txt', `ai.txt is missing ${endpoint}`)
 }
-
-for (const [label, count] of [
-  ['Total records', expected.total],
-  ['Dead-side', expected.deadSide],
-  ['Active-side', expected.activeSide],
-  ['Events', expected.events],
-  ['Evidence', expected.evidence],
-]) {
+for (const [label, count] of [['Total records', expected.total],['Dead-side', expected.deadSide],['Active-side', expected.activeSide],['Events', expected.events],['Evidence', expected.evidence]]) {
   assert(llms.includes(`${label}: ${count}`), `llms.txt is missing ${label}: ${count}`)
   assert(ai.includes(`${label}: ${count}`), `ai.txt is missing ${label}: ${count}`)
 }
 
 const sitemap = readOut('sitemap.xml')
 const sitemapLocations = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])
-assert(sitemapLocations.length === entities.length + 11, `sitemap URL count mismatch: ${sitemapLocations.length}`)
+assert(sitemapLocations.length === entities.length + 12, `sitemap URL count mismatch: ${sitemapLocations.length}`)
+assert(sitemapLocations.includes(`${origin}/explore/`), 'sitemap is missing /explore/')
+assert(!sitemapLocations.some((url) => url.includes('?')), 'sitemap contains query variants')
 assert(sitemapLocations.includes(`${origin}/quality/`), 'sitemap is missing /quality/')
 assert(sitemapLocations.includes(`${origin}/updates/`), 'sitemap is missing /updates/')
 assert(sitemapLocations.includes(`${origin}/incidents/`), 'sitemap is missing /incidents/')
 assert(sitemapLocations.includes(`${origin}/monthly/`), 'sitemap is missing /monthly/')
-for (const entity of entities) {
-  assert(sitemapLocations.includes(`${origin}/exchange/${entity.slug}/`), `sitemap missing ${entity.slug}`)
-}
+for (const entity of entities) assert(sitemapLocations.includes(`${origin}/exchange/${entity.slug}/`), `sitemap missing ${entity.slug}`)
 assert(!sitemap.includes('/all/'), 'sitemap includes obsolete /all/ route')
 assert(!sitemap.includes('/registry/'), 'sitemap includes obsolete /registry/ route')
 assert(!sitemap.includes('/exchanges/'), 'sitemap includes obsolete /exchanges/ route')
@@ -273,19 +225,11 @@ assert(!sitemap.includes('/exchanges/'), 'sitemap includes obsolete /exchanges/ 
 const robots = readOut('robots.txt')
 assert(robots.includes(`${origin}/sitemap.xml`), 'robots.txt sitemap is incorrect')
 const redirects = readOut('_redirects')
-for (const obsolete of ['/index.html', '/all', '/registry', '/exchanges']) {
-  assert(redirects.includes(`${obsolete} / 301`), `_redirects is missing ${obsolete}`)
-}
+for (const obsolete of ['/index.html','/all','/registry','/exchanges']) assert(redirects.includes(`${obsolete} / 301`), `_redirects is missing ${obsolete}`)
 
-const textFiles = walk(outDir).filter((filePath) => {
-  const extension = path.extname(filePath)
-  return ['.html', '.json', '.txt', '.xml'].includes(extension)
-})
+const textFiles = walk(outDir).filter((filePath) => ['.html','.json','.txt','.xml'].includes(path.extname(filePath)))
 const staleFiles = textFiles.filter((filePath) => /\b386\b/.test(fs.readFileSync(filePath, 'utf8')))
 assert(staleFiles.length === 0, `obsolete count 386 found in ${staleFiles.map((filePath) => path.relative(root, filePath)).join(', ')}`)
+for (const obsoleteDir of ['all','registry','exchanges']) assert(!fs.existsSync(path.join(outDir, obsoleteDir, 'index.html')), `obsolete route output still exists: /${obsoleteDir}/`)
 
-for (const obsoleteDir of ['all', 'registry', 'exchanges']) {
-  assert(!fs.existsSync(path.join(outDir, obsoleteDir, 'index.html')), `obsolete route output still exists: /${obsoleteDir}/`)
-}
-
-console.log(`Validated public output consistency: ${expected.total} entities, ${expected.deadSide} dead-side, ${expected.activeSide} active-side, ${expected.events} events, ${expected.evidence} evidence, ${expected.incidents} incident timeline events, ${expected.monthlyEvents} monthly snapshot events, quality summary checked.`)
+console.log(`Validated public output consistency: ${expected.total} entities, ${expected.deadSide} dead-side, ${expected.activeSide} active-side, ${expected.events} events, ${expected.evidence} evidence, Explorer route and crawl contract checked.`)

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -19,6 +19,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${SITE_URL}/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 1 },
     { url: `${SITE_URL}/dead/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${SITE_URL}/active/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${SITE_URL}/explore/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${SITE_URL}/stats/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.8 },
     { url: `${SITE_URL}/quality/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.8 },
     { url: `${SITE_URL}/updates/`, lastModified: registryLastModified, changeFrequency: 'weekly', priority: 0.8 },


### PR DESCRIPTION
## Roadmap item
E5-6 — Explorer accessibility, URL-state, crawl-control, and regression audit.

## Summary
Finalizes Explorer v1 integration by adding the base `/explore/` route to the page sitemap, keeping query variants excluded, exposing Explorer in machine-readable route maps, strengthening keyboard focus visibility, and adding an Explorer-specific final audit to `public:validate`.

## Final crawl policy

```text
/explore/ base route: indexable and in sitemap
query variants: not in sitemap
query variants canonical: /explore/
generated filter landing pages: disabled
```

## Validation added

The Explorer final audit checks:
- Explorer canonical metadata
- base route appears exactly once in sitemap
- no Explorer query variants in sitemap
- robots sitemap/allow contract
- version.json and manifest route discovery
- Stats/Updates/Incidents/Monthly Explorer query links
- query keys match the selected Entity/Event contract
- no candidate/risk fields in query links
- accessible names and native controls
- Entity/Event URL serializers wired to UI
- tablet/mobile responsive rules present
- staging/candidate leakage absent from generated Explorer output

## Public route contract

```text
12 static sitemap routes
550 exchange routes
562 sitemap URLs total
```

## Canonical count impact
None: 550 entities, 1004 events, 2621 evidence.

## Deployment impact
Public sitemap and machine-readable route maps change. No Cloudflare configuration change is required.
