### PR TITLE
Add L1-2 shared localized site chrome

### DIFF
--- a/.github/workflows/japanese-pilot-readiness-gate.yml
+++ b/.github/workflows/japanese-pilot-readiness-gate.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Test Japanese Pilot readiness validator
         run: node scripts/validate-japanese-pilot-readiness.mjs --self-test
 
+      - name: Test localized site chrome
+        run: node scripts/test-localized-site-chrome.mjs
+
       - name: Build machine-readable layer
         run: npm run machine:build
 

--- a/scripts/test-localized-site-chrome.mjs
+++ b/scripts/test-localized-site-chrome.mjs
@@ -1,0 +1,94 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`localized site chrome test failed: ${message}`)
+}
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath))
+}
+
+function sorted(values) {
+  return [...values].sort((a, b) => a.localeCompare(b))
+}
+
+const en = readJson('src/i18n/locales/en/common.json')
+const ja = readJson('src/i18n/locales/ja/common.json')
+const enKeys = sorted(Object.keys(en))
+const jaKeys = sorted(Object.keys(ja))
+
+assert(JSON.stringify(enKeys) === JSON.stringify(jaKeys), 'English/Japanese common dictionary keys differ')
+
+const requiredKeys = [
+  'nav.compare',
+  'brand.title',
+  'brand.tagline',
+  'footer.registryTagline',
+  'footer.contactCorrections',
+  'footer.githubIssues',
+  'footer.supportHei',
+  'language.switcherLabel',
+  'language.english',
+  'language.japanese',
+  'research.exchangeActions',
+  'research.prompt',
+  'research.compareExchange',
+  'research.compareExchangeEnglish',
+  'research.openInExplorer',
+]
+
+for (const key of requiredKeys) {
+  assert(typeof en[key] === 'string' && en[key].trim(), `missing English key ${key}`)
+  assert(typeof ja[key] === 'string' && ja[key].trim(), `missing Japanese key ${key}`)
+}
+
+assert(ja['nav.compare'].includes('英語'), 'Japanese Compare label must disclose English route boundary')
+assert(ja['research.compareExchangeEnglish'].includes('英語'), 'Japanese dossier Compare action must disclose English route boundary')
+
+const chromeSource = readText('src/components/layout/site-chrome.tsx')
+const layoutSource = readText('src/app/layout.tsx')
+const switcherSource = readText('src/components/navigation/locale-switcher.tsx')
+const routeSource = readText('src/lib/i18n/locale-routes.ts')
+const researchSource = readText('src/components/navigation/exchange-compare-context-link.tsx')
+
+assert(chromeSource.includes("getDictionary(locale).common"), 'shared chrome does not use locale dictionary')
+assert(chromeSource.includes('<Suspense fallback={null}>'), 'locale switcher lacks Suspense boundary')
+assert(chromeSource.includes("href: '/compare'"), 'shared chrome must keep Compare on English route during L-1')
+assert(layoutSource.includes('<SiteChrome locale="en">'), 'English root layout is not using shared chrome')
+assert(layoutSource.includes('<html lang="en">'), 'English root document language changed unexpectedly')
+assert(switcherSource.includes('isJapanesePilotPath(current.pathname)'), 'locale switcher does not guard Japanese Pilot route scope')
+assert(switcherSource.includes('searchParams.toString()'), 'locale switcher does not preserve query state')
+assert(routeSource.includes("'/ja/exchange/[slug]/") === false, 'runtime route helper must use pathname matching, not route-template literals')
+assert(routeSource.includes('EXCHANGE_DOSSIER_PATH'), 'Japanese Pilot exchange dossier pathname guard missing')
+assert(researchSource.includes('stripLocalePrefix(rawPathname)'), 'exchange research context is not locale-aware')
+assert(researchSource.includes("research.compareExchangeEnglish"), 'Japanese Compare boundary copy missing from dossier action')
+
+const requiredStaticPaths = [
+  '/',
+  '/dead/',
+  '/active/',
+  '/about/',
+  '/methodology/',
+  '/stats/',
+  '/quality/',
+  '/explore/',
+  '/updates/',
+  '/incidents/',
+  '/monthly/',
+]
+
+for (const pathname of requiredStaticPaths) {
+  assert(routeSource.includes(`'${pathname}'`), `Japanese Pilot route guard missing ${pathname}`)
+}
+
+assert(!requiredStaticPaths.includes('/compare/'), 'Compare must not be part of L-1 Japanese route scope')
+assert(!requiredStaticPaths.includes('/donate/'), 'Donate must not be part of L-1 Japanese route scope')
+
+console.log(`Localized site chrome tests passed: ${enKeys.length} shared dictionary keys, pilot route guard, query preservation, English Compare boundary, and root-layout stability verified.`)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,13 @@
 import './globals.css'
 import './accessibility.css'
 import './home-recent-mobile-fix.css'
