### PR TITLE
Complete Compare v1 depth with archive coverage and major events

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,7 +1,10 @@
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import CompareClient from '../../components/compare/compare-client'
+import { buildCompareContext } from '../../lib/compare/compare-context'
 import { loadEntities } from '../../lib/data/load-entities'
+import { loadEvents } from '../../lib/data/load-events'
+import { loadEvidence } from '../../lib/data/load-evidence'
 import { SITE_NAME, SITE_URL } from '../../lib/site-constants'
 
 export function generateMetadata(): Metadata {
@@ -31,6 +34,9 @@ export function generateMetadata(): Metadata {
 
 export default function ComparePage() {
   const entities = loadEntities()
+  const events = loadEvents()
+  const evidence = loadEvidence()
+  const context = buildCompareContext(entities, events, evidence)
 
   const collectionJsonLd = {
     '@context': 'https://schema.org',
@@ -52,14 +58,14 @@ export default function ComparePage() {
             <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>Research layer</p>
             <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>Compare</h2>
             <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '72ch' }}>
-              Inspect reviewed exchange identity and lifecycle facts side by side. Compare uses reviewed public records and deterministic derived values only.
+              Inspect reviewed exchange identity, lifecycle, archive state, coverage, and major events side by side. Compare uses reviewed public records and deterministic derived values only.
             </p>
           </div>
         </div>
       </section>
 
       <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>Loading comparison state…</div></div></section>}>
-        <CompareClient entities={entities} />
+        <CompareClient entities={entities} context={context} />
       </Suspense>
     </main>
   )

--- a/src/components/compare/compare-client.module.css
+++ b/src/components/compare/compare-client.module.css
@@ -148,6 +148,88 @@
   font-weight: 400;
 }
 
