### PR TITLE
Add Compare v1 core route and lifecycle matrix

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,66 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import CompareClient from '../../components/compare/compare-client'
+import { loadEntities } from '../../lib/data/load-entities'
+import { SITE_NAME, SITE_URL } from '../../lib/site-constants'
+
+export function generateMetadata(): Metadata {
+  const entities = loadEntities()
+  const description = `Compare reviewed lifecycle facts across ${entities.length} Historical Exchange Index entities using deterministic, shareable URL state.`
+
+  return {
+    title: 'Compare',
+    description,
+    alternates: { canonical: '/compare' },
+    openGraph: {
+      type: 'website',
+      url: `${SITE_URL}/compare/`,
+      title: `Compare | ${SITE_NAME}`,
+      description,
+      siteName: SITE_NAME,
+      images: ['/opengraph-image'],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `Compare | ${SITE_NAME}`,
+      description,
+      images: ['/twitter-image'],
+    },
+  }
+}
+
+export default function ComparePage() {
+  const entities = loadEntities()
+
+  const collectionJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    '@id': `${SITE_URL}/compare/`,
+    url: `${SITE_URL}/compare/`,
+    name: 'HEI Compare',
+    description: 'Side-by-side comparison of reviewed Historical Exchange Index entity lifecycle facts.',
+    isPartOf: { '@type': 'WebSite', name: SITE_NAME, url: SITE_URL },
+  }
+
+  return (
+    <main className="longform">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }} />
+
+      <section className="panel longform-panel">
+        <div className="detail-header">
+          <div>
+            <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>Research layer</p>
+            <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>Compare</h2>
+            <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '72ch' }}>
+              Inspect reviewed exchange identity and lifecycle facts side by side. Compare uses reviewed public records and deterministic derived values only.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>Loading comparison state…</div></div></section>}>
+        <CompareClient entities={entities} />
+      </Suspense>
+    </main>
+  )
+}