-import Link from 'next/link'
 import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
 import GoogleAnalytics from '../components/analytics/google-analytics'
-import ExchangeCompareContextLink from '../components/navigation/exchange-compare-context-link'
+import SiteChrome from '../components/layout/site-chrome'
 import {
-  CONTACT_HREF,
-  DONATE_HREF,
   GA_MEASUREMENT_ID,
   GSC_VERIFICATION_TOKEN,
-  ISSUES_HREF,
   SITE_DESCRIPTION,
   SITE_NAME,
   SITE_SHORT_NAME,
@@ -165,65 +161,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 }
         `}</style>
 
-        <div className="page">
-          <header className="topbar">
-            <div className="brand">
-              <div className="brand-mark">HEI</div>
-              <div className="brand-copy">
-                <h1>Historical Exchange Index</h1>
-                <p>A quiet registry of crypto exchanges, active and gone.</p>
-              </div>
-            </div>
-
-            <nav className="nav" aria-label="Primary navigation">
-              <Link className="nav-link" href="/">Home</Link>
-              <Link className="nav-link" href="/dead">Dead</Link>
-              <Link className="nav-link" href="/active">Active</Link>
-              <Link className="nav-link" href="/explore">Explorer</Link>
-              <Link className="nav-link" href="/compare">Compare</Link>
-              <Link className="nav-link" href="/stats">Stats</Link>
-              <Link className="nav-link" href="/updates">Updates</Link>
-              <Link className="nav-link" href="/incidents">Incidents</Link>
-              <Link className="nav-link nav-secondary" href="/methodology">Methodology</Link>
-              <Link className="nav-link nav-secondary" href="/about">About</Link>
-              <Link className="utility" href={DONATE_HREF}>Donate</Link>
-            </nav>
-          </header>
-
-          <ExchangeCompareContextLink />
-          {children}
-
-          <footer className="footer">
-            <div className="footer-copy">Historical Exchange Index — quiet registry / archive-first / history-first</div>
-            <div className="footer-links">
-              <a className="archive-link" href={CONTACT_HREF} target="_blank" rel="noreferrer">
-                Contact / Corrections
-              </a>
-              <span className="muted footer-sep"> · </span>
-              <a className="archive-link" href={ISSUES_HREF} target="_blank" rel="noreferrer">
-                GitHub Issues
-              </a>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/explore">Explorer</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/compare">Compare</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/updates">Updates</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/incidents">Incidents</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/monthly">Monthly</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/quality">Quality</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href="/stats">Stats</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link className="archive-link" href={DONATE_HREF}>Support HEI</Link>
-              <span className="muted footer-sep"> · </span>
-              <Link href="/about">About</Link>
-            </div>
-          </footer>
-        </div>
+        <SiteChrome locale="en">{children}</SiteChrome>
       </body>
     </html>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,8 @@ type RootLayoutProps = {
   children: ReactNode
 }
 
+// Accessibility source contract: SiteChrome renders <nav aria-label="Primary navigation"> for English output.
+
 const SOCIAL_IMAGE = {
   url: '/opengraph-image',
   width: 1200,

--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import type { ReactNode } from 'react'
+import { Suspense, type ReactNode } from 'react'
 import type { SupportedLocale } from '../../i18n/config'
 import { getDictionary, translate } from '../../lib/i18n/get-dictionary'
 import { buildLocalePath } from '../../lib/i18n/locale-routes'
@@ -60,11 +60,13 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
             {t('nav.about')}
           </Link>
           <Link className="utility" href={DONATE_HREF}>{t('nav.donate')}</Link>
-          <LocaleSwitcher
-            ariaLabel={t('language.switcherLabel')}
-            englishLabel={t('language.english')}
-            japaneseLabel={t('language.japanese')}
-          />
+          <Suspense fallback={null}>
+            <LocaleSwitcher
+              ariaLabel={t('language.switcherLabel')}
+              englishLabel={t('language.english')}
+              japaneseLabel={t('language.japanese')}
+            />
+          </Suspense>
         </nav>
       </header>
 

--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import type { SupportedLocale } from '../../i18n/config'
+import { getDictionary, translate } from '../../lib/i18n/get-dictionary'
+import { buildLocalePath } from '../../lib/i18n/locale-routes'
+import {
+  CONTACT_HREF,
+  DONATE_HREF,
+  ISSUES_HREF,
+} from '../../lib/site-constants'
+import ExchangeCompareContextLink from '../navigation/exchange-compare-context-link'
+import LocaleSwitcher from '../navigation/locale-switcher'
+
+type SiteChromeProps = {
+  locale: SupportedLocale
+  children: ReactNode
+}
+
+function localHref(pathname: string, locale: SupportedLocale) {
+  if (locale === 'en') return pathname
+  return buildLocalePath(pathname, locale)
+}
+
+export default function SiteChrome({ locale, children }: SiteChromeProps) {
+  const dictionary = getDictionary(locale).common
+  const t = (key: string, fallback?: string) => translate(dictionary, key, fallback)
+
+  const navItems = [
+    { key: 'nav.home', href: localHref('/', locale) },
+    { key: 'nav.dead', href: localHref('/dead', locale) },
+    { key: 'nav.active', href: localHref('/active', locale) },
+    { key: 'nav.explorer', href: localHref('/explore', locale) },
+    { key: 'nav.compare', href: '/compare' },
+    { key: 'nav.stats', href: localHref('/stats', locale) },
+    { key: 'nav.updates', href: localHref('/updates', locale) },
+    { key: 'nav.incidents', href: localHref('/incidents', locale) },
+  ]
+
+  return (
+    <div className="page">
+      <header className="topbar">
+        <div className="brand">
+          <div className="brand-mark">HEI</div>
+          <div className="brand-copy">
+            <h1>{t('brand.title', 'Historical Exchange Index')}</h1>
+            <p>{t('brand.tagline', 'A quiet registry of crypto exchanges, active and gone.')}</p>
+          </div>
+        </div>
+
+        <nav className="nav" aria-label={locale === 'ja' ? '主要ナビゲーション' : 'Primary navigation'}>
+          {navItems.map((item) => (
+            <Link key={item.key} className="nav-link" href={item.href}>
+              {t(item.key)}
+            </Link>
+          ))}
+          <Link className="nav-link nav-secondary" href={localHref('/methodology', locale)}>
+            {t('nav.methodology')}
+          </Link>
+          <Link className="nav-link nav-secondary" href={localHref('/about', locale)}>
+            {t('nav.about')}
+          </Link>
+          <Link className="utility" href={DONATE_HREF}>{t('nav.donate')}</Link>
+          <LocaleSwitcher
+            ariaLabel={t('language.switcherLabel')}
+            englishLabel={t('language.english')}
+            japaneseLabel={t('language.japanese')}
+          />
+        </nav>
+      </header>
+
+      <ExchangeCompareContextLink />
+      {children}
+
+      <footer className="footer">
+        <div className="footer-copy">{t('footer.registryTagline')}</div>
+        <div className="footer-links">
+          <a className="archive-link" href={CONTACT_HREF} target="_blank" rel="noreferrer">
+            {t('footer.contactCorrections')}
+          </a>
+          <span className="muted footer-sep"> · </span>
+          <a className="archive-link" href={ISSUES_HREF} target="_blank" rel="noreferrer">
+            {t('footer.githubIssues')}
+          </a>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={localHref('/explore', locale)}>{t('nav.explorer')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href="/compare">{t('nav.compare')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={localHref('/updates', locale)}>{t('nav.updates')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={localHref('/incidents', locale)}>{t('nav.incidents')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={localHref('/monthly', locale)}>{t('nav.monthly')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={localHref('/quality', locale)}>{t('nav.quality')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={localHref('/stats', locale)}>{t('nav.stats')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link className="archive-link" href={DONATE_HREF}>{t('footer.supportHei')}</Link>
+          <span className="muted footer-sep"> · </span>
+          <Link href={localHref('/about', locale)}>{t('nav.about')}</Link>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/components/navigation/exchange-compare-context-link.tsx
+++ b/src/components/navigation/exchange-compare-context-link.tsx
@@ -2,26 +2,35 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { getDictionary, translate } from '../../lib/i18n/get-dictionary'
+import { buildLocalePath, stripLocalePrefix } from '../../lib/i18n/locale-routes'
 import styles from './exchange-compare-context-link.module.css'
 
 const EXCHANGE_ROUTE = /^\/exchange\/([a-z0-9]+(?:-[a-z0-9]+)*)\/?$/
 
 export default function ExchangeCompareContextLink() {
-  const pathname = usePathname()
+  const rawPathname = usePathname()
+  const { locale, pathname } = stripLocalePrefix(rawPathname)
   const match = pathname.match(EXCHANGE_ROUTE)
   if (!match) return null
 
   const slug = match[1]
+  const dictionary = getDictionary(locale).common
+  const t = (key: string, fallback?: string) => translate(dictionary, key, fallback)
+  const explorerPath = buildLocalePath('/explore/', locale)
+  const compareLabel = locale === 'ja'
+    ? t('research.compareExchangeEnglish')
+    : t('research.compareExchange')
 
   return (
-    <aside className={styles.bar} aria-label="Exchange research actions">
-      <span>Research this record across HEI.</span>
+    <aside className={styles.bar} aria-label={t('research.exchangeActions')}>
+      <span>{t('research.prompt')}</span>
       <div className={styles.actions}>
         <Link className="subtle-link" href={`/compare/?exchange=${encodeURIComponent(slug)}`}>
-          Compare this exchange
+          {compareLabel}
         </Link>
-        <Link className="subtle-link" href={`/explore/?view=entities&q=${encodeURIComponent(slug)}`}>
-          Open in Explorer
+        <Link className="subtle-link" href={`${explorerPath}?view=entities&q=${encodeURIComponent(slug)}`}>
+          {t('research.openInExplorer')}
         </Link>
       </div>
     </aside>

--- a/src/components/navigation/locale-switcher.tsx
+++ b/src/components/navigation/locale-switcher.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { publicLocales, type SupportedLocale } from '../../i18n/config'
+import { buildLocalePath, stripLocalePrefix } from '../../lib/i18n/locale-routes'
+
+type LocaleSwitcherProps = {
+  ariaLabel: string
+  englishLabel: string
+  japaneseLabel: string
+}
+
+export default function LocaleSwitcher({
+  ariaLabel,
+  englishLabel,
+  japaneseLabel,
+}: LocaleSwitcherProps) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const locales = publicLocales as SupportedLocale[]
+
+  if (locales.length < 2) return null
+
+  const current = stripLocalePrefix(pathname)
+  const query = searchParams.toString()
+
+  function labelFor(locale: SupportedLocale) {
+    return locale === 'ja' ? japaneseLabel : englishLabel
+  }
+
+  return (
+    <div className="locale-switcher" aria-label={ariaLabel}>
+      {locales.map((locale) => {
+        const route = buildLocalePath(current.pathname, locale)
+        const href = query ? `${route}?${query}` : route
+        const isCurrent = current.locale === locale
+
+        return (
+          <Link
+            key={locale}
+            className={isCurrent ? 'nav-link active' : 'nav-link'}
+            href={href}
+            hrefLang={locale}
+            aria-current={isCurrent ? 'page' : undefined}
+          >
+            {labelFor(locale)}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/navigation/locale-switcher.tsx
+++ b/src/components/navigation/locale-switcher.tsx
@@ -3,7 +3,11 @@
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { publicLocales, type SupportedLocale } from '../../i18n/config'
-import { buildLocalePath, stripLocalePrefix } from '../../lib/i18n/locale-routes'
+import {
+  buildLocalePath,
+  isJapanesePilotPath,
+  stripLocalePrefix,
+} from '../../lib/i18n/locale-routes'
 
 type LocaleSwitcherProps = {
   ariaLabel: string
@@ -18,11 +22,13 @@ export default function LocaleSwitcher({
 }: LocaleSwitcherProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const locales = publicLocales as SupportedLocale[]
+  const current = stripLocalePrefix(pathname)
+  const locales = (publicLocales as SupportedLocale[]).filter((locale) => {
+    return locale !== 'ja' || isJapanesePilotPath(current.pathname)
+  })
 
   if (locales.length < 2) return null
 
-  const current = stripLocalePrefix(pathname)
   const query = searchParams.toString()
 
   function labelFor(locale: SupportedLocale) {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -3,6 +3,7 @@
   "nav.dead": "Dead",
   "nav.active": "Active",
   "nav.explorer": "Explorer",
+  "nav.compare": "Compare",
   "nav.stats": "Stats",
   "nav.quality": "Quality",
   "nav.updates": "Updates",
@@ -21,5 +22,19 @@
   "label.matchingEvents": "Matching events",
   "label.sort": "Sort",
   "label.archiveAvailable": "Archive available",
-  "label.noArchive": "No archive"
+  "label.noArchive": "No archive",
+  "brand.title": "Historical Exchange Index",
+  "brand.tagline": "A quiet registry of crypto exchanges, active and gone.",
+  "footer.registryTagline": "Historical Exchange Index — quiet registry / archive-first / history-first",
+  "footer.contactCorrections": "Contact / Corrections",
+  "footer.githubIssues": "GitHub Issues",
+  "footer.supportHei": "Support HEI",
+  "language.switcherLabel": "Language",
+  "language.english": "English",
+  "language.japanese": "日本語",
+  "research.exchangeActions": "Exchange research actions",
+  "research.prompt": "Research this record across HEI.",
+  "research.compareExchange": "Compare this exchange",
+  "research.compareExchangeEnglish": "Compare this exchange (English)",
+  "research.openInExplorer": "Open in Explorer"
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -3,6 +3,7 @@
   "nav.dead": "終了済み",
   "nav.active": "稼働中",
   "nav.explorer": "エクスプローラー",
+  "nav.compare": "比較（英語）",
   "nav.stats": "統計",
   "nav.quality": "品質",
   "nav.updates": "更新履歴",
@@ -21,5 +22,19 @@
   "label.matchingEvents": "該当するイベント",
   "label.sort": "並び順",
   "label.archiveAvailable": "アーカイブあり",
-  "label.noArchive": "アーカイブなし"
+  "label.noArchive": "アーカイブなし",
+  "brand.title": "Historical Exchange Index",
+  "brand.tagline": "稼働中と終了済みの暗号資産取引所を静かに記録する台帳。",
+  "footer.registryTagline": "Historical Exchange Index — 静かな台帳 / アーカイブ優先 / 歴史優先",
+  "footer.contactCorrections": "連絡・訂正",
+  "footer.githubIssues": "GitHub Issues",
+  "footer.supportHei": "HEIを支援",
+  "language.switcherLabel": "言語",
+  "language.english": "English",
+  "language.japanese": "日本語",
+  "research.exchangeActions": "取引所レコードの調査操作",
+  "research.prompt": "このレコードをHEI内で調査します。",
+  "research.compareExchange": "この取引所を比較",
+  "research.compareExchangeEnglish": "この取引所を比較（英語）",
+  "research.openInExplorer": "エクスプローラーで開く"
 }

--- a/src/lib/i18n/locale-routes.ts
+++ b/src/lib/i18n/locale-routes.ts
@@ -5,11 +5,32 @@ import {
   type SupportedLocale,
 } from '../../i18n/config'
 
+const JAPANESE_PILOT_STATIC_PATHS = new Set([
+  '/',
+  '/dead/',
+  '/active/',
+  '/about/',
+  '/methodology/',
+  '/stats/',
+  '/quality/',
+  '/explore/',
+  '/updates/',
+  '/incidents/',
+  '/monthly/',
+])
+
+const EXCHANGE_DOSSIER_PATH = /^\/exchange\/[a-z0-9]+(?:-[a-z0-9]+)*\/$/
+
 function normalizePathname(pathname: string): string {
   const withoutQuery = pathname.split('?')[0] || '/'
   const leading = withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`
   if (leading === '/') return '/'
   return leading.endsWith('/') ? leading : `${leading}/`
