### PR TITLE
Add L-1 Japanese Pilot activation safety gate

### DIFF
--- a/.github/workflows/japanese-pilot-readiness-gate.yml
+++ b/.github/workflows/japanese-pilot-readiness-gate.yml
@@ -1,0 +1,39 @@
+name: Japanese Pilot readiness gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test Japanese Pilot readiness validator
+        run: node scripts/validate-japanese-pilot-readiness.mjs --self-test
+
+      - name: Build machine-readable layer
+        run: npm run machine:build
+
+      - name: Build public site
+        run: npm run build
+
+      - name: Validate Japanese Pilot readiness and activation safety
+        run: node scripts/validate-japanese-pilot-readiness.mjs

--- a/config/japanese-pilot-route-contract.json
+++ b/config/japanese-pilot-route-contract.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "locale": "ja",
+  "path_prefix": "/ja/",
+  "minimum_reviewed_entities": 750,
+  "completion_audit_path": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
+  "required_static_routes": [
+    "/ja/",
+    "/ja/dead/",
+    "/ja/active/",
+    "/ja/about/",
+    "/ja/methodology/",
+    "/ja/stats/",
+    "/ja/quality/",
+    "/ja/explore/",
+    "/ja/updates/",
+    "/ja/incidents/",
+    "/ja/monthly/"
+  ],
+  "required_dynamic_route": "/ja/exchange/[slug]/",
+  "representative_exchange_slug": "mt-gox",
+  "required_metadata": {
+    "html_lang": "ja",
+    "canonical_prefix": "https://hei.badjoke-lab.com/ja/",
+    "alternate_locales": ["en", "ja"],
+    "og_locale": "ja_JP"
+  },
+  "sitemap": {
+    "include_static_routes": true,
+    "include_all_reviewed_exchange_routes": true,
+    "exclude_query_variants": true
+  },
+  "fallback": {
+    "default_locale": "en",
+    "record_copy_fallback": "en",
+    "canonical_facts_single_source": true
+  }
+}

