### PR TITLE
Connect L1 page presentations to public renderers

### DIFF
--- a/.github/workflows/japanese-pilot-readiness-gate.yml
+++ b/.github/workflows/japanese-pilot-readiness-gate.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Test page presentation foundation
         run: node scripts/test-page-presentation-foundation.mjs
 
+      - name: Test page presentation connections
+        run: node scripts/test-page-presentation-connections.mjs
+
       - name: Build machine-readable layer
         run: npm run machine:build
 

--- a/scripts/test-page-presentation-connections.mjs
+++ b/scripts/test-page-presentation-connections.mjs
@@ -1,0 +1,46 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`page presentation connection test failed: ${message}`)
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+const home = read('src/app/page.tsx')
+const dead = read('src/app/dead/page.tsx')
+const active = read('src/app/active/page.tsx')
+const about = read('src/app/about/page.tsx')
+const header = read('src/components/layout/localized-page-header.tsx')
+
+assert(home.includes("getPagePresentation('en', 'home')"), 'home metadata is not connected to page presentation data')
+assert(home.includes("buildLocalizedPageMetadata({"), 'home metadata helper connection missing')
+
+for (const [name, source, pageKey] of [
+  ['dead', dead, 'dead'],
+  ['active', active, 'active'],
+  ['about', about, 'about'],
+]) {
+  assert(source.includes(`getPagePresentation('en', '${pageKey}')`), `${name} presentation lookup missing`)
+  assert(source.includes('buildLocalizedPageMetadata({'), `${name} localized metadata helper missing`)
+  assert(source.includes('<LocalizedPageHeader'), `${name} shared localized page header missing`)
+}
+
+assert(dead.includes('name: presentation.heading'), 'dead JSON-LD name is not presentation-backed')
+assert(dead.includes('description: presentation.description'), 'dead JSON-LD description is not presentation-backed')
+assert(active.includes('name: presentation.heading'), 'active JSON-LD name is not presentation-backed')
+assert(active.includes('description: presentation.description'), 'active JSON-LD description is not presentation-backed')
+
+for (const field of ['presentation.eyebrow', 'presentation.heading', 'presentation.intro']) {
+  assert(header.includes(field), `shared header missing ${field}`)
+}
+
+assert(!dead.includes('>Dead-side registry</h2>'), 'dead page still contains duplicated hardcoded page heading')
+assert(!active.includes('>Active-side registry</h2>'), 'active page still contains duplicated hardcoded page heading')
+assert(!about.includes('>Why Historical Exchange Index exists</h2>'), 'about page still contains duplicated hardcoded page heading')
+
+console.log('Page presentation connection tests passed: home metadata plus dead, active, and about renderer connections verified.')

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,31 +1,25 @@
 import type { Metadata } from 'next'
+import LocalizedPageHeader from '../../components/layout/localized-page-header'
+import {
+  buildLocalizedPageMetadata,
+  getPagePresentation,
+} from '../../lib/i18n/page-presentations'
 import { CONTACT_HREF, ISSUES_HREF } from '../../lib/site-constants'
 