+.majorEventsSection {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border-top: 1px solid var(--line-soft);
+  background: rgba(255, 255, 255, 0.008);
+}
+
+.sectionHeading {
+  display: grid;
+  gap: 5px;
+}
+
+.sectionHeading strong {
+  font-size: 15px;
+  letter-spacing: -0.02em;
+}
+
+.sectionHeading span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.majorEventsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.majorEventsColumn {
+  min-width: 0;
+  border: 1px solid var(--line-soft);
+  border-radius: 14px;
+  background: var(--panel-2);
+  overflow: hidden;
+}
+
+.majorEventsTitle {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.eventList {
+  display: grid;
+}
+
+.eventItem {
+  display: grid;
+  gap: 7px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.eventItem:last-child {
+  border-bottom: 0;
+}
+
+.eventMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.eventTitle {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.noEvents {
+  padding: 14px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
 .emptyState {
   display: grid;
   gap: 8px;
@@ -190,5 +272,9 @@
 
   .matrix th:first-child {
     width: 128px;
+  }
+
+  .majorEventsSection {
+    padding: 16px;
   }
 }

--- a/src/components/compare/compare-client.tsx
+++ b/src/components/compare/compare-client.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import type { EntityRecord } from '../../lib/types/entity'
+import type { CompareContextMap, CompareEntityContext } from '../../lib/compare/compare-context'
 import {
   COMPARE_MAX,
   calculateLifespanDays,
@@ -13,16 +13,34 @@ import {
   serializeCompareState,
   type CompareState,
 } from '../../lib/compare/compare-state'
+import type { EntityRecord } from '../../lib/types/entity'
+import { DEATH_REASON_LABELS } from '../../lib/utils/death-reason-meta'
 import { formatDate } from '../../lib/utils/format-date'
+import { STATUS_LABELS } from '../../lib/utils/status-meta'
+import { URL_STATUS_LABELS } from '../../lib/utils/url-meta'
 import styles from './compare-client.module.css'
 
 type Props = {
   entities: EntityRecord[]
+  context: CompareContextMap
 }
 
 type Row = {
   label: string
-  render: (entity: EntityRecord) => React.ReactNode
+  render: (entity: EntityRecord, entityContext: CompareEntityContext) => ReactNode
+}
+
+const EMPTY_CONTEXT: CompareEntityContext = {
+  event_count: 0,
+  evidence_count: 0,
+  selected_major_events: [],
+}
+
+function titleCase(value: string): string {
+  return value
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
 }
 
 const rows: Row[] = [
@@ -46,6 +64,46 @@ const rows: Row[] = [
     },
   },
   {
+    label: 'Status',
+    render: (entity) => <span className={`chip ${entity.status}`}>{STATUS_LABELS[entity.status]}</span>,
+  },
+  {
+    label: 'Death reason',
+    render: (entity) => entity.death_reason
+      ? <span className="chip reason">{DEATH_REASON_LABELS[entity.death_reason]}</span>
+      : <span className="muted">Unknown / not applicable</span>,
+  },
+  {
+    label: 'Country / origin',
+    render: (entity) => entity.country_or_origin ?? <span className="muted">Unknown</span>,
+  },
+  {
+    label: 'Confidence',
+    render: (entity) => titleCase(entity.confidence),
+  },
+  {
+    label: 'Original domain',
+    render: (entity) => entity.official_domain_original ?? <span className="muted">Unknown</span>,
+  },
+  {
+    label: 'URL status',
+    render: (entity) => URL_STATUS_LABELS[entity.official_url_status],
+  },
+  {
+    label: 'Archive',
+    render: (entity) => entity.archived_url
+      ? <a className="archive-link" href={entity.archived_url} target="_blank" rel="noreferrer">View archive</a>
+      : <span className="muted">No reviewed archive URL</span>,
+  },
+  {
+    label: 'Reviewed events',
+    render: (_entity, entityContext) => entityContext.event_count.toLocaleString(),
+  },
+  {
+    label: 'Reviewed evidence',
+    render: (_entity, entityContext) => entityContext.evidence_count.toLocaleString(),
+  },
+  {
     label: 'Record',
     render: (entity) => <Link className="subtle-link" href={`/exchange/${entity.slug}/`}>Open dossier</Link>,
   },
@@ -56,7 +114,7 @@ function buildUrl(pathname: string, state: CompareState): string {
   return query ? `${pathname}?${query}` : pathname
 }
 
-export default function CompareClient({ entities }: Props) {
+export default function CompareClient({ entities, context }: Props) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -150,31 +208,68 @@ export default function CompareClient({ entities }: Props) {
       </div>
 
       {ready ? (
-        <div className={styles.matrixScroller}>
-          <table className={styles.matrix}>
-            <thead>
-              <tr>
-                <th scope="col">Field</th>
-                {selectedEntities.map((entity) => (
-                  <th scope="col" key={entity.id}>
-                    <div className={styles.entityHeading}>
-                      <Link className="subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link>
-                      <span>{entity.slug}</span>
-                    </div>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr key={row.label}>
-                  <th scope="row">{row.label}</th>
-                  {selectedEntities.map((entity) => <td key={entity.id}>{row.render(entity)}</td>)}
+        <>
+          <div className={styles.matrixScroller}>
+            <table className={styles.matrix}>
+              <thead>
+                <tr>
+                  <th scope="col">Field</th>
+                  {selectedEntities.map((entity) => (
+                    <th scope="col" key={entity.id}>
+                      <div className={styles.entityHeading}>
+                        <Link className="subtle-link" href={`/exchange/${entity.slug}/`}>{entity.canonical_name}</Link>
+                        <span>{entity.slug}</span>
+                      </div>
+                    </th>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.label}>
+                    <th scope="row">{row.label}</th>
+                    {selectedEntities.map((entity) => (
+                      <td key={entity.id}>{row.render(entity, context[entity.slug] ?? EMPTY_CONTEXT)}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className={styles.majorEventsSection}>
+            <div className={styles.sectionHeading}>
+              <strong>Selected major events</strong>
+              <span>Up to five reviewed events per entity, selected by the fixed deterministic Compare contract.</span>
+            </div>
+            <div className={styles.majorEventsGrid}>
+              {selectedEntities.map((entity) => {
+                const majorEvents = (context[entity.slug] ?? EMPTY_CONTEXT).selected_major_events
+                return (
+                  <article className={styles.majorEventsColumn} key={entity.id}>
+                    <div className={styles.majorEventsTitle}>{entity.canonical_name}</div>
+                    {majorEvents.length === 0 ? (
+                      <div className={styles.noEvents}>No reviewed high-impact or explicit major event is available for this record.</div>
+                    ) : (
+                      <div className={styles.eventList}>
+                        {majorEvents.map((event) => (
+                          <div className={styles.eventItem} key={event.id}>
+                            <div className={styles.eventMeta}>
+                              <span>{formatDate(event.event_date)}</span>
+                              <span className="chip reason">{titleCase(event.event_type)}</span>
+                              <span>{titleCase(event.impact_level)}</span>
+                            </div>
+                            <div className={styles.eventTitle}>{event.title}</div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </article>
+                )
+              })}
+            </div>
+          </div>
+        </>
       ) : (
         <div className={styles.emptyState}>
           <strong>Comparison not ready</strong>

--- a/src/lib/compare/compare-context.ts
+++ b/src/lib/compare/compare-context.ts
@@ -1,0 +1,112 @@
+import type { EntityRecord } from '../types/entity'
+import type { EventRecord } from '../types/event'
+import type { EvidenceRecord } from '../types/evidence'
+
+export type CompareMajorEvent = Pick<
+  EventRecord,
+  'id' | 'event_type' | 'event_date' | 'title' | 'impact_level' | 'sort_order'
+>
+
+export type CompareEntityContext = {
+  event_count: number
+  evidence_count: number
+  selected_major_events: CompareMajorEvent[]
+}
+
+export type CompareContextMap = Record<string, CompareEntityContext>
+
+type MajorEventCapable = EventRecord & {
+  is_major_event?: boolean
+}
+
+const IMPACT_PRIORITY: Record<EventRecord['impact_level'], number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+}
+
+function isMajorEventCandidate(event: MajorEventCapable): boolean {
+  return event.is_major_event === true
+    || event.impact_level === 'critical'
+    || event.impact_level === 'high'
+}
+
+function compareSelectionPriority(a: MajorEventCapable, b: MajorEventCapable): number {
+  const explicitMajor = Number(b.is_major_event === true) - Number(a.is_major_event === true)
+  if (explicitMajor !== 0) return explicitMajor
+
+  const impact = IMPACT_PRIORITY[a.impact_level] - IMPACT_PRIORITY[b.impact_level]
+  if (impact !== 0) return impact
+
+  const aKnown = Boolean(a.event_date)
+  const bKnown = Boolean(b.event_date)
+  if (aKnown !== bKnown) return aKnown ? -1 : 1
+
+  if (a.event_date !== b.event_date) {
+    return (b.event_date ?? '').localeCompare(a.event_date ?? '')
+  }
+
+  if (a.sort_order !== b.sort_order) return b.sort_order - a.sort_order
+  return a.id.localeCompare(b.id)
+}
+
+function compareDisplayOrder(a: EventRecord, b: EventRecord): number {
+  const aKnown = Boolean(a.event_date)
+  const bKnown = Boolean(b.event_date)
+  if (aKnown !== bKnown) return aKnown ? -1 : 1
+
+  if (a.event_date !== b.event_date) {
+    return (a.event_date ?? '').localeCompare(b.event_date ?? '')
+  }
+
+  if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order
+  return a.id.localeCompare(b.id)
+}
+
+export function selectCompareMajorEvents(events: EventRecord[], limit = 5): CompareMajorEvent[] {
+  return events
+    .filter((event) => isMajorEventCandidate(event))
+    .sort(compareSelectionPriority)
+    .slice(0, limit)
+    .sort(compareDisplayOrder)
+    .map((event) => ({
+      id: event.id,
+      event_type: event.event_type,
+      event_date: event.event_date,
+      title: event.title,
+      impact_level: event.impact_level,
+      sort_order: event.sort_order,
+    }))
+}
+
+export function buildCompareContext(
+  entities: EntityRecord[],
+  events: EventRecord[],
+  evidence: EvidenceRecord[],
+): CompareContextMap {
+  const eventsByEntity = new Map<string, EventRecord[]>()
+  const evidenceCountByEntity = new Map<string, number>()
+
+  for (const event of events) {
+    const current = eventsByEntity.get(event.exchange_id) ?? []
+    current.push(event)
+    eventsByEntity.set(event.exchange_id, current)
+  }
+
+  for (const source of evidence) {
+    evidenceCountByEntity.set(
+      source.exchange_id,
+      (evidenceCountByEntity.get(source.exchange_id) ?? 0) + 1,
+    )
+  }
+
+  return Object.fromEntries(entities.map((entity) => {
+    const entityEvents = eventsByEntity.get(entity.id) ?? []
+    return [entity.slug, {
+      event_count: entityEvents.length,
+      evidence_count: evidenceCountByEntity.get(entity.id) ?? 0,
+      selected_major_events: selectCompareMajorEvents(entityEvents),
+    }]
+  }))
+}


### PR DESCRIPTION
## Roadmap item

Phase H — Compare v1

H-3 — Status/origin, URL/archive safety, reviewed coverage counts, and selected major events.

## Specification sources

- `docs/HEI_COMPARE_V1_SPEC.md`
- `config/compare-v1-contract.json`
- `docs/HEI_PRODUCT_SURFACES_SPEC.md`

## Summary

Extends the public Compare surface from core identity/lifecycle comparison into the full reviewed comparison depth required by H-3.

Added:

```text
src/lib/compare/compare-context.ts
```

Updated:

```text
src/app/compare/page.tsx
src/components/compare/compare-client.tsx
src/components/compare/compare-client.module.css
```

Implemented comparison rows:

- status;
- death reason;
- country / origin;
- confidence;
- original domain as text;
- URL status;
- safe archive action from reviewed `archived_url`;
- reviewed event count;
- reviewed evidence count.

Implemented deterministic selected major events:

- candidate if explicit `is_major_event === true`, or impact is `critical` / `high`;
- explicit major first;
- critical before high;
- known dates before unknown;
- newer dates first for selection priority;
- higher sort order first;
- ID as deterministic tie-break;
- maximum 5 selected per entity;
- selected events displayed chronologically.

## Reviewed-public boundary

- entity universe still comes from `loadEntities()` reviewed aggregation;
- events come from `loadEvents()` reviewed aggregation;
- evidence counts come from `loadEvidence()` reviewed aggregation;
- raw monitoring, watchlists, staging, and unmerged candidates are not used;
- full evidence records are not sent to the client; server-side aggregation exports only counts and selected reviewed event summaries.

## URL safety

Compare does not create direct original-URL actions. Original domain is informational text, URL status is shown explicitly, and the public external action is the reviewed archive URL when present. This does not weaken the existing dossier URL-safety policy.

## Canonical count impact

None.

```text
Entities: 550
Events:   1004
Evidence: 2621
```

## Deployment impact

Public `/compare/` output changes.

GitHub CI/build/public validation are required before merge. Production verification after deployment begins with `/version.json` commit identity and then checks representative 2-entity and 4-entity comparison queries.

## Validation plan

- production Next.js build;
- existing `public:validate`;
- machine/public consistency gate;
- cross-surface integration gate;
- accessibility gate;
- reviewed-public aggregation preservation;
- deterministic major-event ordering review.

## Next item after merge

H-4 — share flow, dossier/Explorer discovery links, and public navigation integration.