--- a/docs/HEI_L1_JAPANESE_PILOT_IMPLEMENTATION_PLAN.md
+++ b/docs/HEI_L1_JAPANESE_PILOT_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,272 @@
+# HEI L-1 Japanese Pilot Implementation Plan
+
+Status: active implementation plan  
+Project: Historical Exchange Index (HEI)  
+Entry gate: D-750 Reviewed Entity Milestone COMPLETE
+
+## 1. Objective
+
+Implement the first public Japanese pilot without creating a second factual registry, weakening English fallback, or exposing incomplete `/ja/` route families.
+
+The pilot follows:
+
+```text
+canonical reviewed facts
+        ↓
+shared locale-independent identity and query state
+        ↓
+Japanese UI dictionary and optional copy overlays
+        ↓
+Japanese route shell
+        ↓
+activation gate
+        ↓
+public pilot
+```
+
+Canonical facts remain single-source. Japanese record-copy overlays are optional presentation copy only.
+
+## 2. Fixed pilot route scope
+
+```text
+/ja/
+/ja/dead/
+/ja/active/
+/ja/about/
+/ja/methodology/
+/ja/stats/
+/ja/quality/
+/ja/explore/
+/ja/updates/
+/ja/incidents/
+/ja/monthly/
+/ja/exchange/[slug]/
+```
+
+The pilot does not require complete Japanese translation of all record summaries or events.
+
+## 3. Safety rule
+
+Japanese routes must not become public merely because a locale is listed as supported.
+
+Activation requires all of the following in one reviewed public state:
+
+```text
+D-750 completion evidence exists
+reviewed entity count >= 750
+Japanese route family complete
+Japanese dossier count == reviewed entity count
+html lang=ja on representative Japanese output
+locale-specific canonical URLs
+reciprocal en/ja hreflang
+og:locale=ja_JP
+Japanese static routes in sitemap
+all reviewed Japanese dossier routes in sitemap
+no query variants in sitemap
+English fallback preserved
+canonical facts single-source
+```
+
+`config/japanese-pilot-route-contract.json` and `scripts/validate-japanese-pilot-readiness.mjs` are the activation safety contract.
+
+## 4. Static-export language handling
+
+HEI uses Next.js static export. The current root layout emits `<html lang="en">`.
+
+L-1 must not publish Japanese pages with an English document language declaration.
+
+The implementation should preserve the existing static-export architecture and use a deterministic localized-output step for Japanese output if route-level Next.js layout structure cannot emit the correct document language directly without a broad route-tree migration.
+
+Any localized-output step must be:
+
+- deterministic;
+- build-time only;
+- limited to Japanese output paths;
+- validated by the Japanese Pilot readiness gate;
+- unable to alter canonical factual JSON;
+- covered by a self-test.
+
+A broad route-group migration is not required for the pilot unless the smaller static-export approach proves unsafe or unmaintainable.
+
+## 5. Implementation sequence
+
+### L1-1 — Activation contract and gate
+
+Deliver:
+
+```text
+Japanese route contract
+D-750 prerequisite check
+pre-activation leak check
+public activation route checks
+html lang check
+canonical check
+hreflang check
+Open Graph locale check
+sitemap coverage check
+Japanese dossier-count check
+CI gate
+```
+
+No Japanese route is activated in this step.
+
+### L1-2 — Shared localized shell and dictionary coverage
+
+Deliver reusable locale-aware presentation components without publishing `/ja/` routes yet:
+
+```text
+locale-aware header/navigation/footer
+language-switch model
+page-label helpers
+required Japanese UI dictionary expansion
+Compare handoff behavior decision for pilot routes
+accessibility labels
+URL-safety labels
+```
+
+English output must remain unchanged.
+
+### L1-3 — Locale-aware page renderers
+
+Prepare reusable Japanese rendering inputs for:
+
+```text
+Home
+Dead
+Active
+About
+Methodology
+Stats
+Quality
+Explorer
+Updates
+Incidents
+Monthly
+Exchange dossier
+```
+
+This step should reuse reviewed canonical data and English fallback rather than fork data loading.
+
+### L1-4 — Route shell, metadata, sitemap, and activation
+
+Deliver the full route family and activate Japanese public routing in one reviewed change only after the readiness gate can pass.
+
+Required:
+
+```text
+public locale activation
+all required /ja/ routes
+all reviewed /ja/exchange/[slug]/ routes
+html lang=ja
+locale canonical metadata
+en/ja reciprocal hreflang
+og:locale=ja_JP
+sitemap integration
+language switcher
+public navigation integration
+machine/public consistency review
+accessibility review
+URL-safety review
+```
+
+Partial route-family publication is prohibited.
+
+### L1-5 — Controlled optional record-copy sample
+
+After route activation is stable, add optional Japanese copy overlays in reviewed batches.
+
+Priority may include:
+
+```text
+up to 100 dead-side entity summaries
+up to 50 active-side entity summaries
+selected major event titles/descriptions
+```
+
+Missing overlays continue to fall back to canonical English copy.
+
+## 6. Compare scope
+
+The fixed L-1 pilot route list does not require `/ja/compare/`.
+
+During the pilot:
+
+- Japanese navigation must not imply that a Japanese Compare route exists unless implemented;
+- a Japanese surface may link to the reviewed English Compare route with clear locale behavior;
+- Compare selection keys and exchange slugs remain locale-independent;
+- adding `/ja/compare/` requires a separate reviewed scope decision and localization coverage.
+
+## 7. Validation strategy
+
+L-1 validation is layered:
+
+```text
+F-1 foundation validation
+        +
+Japanese Pilot readiness gate
+        +
+normal CI/public build validation
+        +
+URL safety
+        +
+machine/public consistency
+        +
+accessibility
+```
+
+The Japanese readiness gate has two states:
+
+### Pre-activation
+
+Pass only when:
+
+- D-750 completion evidence exists;
+- ja remains a supported pilot locale;
+- no built Japanese root is exposed before activation;
+- route and metadata contract is internally valid.
+
+### Public activation
+
+Pass only when:
+
+- ja is a public locale;
+- all contracted static routes exist;
+- Japanese dossier count matches reviewed entity count;
+- representative pages have correct locale metadata;
+- sitemap coverage is complete and query-safe.
+
+## 8. Non-goals
+
+L-1 does not include:
+
+```text
+full translation of all 750+ records
+translation of evidence titles
+translation of publisher names
+translation of canonical names by default
+Japanese canonical factual forks
+third-language work
+automatic machine translation into canonical data
+stopping reviewed data growth
+```
+
+## 9. Completion handoff
+
+After L-1 is public and stable, collect evidence for L-2:
+
+```text
+Japanese search impressions and clicks
+indexing state
+Japanese landing-page distribution
+language-switch use
+localized navigation depth
+Explorer/Stats/Quality usage
+exchange dossier transitions
+fallback frequency
+broken locale links
+translation synchronization burden
+operator QA burden
+CI/localization failure rate
+```
+
+L-2 decides GO / HOLD / PIVOT. It does not authorize a third language.