-export const metadata: Metadata = {
-  title: 'About',
-  description:
-    'About Historical Exchange Index, a historical registry of crypto exchanges covering active, dead, merged, acquired, and rebranded exchange records.',
-  alternates: {
-    canonical: '/about',
-  },
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({
+    locale: 'en',
+    page: 'about',
+    pathname: '/about/',
+  })
 }
 
 export default function AboutPage() {
+  const presentation = getPagePresentation('en', 'about')
+
   return (
     <main className="longform">
-      <section className="panel longform-panel">
-        <p className="muted">About</p>
-        <h2 style={{ marginTop: 0, fontSize: '34px' }}>Why Historical Exchange Index exists</h2>
-        <p className="muted" style={{ lineHeight: 1.75, maxWidth: '82ch' }}>
-          Historical Exchange Index exists to keep crypto exchange identity, status shifts, major lifecycle events,
-          archived URLs, and supporting evidence in one place. The goal is not to hype current winners, but to
-          preserve a readable historical registry of crypto exchange history.
-        </p>
-        <p className="muted" style={{ lineHeight: 1.75, maxWidth: '82ch' }}>
-          Existing information is often split across live exchange lists, DEX trackers, news articles, shutdown notices,
-          archived pages, and exchange graveyards. HEI tries to bring those fragments into one structured registry view.
-        </p>
-      </section>
+      <LocalizedPageHeader presentation={presentation} />
 
       <section className="panel longform-panel">
         <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>

--- a/src/app/active/page.tsx
+++ b/src/app/active/page.tsx
@@ -1,7 +1,12 @@
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
+import LocalizedPageHeader from '../../components/layout/localized-page-header'
 import ActiveExplorerClient from '../../components/registry/active-explorer-client'
 import { loadEntities } from '../../lib/data/load-entities'
+import {
+  buildLocalizedPageMetadata,
+  getPagePresentation,
+} from '../../lib/i18n/page-presentations'
 import { CONTACT_HREF, SITE_NAME, SITE_URL } from '../../lib/site-constants'
 
 const ACTIVE_SIDE = new Set<string>(['active', 'limited', 'inactive'])
@@ -14,31 +19,18 @@ function loadActiveEntities() {
 
 export function generateMetadata(): Metadata {
   const total = loadActiveEntities().length
-  const description = `Browse ${total} active-side crypto exchange records, including active, limited, and inactive entries with URL handling and launch timing.`
-
-  return {
-    title: 'Active exchanges',
-    description,
-    alternates: { canonical: '/active' },
-    openGraph: {
-      type: 'website',
-      url: `${SITE_URL}/active/`,
-      title: `Active exchanges | ${SITE_NAME}`,
-      description,
-      siteName: SITE_NAME,
-      images: ['/opengraph-image'],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: `Active exchanges | ${SITE_NAME}`,
-      description,
-      images: ['/twitter-image'],
-    },
-  }
+  const presentation = getPagePresentation('en', 'active')
+  return buildLocalizedPageMetadata({
+    locale: 'en',
+    page: 'active',
+    pathname: '/active/',
+    descriptionOverride: `${presentation.description} Current reviewed active-side records: ${total}.`,
+  })
 }
 
 export default function ActivePage() {
   const entities = loadActiveEntities()
+  const presentation = getPagePresentation('en', 'active')
   const summary = {
     total: entities.length,
     active: entities.filter((item) => item.status === 'active').length,
@@ -54,8 +46,8 @@ export default function ActivePage() {
     '@type': 'CollectionPage',
     '@id': `${SITE_URL}/active/`,
     url: `${SITE_URL}/active/`,
-    name: 'Active-side exchange registry',
-    description: `Collection of ${summary.total} active-side crypto exchange records.`,
+    name: presentation.heading,
+    description: presentation.description,
     numberOfItems: summary.total,
     isPartOf: { '@type': 'WebSite', name: SITE_NAME, url: SITE_URL },
   }
@@ -66,36 +58,28 @@ export default function ActivePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
       />
-      <section className="panel longform-panel">
-        <div className="detail-header">
-          <div>
-            <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>Active Exchanges</p>
-            <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>Active-side registry</h2>
-            <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '64ch' }}>
-              Active, limited, and inactive-side entries. This page emphasizes active-side classification,
-              URL status clarity, and launch timing without turning the registry into a ranking page.
-            </p>
-            <p style={{ margin: '12px 0 0', fontWeight: 700 }}>
-              Active-side total: {summary.total}
-            </p>
-          </div>
-
-          <div className="hero-actions" style={{ marginTop: 0 }}>
-            <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">
-              Contact / corrections
-            </a>
-          </div>
-        </div>
-      </section>
+      <LocalizedPageHeader
+        presentation={presentation}
+        footer={(
+          <p style={{ margin: '12px 0 0', fontWeight: 700 }}>
+            Active-side total: {summary.total}
+          </p>
+        )}
+        actions={(
+          <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">
+            Contact / corrections
+          </a>
+        )}
+      />
 
       <Suspense
-        fallback={
+        fallback={(
           <section className="panel table-panel">
             <div className="results-meta">
               <div>Loading registry…</div>
             </div>
           </section>
-        }
+        )}
       >
         <ActiveExplorerClient entities={entities} summary={summary} />
       </Suspense>

--- a/src/app/dead/page.tsx
+++ b/src/app/dead/page.tsx
@@ -1,7 +1,12 @@
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
+import LocalizedPageHeader from '../../components/layout/localized-page-header'
 import DeadExplorerClient from '../../components/registry/dead-explorer-client'
 import { loadEntities } from '../../lib/data/load-entities'
+import {
+  buildLocalizedPageMetadata,
+  getPagePresentation,
+} from '../../lib/i18n/page-presentations'
 import { CONTACT_HREF, SITE_NAME, SITE_URL } from '../../lib/site-constants'
 
 const DEAD_SIDE = new Set<string>(['dead', 'merged', 'acquired', 'rebranded'])
@@ -19,31 +24,18 @@ function loadDeadEntities() {
 
 export function generateMetadata(): Metadata {
   const total = loadDeadEntities().length
-  const description = `Browse ${total} dead-side crypto exchange records, including dead, merged, acquired, and rebranded exchanges with archive-aware handling.`
-
-  return {
-    title: 'Dead exchanges',
-    description,
-    alternates: { canonical: '/dead' },
-    openGraph: {
-      type: 'website',
-      url: `${SITE_URL}/dead/`,
-      title: `Dead exchanges | ${SITE_NAME}`,
-      description,
-      siteName: SITE_NAME,
-      images: ['/opengraph-image'],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: `Dead exchanges | ${SITE_NAME}`,
-      description,
-      images: ['/twitter-image'],
-    },
-  }
+  const presentation = getPagePresentation('en', 'dead')
+  return buildLocalizedPageMetadata({
+    locale: 'en',
+    page: 'dead',
+    pathname: '/dead/',
+    descriptionOverride: `${presentation.description} Current reviewed dead-side records: ${total}.`,
+  })
 }
 
 export default function DeadPage() {
   const entities = loadDeadEntities()
+  const presentation = getPagePresentation('en', 'dead')
   const summary = {
     total: entities.length,
     dead: entities.filter((item) => item.status === 'dead').length,
@@ -59,8 +51,8 @@ export default function DeadPage() {
     '@type': 'CollectionPage',
     '@id': `${SITE_URL}/dead/`,
     url: `${SITE_URL}/dead/`,
-    name: 'Dead-side exchange registry',
-    description: `Collection of ${summary.total} dead-side crypto exchange records.`,
+    name: presentation.heading,
+    description: presentation.description,
     numberOfItems: summary.total,
     isPartOf: { '@type': 'WebSite', name: SITE_NAME, url: SITE_URL },
   }
@@ -71,36 +63,28 @@ export default function DeadPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionJsonLd) }}
       />
-      <section className="panel longform-panel">
-        <div className="detail-header">
-          <div>
-            <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>Dead Exchanges</p>
-            <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>Dead-side registry</h2>
-            <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '64ch' }}>
-              Closed, absorbed, rebranded, or otherwise gone exchanges. This page emphasizes death reason,
-              archive access, and dense graveyard browsing.
-            </p>
-            <p style={{ margin: '12px 0 0', fontWeight: 700 }}>
-              Dead-side total: {summary.total}
-            </p>
-          </div>
-
-          <div className="hero-actions" style={{ marginTop: 0 }}>
-            <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">
-              Contact / corrections
-            </a>
-          </div>
-        </div>
-      </section>
+      <LocalizedPageHeader
+        presentation={presentation}
+        footer={(
+          <p style={{ margin: '12px 0 0', fontWeight: 700 }}>
+            Dead-side total: {summary.total}
+          </p>
+        )}
+        actions={(
+          <a className="btn" href={CONTACT_HREF} target="_blank" rel="noreferrer">
+            Contact / corrections
+          </a>
+        )}
+      />
 
       <Suspense
-        fallback={
+        fallback={(
           <section className="panel table-panel">
             <div className="results-meta">
               <div>Loading registry…</div>
             </div>
           </section>
-        }
+        )}
       >
         <DeadExplorerClient entities={entities} summary={summary} />
       </Suspense>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,22 @@
 import type { Metadata } from 'next'
 import HomeHubClient from '../components/home/home-hub-client'
 import { buildRegistryView } from '../lib/data/build-registry-view'
+import {
+  buildLocalizedPageMetadata,
+  getPagePresentation,
+} from '../lib/i18n/page-presentations'
 import { SITE_NAME, SITE_URL } from '../lib/site-constants'
 
 export function generateMetadata(): Metadata {
   const { summary } = buildRegistryView()
-  const description = `Historical registry of ${summary.total} crypto exchanges: ${summary.deadSide} dead-side and ${summary.activeSide} active-side records, with timeline events and evidence.`
-
-  return {
-    title: SITE_NAME,
-    description,
-    alternates: { canonical: '/' },
-    openGraph: {
-      type: 'website',
-      url: SITE_URL,
-      title: SITE_NAME,
-      description,
-      siteName: SITE_NAME,
-      images: ['/opengraph-image'],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: SITE_NAME,
-      description,
-      images: ['/twitter-image'],
-    },
-  }
+  const presentation = getPagePresentation('en', 'home')
+  return buildLocalizedPageMetadata({
+    locale: 'en',
+    page: 'home',
+    pathname: '/',
+    titleOverride: SITE_NAME,
+    descriptionOverride: `${presentation.description} Current reviewed registry: ${summary.total} entities, ${summary.deadSide} dead-side and ${summary.activeSide} active-side.`,
+  })
 }
 
 export default function HomePage() {

--- a/src/components/layout/localized-page-header.tsx
+++ b/src/components/layout/localized-page-header.tsx
@@ -5,17 +5,15 @@ type LocalizedPageHeaderProps = {
   presentation: PagePresentation
   actions?: ReactNode
   footer?: ReactNode
-  compact?: boolean
 }
 
 export default function LocalizedPageHeader({
   presentation,
   actions,
   footer,
-  compact = false,
 }: LocalizedPageHeaderProps) {
   return (
-    <section className={compact ? 'panel longform-panel' : 'panel longform-panel'}>
+    <section className="panel longform-panel">
       <div className={actions ? 'detail-header' : undefined}>
         <div>
           <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>

--- a/src/components/layout/localized-page-header.tsx
+++ b/src/components/layout/localized-page-header.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+import type { PagePresentation } from '../../lib/i18n/page-presentations'
+
+type LocalizedPageHeaderProps = {
+  presentation: PagePresentation
+  actions?: ReactNode
+  footer?: ReactNode
+  compact?: boolean
+}
+
+export default function LocalizedPageHeader({
+  presentation,
+  actions,
+  footer,
+  compact = false,
+}: LocalizedPageHeaderProps) {
+  return (
+    <section className={compact ? 'panel longform-panel' : 'panel longform-panel'}>
+      <div className={actions ? 'detail-header' : undefined}>
+        <div>
+          <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>
+            {presentation.eyebrow}
+          </p>
+          <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>
+            {presentation.heading}
+          </h2>
+          <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '82ch' }}>
+            {presentation.intro}
+          </p>
+          {footer}
+        </div>
+        {actions ? <div className="hero-actions" style={{ marginTop: 0 }}>{actions}</div> : null}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Roadmap item

L-1 Japanese Pilot — connect locale-aware page presentation foundation to live English renderers before Japanese route activation.

## Summary

Connects the shared page presentation source to current public surfaces without activating `/ja/*` routes.

Connected in this PR:

```text
Home metadata
Dead page metadata + renderer header + JSON-LD
Active page metadata + renderer header + JSON-LD
About page metadata + renderer header
```

Adds a shared `LocalizedPageHeader` component for stable use by later Japanese route renderers.

## Safety decisions

- English remains the only public locale.
- No `/ja/*` route is activated.
- Canonical reviewed data remains unchanged.
- Dead and Active entity collections and filtering behavior remain unchanged.
- Registry counts remain data-derived.
- JSON-LD collection names/descriptions now use the same page presentation source as visible headings and metadata.
- Home metadata uses the localized metadata helper while keeping live reviewed counts in the description.

## Validation

Adds `scripts/test-page-presentation-connections.mjs` covering:

- Home metadata helper connection;
- Dead presentation lookup, metadata, shared header, and JSON-LD connection;
- Active presentation lookup, metadata, shared header, and JSON-LD connection;
- About presentation lookup, metadata, and shared header connection;
- removal of duplicated hardcoded primary headings;
- shared header use of eyebrow, heading, and intro presentation fields.

The Japanese Pilot readiness workflow runs the connection test before public build and activation validation.

## Files

```text
src/components/layout/localized-page-header.tsx
src/app/page.tsx
src/app/dead/page.tsx
src/app/active/page.tsx
src/app/about/page.tsx
scripts/test-page-presentation-connections.mjs
.github/workflows/japanese-pilot-readiness-gate.yml
```

## Next execution

After this passes and merges, continue L1-3 by connecting Methodology and the remaining product surfaces, then move to L1-4 Japanese route-shell implementation and activation validation.