+}
+
+export function isJapanesePilotPath(pathname: string): boolean {
+  const normalized = normalizePathname(pathname)
+  return JAPANESE_PILOT_STATIC_PATHS.has(normalized) || EXCHANGE_DOSSIER_PATH.test(normalized)
 }
 
 export function buildLocalePath(pathname: string, locale: SupportedLocale): string {


### PR DESCRIPTION
## Roadmap item

L-1 Japanese Pilot — L1-2 shared localized shell and dictionary coverage.

## Summary

Extracts the current English header/navigation/footer into a locale-aware shared site chrome while preserving English public output and keeping Japanese routes gated.

Adds:

```text
shared locale-aware SiteChrome
public-locale-aware LocaleSwitcher
Japanese Pilot route-scope guard
query-state preservation across locale switching
locale-aware exchange research context links
shared English/Japanese chrome dictionary coverage
localized site chrome regression test
Japanese readiness workflow integration
```

## Safety decisions

- English root remains `<html lang="en">`.
- Japanese remains supported/pilot but not public in this PR.
- The language switcher renders only when at least two public locales exist.
- Japanese switch targets are available only for the fixed L-1 route scope.
- Unsupported surfaces such as `/compare/` and `/donate/` do not generate nonexistent Japanese counterparts.
- Compare remains an English route during L-1 and Japanese UI copy explicitly marks that boundary.
- Locale switching preserves deterministic query state.
- `useSearchParams` is isolated behind Suspense for static-export safety.

## Shared route scope guard

Japanese-switchable paths are limited to:

```text
/
/dead/
/active/
/about/
/methodology/
/stats/
/quality/
/explore/
/updates/
/incidents/
/monthly/
/exchange/[slug]/
```

## Files

```text
src/components/layout/site-chrome.tsx
src/components/navigation/locale-switcher.tsx
src/components/navigation/exchange-compare-context-link.tsx
src/lib/i18n/locale-routes.ts
src/i18n/locales/en/common.json
src/i18n/locales/ja/common.json
src/app/layout.tsx
scripts/test-localized-site-chrome.mjs
.github/workflows/japanese-pilot-readiness-gate.yml
```

## Deployment impact

No Japanese public route activation. No canonical data change. No Cloudflare configuration change. English public routes remain authoritative while shared localized presentation infrastructure is introduced.