--- a/scripts/validate-japanese-pilot-readiness.mjs
+++ b/scripts/validate-japanese-pilot-readiness.mjs
@@ -1,0 +1,152 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const root = process.cwd()
+const selfTest = process.argv.includes('--self-test')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Japanese Pilot readiness validation failed: ${message}`)
+}
+
+function readJson(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function normalizeRoute(route) {
+  assert(typeof route === 'string' && route.startsWith('/'), `invalid route: ${route}`)
+  if (route === '/') return '/'
+  return route.endsWith('/') ? route : `${route}/`
+}
+
+function routeToOutFile(route) {
+  const normalized = normalizeRoute(route)
+  if (normalized === '/') return path.join(root, 'out', 'index.html')
+  return path.join(root, 'out', normalized.slice(1), 'index.html')
+}
+
+function hasHtmlLang(html, lang) {
+  return new RegExp(`<html[^>]*\\blang=["']${lang}["']`, 'i').test(html)
+}
+
+function hasCanonical(html, href) {
+  const tags = [...html.matchAll(/<link\b[^>]*>/gi)].map((match) => match[0])
+  return tags.some((tag) => /\brel=["']canonical["']/i.test(tag) && tag.includes(`href="${href}"`) || /\brel=["']canonical["']/i.test(tag) && tag.includes(`href='${href}'`))
+}
+
+function hasHreflang(html, locale) {
+  const tags = [...html.matchAll(/<link\b[^>]*>/gi)].map((match) => match[0])
+  return tags.some((tag) => new RegExp(`\\bhreflang=["']${locale}["']`, 'i').test(tag) && /\brel=["']alternate["']/i.test(tag))
+}
+
+function hasOgLocale(html, locale) {
+  const tags = [...html.matchAll(/<meta\b[^>]*>/gi)].map((match) => match[0])
+  return tags.some((tag) => /\bproperty=["']og:locale["']/i.test(tag) && new RegExp(`\\bcontent=["']${locale}["']`, 'i').test(tag))
+}
+
+function countExchangeDetailPages(exchangeRoot) {
+  if (!fs.existsSync(exchangeRoot)) return 0
+  return fs.readdirSync(exchangeRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && fs.existsSync(path.join(exchangeRoot, entry.name, 'index.html')))
+    .length
+}
+
+function runSelfTest() {
+  assert(normalizeRoute('/ja') === '/ja/', 'route normalization failed')
+  assert(normalizeRoute('/ja/dead/') === '/ja/dead/', 'normalized route changed unexpectedly')
+  assert(routeToOutFile('/ja/').endsWith(path.join('out', 'ja', 'index.html')), 'Japanese root output mapping failed')
+  assert(routeToOutFile('/ja/dead/').endsWith(path.join('out', 'ja', 'dead', 'index.html')), 'Japanese nested output mapping failed')
+
+  const sample = '<html lang="ja"><head><link rel="canonical" href="https://hei.badjoke-lab.com/ja/"><link rel="alternate" hreflang="en" href="https://hei.badjoke-lab.com/"><link rel="alternate" hreflang="ja" href="https://hei.badjoke-lab.com/ja/"><meta property="og:locale" content="ja_JP"></head></html>'
+  assert(hasHtmlLang(sample, 'ja'), 'HTML lang detection failed')
+  assert(hasCanonical(sample, 'https://hei.badjoke-lab.com/ja/'), 'canonical detection failed')
+  assert(hasHreflang(sample, 'en') && hasHreflang(sample, 'ja'), 'hreflang detection failed')
+  assert(hasOgLocale(sample, 'ja_JP'), 'Open Graph locale detection failed')
+
+  console.log('Japanese Pilot readiness self-test: pass')
+}
+
+if (selfTest) {
+  runSelfTest()
+  process.exit(0)
+}
+
+const contract = readJson('config/japanese-pilot-route-contract.json')
+const localeConfig = readJson('config/i18n-locales.json')
+
+assert(contract.version === 1, 'contract version must be 1')
+assert(contract.locale === 'ja', 'pilot locale must be ja')
+assert(contract.path_prefix === '/ja/', 'pilot path prefix must be /ja/')
+assert(contract.minimum_reviewed_entities >= 750, 'minimum reviewed entity gate must be at least 750')
+assert(Array.isArray(contract.required_static_routes) && contract.required_static_routes.length === 11, 'required static route set must contain 11 routes')
+assert(new Set(contract.required_static_routes).size === contract.required_static_routes.length, 'required static routes contain duplicates')
+assert(contract.required_static_routes.every((route) => normalizeRoute(route).startsWith('/ja/')), 'all required static routes must use /ja/ prefix')
+assert(contract.required_dynamic_route === '/ja/exchange/[slug]/', 'dynamic exchange route contract mismatch')
+assert(contract.representative_exchange_slug, 'representative exchange slug is required')
+assert(fs.existsSync(path.join(root, contract.completion_audit_path)), 'D-750 completion audit is missing')
+
+assert(localeConfig.default_locale === contract.fallback.default_locale, 'default locale mismatch')
+assert(localeConfig.fallback_locale === contract.fallback.record_copy_fallback, 'record-copy fallback mismatch')
+assert(localeConfig.supported_locales.includes(contract.locale), 'Japanese locale is not supported')
+assert(localeConfig.pilot_locales.includes(contract.locale), 'Japanese locale is not registered as pilot')
+
+const activated = localeConfig.public_locales.includes(contract.locale)
+const jaOutputRoot = path.join(root, 'out', 'ja')
+
+if (!activated) {
+  assert(!fs.existsSync(path.join(jaOutputRoot, 'index.html')), 'Japanese root was built before pilot activation')
+  console.log(`Japanese Pilot readiness: pre-activation pass; ${contract.required_static_routes.length} static routes + exchange dossier family remain gated.`)
+  process.exit(0)
+}
+
+const manifest = readJson('out/data/manifest.json')
+const reviewedEntities = manifest?.record_counts?.primary_records
+assert(Number.isInteger(reviewedEntities), 'built manifest reviewed entity count is missing')
+assert(reviewedEntities >= contract.minimum_reviewed_entities, `reviewed entity gate not met: ${reviewedEntities}`)
+
+for (const route of contract.required_static_routes) {
+  const filePath = routeToOutFile(route)
+  assert(fs.existsSync(filePath), `missing built Japanese route: ${route}`)
+}
+
+const representativeRoute = `/ja/exchange/${contract.representative_exchange_slug}/`
+const representativeFile = routeToOutFile(representativeRoute)
+assert(fs.existsSync(representativeFile), `missing representative Japanese exchange route: ${representativeRoute}`)
+
+const jaExchangeRoot = path.join(root, 'out', 'ja', 'exchange')
+const jaDetailPages = countExchangeDetailPages(jaExchangeRoot)
+assert(jaDetailPages === reviewedEntities, `Japanese exchange detail route count mismatch: ${jaDetailPages} != ${reviewedEntities}`)
+
+const representativeChecks = [
+  { route: '/ja/', file: routeToOutFile('/ja/') },
+  { route: '/ja/methodology/', file: routeToOutFile('/ja/methodology/') },
+  { route: representativeRoute, file: representativeFile },
+]
+
+for (const item of representativeChecks) {
+  const html = fs.readFileSync(item.file, 'utf8')
+  const canonical = `https://hei.badjoke-lab.com${item.route}`
+  assert(hasHtmlLang(html, contract.required_metadata.html_lang), `${item.route}: html lang is not ja`)
+  assert(hasCanonical(html, canonical), `${item.route}: canonical mismatch`)
+  for (const locale of contract.required_metadata.alternate_locales) {
+    assert(hasHreflang(html, locale), `${item.route}: missing hreflang ${locale}`)
+  }
+  assert(hasOgLocale(html, contract.required_metadata.og_locale), `${item.route}: Open Graph locale mismatch`)
+}
+
+const sitemapPath = path.join(root, 'out', 'sitemap.xml')
+assert(fs.existsSync(sitemapPath), 'missing built sitemap')
+const sitemap = fs.readFileSync(sitemapPath, 'utf8')
+const locations = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])
+assert(!locations.some((location) => location.includes('?')), 'sitemap contains query variants')
+
+for (const route of contract.required_static_routes) {
+  assert(locations.includes(`https://hei.badjoke-lab.com${route}`), `sitemap missing Japanese route: ${route}`)
+}
+
+const jaEntityLocations = locations.filter((location) => location.includes('/ja/exchange/'))
+assert(jaEntityLocations.length === reviewedEntities, `Japanese sitemap entity route count mismatch: ${jaEntityLocations.length} != ${reviewedEntities}`)
+
+console.log(`Japanese Pilot readiness: public activation pass; ${reviewedEntities} reviewed entities, ${contract.required_static_routes.length} static Japanese routes, ${jaDetailPages} Japanese dossier routes.`)


### PR DESCRIPTION
## Roadmap item

L-1 Japanese Pilot — activation safety foundation.

## Summary

Adds the first L-1 implementation unit after D-750 completion:

```text
Japanese Pilot route contract
D-750 prerequisite check
pre-activation leak guard
public activation route checks
html lang=ja validation
canonical validation
reciprocal en/ja hreflang validation
og:locale=ja_JP validation
sitemap coverage validation
Japanese dossier-count validation
CI workflow gate
staged L-1 implementation plan
```

## Safety model

Before ja is public, the gate verifies:

- D-750 completion evidence exists;
- ja remains a supported pilot locale;
- Japanese public root output is not accidentally built;
- the activation contract is internally valid.

After ja becomes a public locale, the same gate requires:

- all contracted Japanese static routes;
- Japanese dossier count equal to reviewed entity count;
- reviewed entity count >= 750;
- representative pages with `html lang=ja`;
- locale-specific canonical URLs;
- reciprocal English/Japanese hreflang;
- `og:locale=ja_JP`;
- Japanese static and dossier sitemap coverage;
- no query-variant sitemap entries.

## Fixed route scope

```text
/ja/
/ja/dead/
/ja/active/
/ja/about/
/ja/methodology/
/ja/stats/
/ja/quality/
/ja/explore/
/ja/updates/
/ja/incidents/
/ja/monthly/
/ja/exchange/[slug]/
```

## Implementation sequence

The new plan fixes:

```text
L1-1 activation contract and gate
L1-2 shared localized shell and dictionary coverage
L1-3 locale-aware page renderers
L1-4 route shell + metadata + sitemap + activation
L1-5 controlled optional record-copy sample
```

No Japanese route is activated in this PR.

## Files

```text
config/japanese-pilot-route-contract.json
scripts/validate-japanese-pilot-readiness.mjs
.github/workflows/japanese-pilot-readiness-gate.yml
docs/HEI_L1_JAPANESE_PILOT_IMPLEMENTATION_PLAN.md
```

## Deployment impact

No Japanese public route activation. No canonical data change. No Cloudflare configuration change. This PR adds contract, validation, workflow, and implementation-plan infrastructure only.