### PR TITLE
Verify Compare v1 production deployment

### DIFF
--- a/.github/workflows/compare-production-verification.yml
+++ b/.github/workflows/compare-production-verification.yml
@@ -1,0 +1,34 @@
+name: Compare production verification
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/verify-compare-production.mjs'
+      - '.github/workflows/compare-production-verification.yml'
+      - 'docs/audits/HEI_H5_COMPARE_PRODUCTION_VERIFICATION_*.md'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Verify deployed H-5 Compare integration
+        env:
+          HEI_EXPECTED_PRODUCTION_COMMIT: 9fb3e1a3bda0c51ce59af364402a98a86736bcb1
+          HEI_PRODUCTION_ORIGIN: https://hei.badjoke-lab.com
+        run: node scripts/verify-compare-production.mjs | tee compare-production-verification.json
+
+      - name: Upload Compare production verification report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compare-production-verification-report
+          path: compare-production-verification.json
+          if-no-files-found: warn

--- a/scripts/verify-compare-production.mjs
+++ b/scripts/verify-compare-production.mjs
@@ -1,0 +1,103 @@
+const origin = process.env.HEI_PRODUCTION_ORIGIN || 'https://hei.badjoke-lab.com'
+const expectedCommit = process.env.HEI_EXPECTED_PRODUCTION_COMMIT
+
+if (!expectedCommit) {
+  throw new Error('HEI_EXPECTED_PRODUCTION_COMMIT is required')
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function fetchText(pathname) {
+  const response = await fetch(`${origin}${pathname}`, {
+    headers: { 'user-agent': 'HEI-Compare-Production-Verification/1.0' },
+    redirect: 'follow',
+  })
+  if (!response.ok) throw new Error(`${pathname} returned HTTP ${response.status}`)
+  return response.text()
+}
+
+async function fetchJson(pathname) {
+  return JSON.parse(await fetchText(pathname))
+}
+
+async function waitForExpectedCommit() {
+  let lastCommit = null
+  for (let attempt = 1; attempt <= 30; attempt += 1) {
+    const version = await fetchJson('/version.json')
+    lastCommit = version.build?.commit ?? null
+    console.log(`commit propagation attempt ${attempt}: ${lastCommit}`)
+    if (lastCommit === expectedCommit) return version
+    await sleep(10_000)
+  }
+  throw new Error(`production commit mismatch after polling: expected ${expectedCommit}, got ${lastCommit}`)
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Compare production verification failed: ${message}`)
+}
+
+const version = await waitForExpectedCommit()
+const manifest = await fetchJson('/data/manifest.json')
+const entitiesFile = await fetchJson('/data/entities.json')
+const sitemap = await fetchText('/sitemap.xml')
+const llms = await fetchText('/llms.txt')
+const ai = await fetchText('/ai.txt')
+const compareBase = await fetchText('/compare/')
+const explorer = await fetchText('/explore/')
+
+const records = entitiesFile.records ?? []
+assert(records.length >= 4, 'public reviewed entity dataset has fewer than four records')
+const sample = records.slice(0, 4)
+const slugs = sample.map((record) => record.slug)
+const names = sample.map((record) => record.canonical_name)
+
+const query2 = `/compare/?exchange=${encodeURIComponent(slugs[0])}&exchange=${encodeURIComponent(slugs[1])}`
+const query4 = `/compare/?${slugs.map((slug) => `exchange=${encodeURIComponent(slug)}`).join('&')}`
+const compare2 = await fetchText(query2)
+const compare4 = await fetchText(query4)
+const dossier = await fetchText(`/exchange/${encodeURIComponent(slugs[0])}/`)
+
+assert(version.build?.commit === expectedCommit, 'version commit does not match expected H-5 merge commit')
+assert(version.routes?.compare === '/compare/', 'version route map does not expose Compare')
+assert(manifest.main_routes?.includes('/compare/'), 'manifest main_routes does not expose Compare')
+assert(llms.includes('/compare/'), 'llms.txt does not expose Compare')
+assert(ai.includes('/compare/'), 'ai.txt does not expose Compare')
+
+assert(compareBase.includes('Compare'), 'Compare base route does not contain Compare surface marker')
+assert(compare2.includes('Compare'), 'representative 2-entity Compare query does not return Compare surface')
+assert(compare4.includes('Compare'), 'representative 4-entity Compare query does not return Compare surface')
+
+const compareBaseUrl = `${origin}/compare/`
+const compareLocMatches = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)]
+  .map((match) => match[1])
+  .filter((url) => url === compareBaseUrl)
+assert(compareLocMatches.length === 1, `sitemap Compare base count is ${compareLocMatches.length}, expected 1`)
+assert(!sitemap.includes('/compare/?'), 'sitemap contains Compare query variant')
+
+assert(dossier.includes('/compare/?exchange='), 'representative dossier does not expose Compare handoff')
+assert(explorer.includes('/compare/'), 'Explorer does not expose Compare discovery link')
+
+const report = {
+  expected_commit: expectedCommit,
+  deployed_commit: version.build.commit,
+  result: 'PASS',
+  verified_at: new Date().toISOString(),
+  origin,
+  routes: {
+    compare_base: 'PASS',
+    compare_query_2: 'PASS',
+    compare_query_4: 'PASS',
+    representative_dossier_handoff: 'PASS',
+    explorer_discovery: 'PASS',
+  },
+  discovery: {
+    version: 'PASS',
+    manifest: 'PASS',
+    llms: 'PASS',
+    ai: 'PASS',
+    sitemap: 'PASS',
+  },
+  sample: { slugs, names },
+}
+
+console.log(JSON.stringify(report, null, 2))


### PR DESCRIPTION
## Roadmap item

Phase H — Compare v1

Post-H-5 production verification against the merged H-5 main commit.

## Expected deployed commit

```text
9fb3e1a3bda0c51ce59af364402a98a86736bcb1
```

## Summary

Adds a Compare-specific live production verification script and GitHub Actions gate.

The verifier polls production `/version.json` until the expected H-5 main commit is deployed, then checks:

- `/compare/` base route;
- representative 2-entity query URL;
- representative 4-entity query URL;
- `/sitemap.xml` contains `/compare/` exactly once and no query variants;
- `/version.json` exposes `routes.compare`;
- `/data/manifest.json` exposes `/compare/` in `main_routes`;
- `/llms.txt` and `/ai.txt` expose `/compare/`;
- a representative dossier exposes a Compare handoff;
- `/explore/` exposes Compare discovery.

The sample comparison slugs are selected from the deployed reviewed public entity dataset rather than hard-coded candidate data.

## Canonical count impact

None.

## Deployment impact

No public UI or canonical data changes. This PR adds verification tooling/workflow only and uses `[CF-Pages-Skip]` commits.

## Completion rule

Phase H is not marked complete until this production verification passes against the expected H-5 merge commit. After PASS, a completion checkpoint PR will record the result and advance the active roadmap item to D-750 Reviewed Entity Milestone.