--- a/src/components/compare/compare-client.module.css
+++ b/src/components/compare/compare-client.module.css
@@ -1,0 +1,194 @@
+.shell {
+  overflow: hidden;
+  margin-top: 22px;
+}
+
+.controls {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+  border-bottom: 1px solid var(--line-soft);
+  background: rgba(255, 255, 255, 0.012);
+}
+
+.controlCopy {
+  display: grid;
+  gap: 6px;
+}
+
+.controlTitle {
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.controlHint {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+  max-width: 78ch;
+}
+
+.addRow {
+  display: grid;
+  grid-template-columns: minmax(240px, 520px) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.selectLabel {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.selectionStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  min-height: 34px;
+  align-items: center;
+}
+
+.emptySelection {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.selectionItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 6px 8px 6px 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel-2);
+  font-size: 13px;
+}
+
+.selectionOrder {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: #efd8b7;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.removeButton {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+}
+
+.removeButton:hover,
+.removeButton:focus-visible {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+  outline: none;
+}
+
+.stateBar {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 18px;
+  color: var(--muted);
+  font-size: 12px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.matrixScroller {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.matrix {
+  min-width: 680px;
+  table-layout: fixed;
+}
+
+.matrix th:first-child {
+  width: 150px;
+}
+
+.matrix tbody th {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.012);
+}
+
+.matrix td,
+.matrix th {
+  vertical-align: top;
+}
+
+.entityHeading {
+  display: grid;
+  gap: 5px;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 14px;
+}
+
+.entityHeading span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.emptyState {
+  display: grid;
+  gap: 8px;
+  padding: 34px 20px;
+}
+
+.emptyState strong {
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+.emptyState span {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+  max-width: 72ch;
+}
+
+@media (max-width: 720px) {
+  .controls {
+    padding: 16px;
+  }
+
+  .addRow {
+    grid-template-columns: 1fr;
+  }
+
+  .addRow button {
+    justify-content: center;
+  }
+
+  .stateBar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .matrix {
+    min-width: 620px;
+  }
+
+  .matrix th:first-child {
+    width: 128px;
+  }
+}

--- a/src/components/compare/compare-client.tsx
+++ b/src/components/compare/compare-client.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import type { EntityRecord } from '../../lib/types/entity'
+import {
+  COMPARE_MAX,
+  calculateLifespanDays,
+  isComparisonReady,
+  parseCompareState,
+  resolveComparedEntities,
+  serializeCompareState,
+  type CompareState,
+} from '../../lib/compare/compare-state'
+import { formatDate } from '../../lib/utils/format-date'
+import styles from './compare-client.module.css'
+
+type Props = {
+  entities: EntityRecord[]
+}
+
+type Row = {
+  label: string
+  render: (entity: EntityRecord) => React.ReactNode
+}
+
+const rows: Row[] = [
+  {
+    label: 'Type',
+    render: (entity) => <span className="chip type">{entity.type.toUpperCase()}</span>,
+  },
+  {
+    label: 'Launch date',
+    render: (entity) => formatDate(entity.launch_date),
+  },
+  {
+    label: 'Terminal date',
+    render: (entity) => formatDate(entity.death_date),
+  },
+  {
+    label: 'Lifespan',
+    render: (entity) => {
+      const days = calculateLifespanDays(entity)
+      return days === null ? <span className="muted">Unknown</span> : `${days.toLocaleString()} days`
+    },
+  },
+  {
+    label: 'Record',
+    render: (entity) => <Link className="subtle-link" href={`/exchange/${entity.slug}/`}>Open dossier</Link>,
+  },
+]
+
+function buildUrl(pathname: string, state: CompareState): string {
+  const query = serializeCompareState(state)
+  return query ? `${pathname}?${query}` : pathname
+}
+
+export default function CompareClient({ entities }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [candidateSlug, setCandidateSlug] = useState('')
+
+  const sortedEntities = useMemo(
+    () => [...entities].sort((a, b) => a.canonical_name.localeCompare(b.canonical_name) || a.id.localeCompare(b.id)),
+    [entities],
+  )
+  const reviewedSlugs = useMemo(() => sortedEntities.map((entity) => entity.slug), [sortedEntities])
+  const state = useMemo(() => parseCompareState(searchParams, reviewedSlugs), [searchParams, reviewedSlugs])
+  const selectedEntities = useMemo(() => resolveComparedEntities(entities, state), [entities, state])
+  const selectedSet = useMemo(() => new Set(state.slugs), [state.slugs])
+  const availableEntities = useMemo(
+    () => sortedEntities.filter((entity) => !selectedSet.has(entity.slug)),
+    [sortedEntities, selectedSet],
+  )
+  const ready = isComparisonReady(state)
+
+  const replaceState = (next: CompareState) => {
+    router.replace(buildUrl(pathname, next), { scroll: false })
+  }
+
+  const addCandidate = () => {
+    if (!candidateSlug || state.slugs.length >= COMPARE_MAX || selectedSet.has(candidateSlug)) return
+    replaceState({ slugs: [...state.slugs, candidateSlug] })
+    setCandidateSlug('')
+  }
+
+  const removeSlug = (slug: string) => {
+    replaceState({ slugs: state.slugs.filter((value) => value !== slug) })
+  }
+
+  return (
+    <section className={`panel ${styles.shell}`}>
+      <div className={styles.controls}>
+        <div className={styles.controlCopy}>
+          <div className={styles.controlTitle}>Select reviewed exchanges</div>
+          <div className={styles.controlHint}>Choose 2–4 entities. Selection order is preserved in the shareable URL and comparison columns.</div>
+        </div>
+
+        <div className={styles.addRow}>
+          <label className={styles.selectLabel}>
+            <span>Add exchange</span>
+            <select
+              className="field"
+              aria-label="Add reviewed exchange to comparison"
+              value={candidateSlug}
+              onChange={(event) => setCandidateSlug(event.target.value)}
+              disabled={state.slugs.length >= COMPARE_MAX}
+            >
+              <option value="">Select a reviewed exchange</option>
+              {availableEntities.map((entity) => (
+                <option key={entity.id} value={entity.slug}>{entity.canonical_name}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={addCandidate}
+            disabled={!candidateSlug || state.slugs.length >= COMPARE_MAX}
+          >
+            Add
+          </button>
+        </div>
+
+        <div className={styles.selectionStrip} aria-label="Selected exchanges">
+          {selectedEntities.length === 0 ? (
+            <span className={styles.emptySelection}>No exchanges selected.</span>
+          ) : selectedEntities.map((entity, index) => (
+            <div className={styles.selectionItem} key={entity.id}>
+              <span className={styles.selectionOrder}>{index + 1}</span>
+              <span>{entity.canonical_name}</span>
+              <button
+                type="button"
+                className={styles.removeButton}
+                onClick={() => removeSlug(entity.slug)}
+                aria-label={`Remove ${entity.canonical_name} from comparison`}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.stateBar}>
+        <span>{selectedEntities.length} of {COMPARE_MAX} selected</span>
+        <span>{ready ? 'Comparison ready' : selectedEntities.length === 1 ? 'Add one more exchange to compare' : 'Select at least two exchanges'}</span>
+      </div>
+
+      {ready ? (
+        <div className={styles.matrixScroller}>
+          <table className={styles.matrix}>
+            <thead>
+              <tr>
+                <th scope="col">Field</th>
+                {selectedEntities.map((entity) => (
+                  <th scope="col" key={entity.id}>
+                    <div className={styles.entityHeading}>
+                      <Link className="subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link>
+                      <span>{entity.slug}</span>
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.label}>
+                  <th scope="row">{row.label}</th>
+                  {selectedEntities.map((entity) => <td key={entity.id}>{row.render(entity)}</td>)}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className={styles.emptyState}>
+          <strong>Comparison not ready</strong>
+          <span>Use the reviewed-entity selector above. HEI does not compare unreviewed candidates or infer missing lifecycle facts.</span>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/compare/compare-state.ts
+++ b/src/lib/compare/compare-state.ts
@@ -1,0 +1,104 @@
+import type { EntityRecord } from '../types/entity'
+
+export const COMPARE_MIN = 2
+export const COMPARE_MAX = 4
+export const COMPARE_PARAMETER = 'exchange'
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const MAX_SLUG_CODE_POINTS = 120
+
+type SearchParamsLike = Pick<URLSearchParams, 'getAll'>
+
+export interface CompareState {
+  slugs: string[]
+}
+
+function codePointLength(value: string): number {
+  return [...value].length
+}
+
+export function normalizeCompareSlug(value: string): string | null {
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return null
+  if (codePointLength(normalized) > MAX_SLUG_CODE_POINTS) return null
+  if (!SLUG_PATTERN.test(normalized)) return null
+  return normalized
+}
+
+export function parseCompareState(
+  params: SearchParamsLike,
+  reviewedSlugs: Iterable<string>,
+): CompareState {
+  const reviewedLookup = new Map<string, string>()
+  for (const slug of reviewedSlugs) {
+    reviewedLookup.set(slug.toLowerCase(), slug)
+  }
+
+  const slugs: string[] = []
+  const seen = new Set<string>()
+
+  for (const raw of params.getAll(COMPARE_PARAMETER)) {
+    const normalized = normalizeCompareSlug(raw)
+    if (!normalized) continue
+
+    const reviewedSlug = reviewedLookup.get(normalized)
+    if (!reviewedSlug || seen.has(reviewedSlug)) continue
+
+    seen.add(reviewedSlug)
+    slugs.push(reviewedSlug)
+    if (slugs.length >= COMPARE_MAX) break
+  }
+
+  return { slugs }
+}
+
+export function serializeCompareState(state: CompareState): string {
+  const params = new URLSearchParams()
+  const seen = new Set<string>()
+
+  for (const slug of state.slugs) {
+    const normalized = normalizeCompareSlug(slug)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    params.append(COMPARE_PARAMETER, normalized)
+    if (seen.size >= COMPARE_MAX) break
+  }
+
+  return params.toString()
+}
+
+export function resolveComparedEntities(
+  entities: EntityRecord[],
+  state: CompareState,
+): EntityRecord[] {
+  const bySlug = new Map(entities.map((entity) => [entity.slug, entity]))
+  return state.slugs
+    .map((slug) => bySlug.get(slug))
+    .filter((entity): entity is EntityRecord => Boolean(entity))
+}
+
+function parseIsoDay(value: string | null): number | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null
+  const [year, month, day] = value.split('-').map(Number)
+  const timestamp = Date.UTC(year, month - 1, day)
+  const date = new Date(timestamp)
+
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) return null
+
+  return timestamp
+}
+
+export function calculateLifespanDays(entity: EntityRecord): number | null {
+  const launch = parseIsoDay(entity.launch_date)
+  const death = parseIsoDay(entity.death_date)
+  if (launch === null || death === null || death < launch) return null
+  return Math.floor((death - launch) / 86_400_000)
+}
+
+export function isComparisonReady(state: CompareState): boolean {
+  return state.slugs.length >= COMPARE_MIN && state.slugs.length <= COMPARE_MAX
+}


### PR DESCRIPTION
## Roadmap item

Phase H — Compare v1

H-2 — Compare route, reviewed selector, normalized URL state, and core identity/lifecycle matrix.

## Specification sources

- `docs/HEI_COMPARE_V1_SPEC.md`
- `config/compare-v1-contract.json`
- `docs/HEI_V1_EXECUTION_ROADMAP.md`
- `docs/HEI_PRODUCT_SURFACES_SPEC.md`

## Summary

Implements the first public Compare surface over reviewed public HEI entities.

Added:

```text
src/app/compare/page.tsx
src/components/compare/compare-client.tsx
src/components/compare/compare-client.module.css
src/lib/compare/compare-state.ts
```

Implemented behavior:

- public `/compare/` route;
- reviewed-public entity selector backed by `loadEntities()` aggregation;
- 2–4 entity comparison limit;
- repeated `exchange=<slug>` URL state;
- selection-order preservation;
- invalid/unknown slug exclusion;
- duplicate slug deduplication;
- fifth-and-later reviewed selection truncation;
- add/remove controls with normalized shareable state;
- identity rows;
- launch date;
- terminal date from reviewed `death_date` only;
- deterministic UTC-day lifespan;
- direct dossier links;
- explicit empty/one-selection states;
- compact horizontally scrollable comparison matrix on small screens.

## Canonical count impact

None.

```text
Entities: 550
Events:   1004
Evidence: 2621
```

## Deployment impact

Public output changes by adding `/compare/`.

Cloudflare preview: not automatically available under current policy and not required for intermediate commits. GitHub CI/build validation is required before merge.

Production verification plan after merge/deploy:

1. verify `/version.json` reports the expected main commit;
2. verify `/compare/` returns the generated page;
3. verify a representative 2-entity query resolves the same ordered comparison state;
4. verify unknown and duplicate slugs do not create extra comparison columns.

## Validation plan

- Next.js production build;
- existing CI and `public:validate` coverage;
- reviewed-public aggregation source preserved;
- no canonical data changes;
- no monitoring/staging/candidate data exposed.

## Deferred to H-3

- status/death-reason/origin/confidence rows;
- URL/archive safety rows;
- event/evidence counts;
- deterministic selected major events.

## Deferred to H-4/H-5

- broader discovery/navigation integration;
- share affordance polish;
- sitemap/canonical audit expansion;
- final accessibility/responsive/regression/production audit.