### PR TITLE
Activate L-1 Japanese Pilot route shell

### DIFF
--- a/.github/workflows/japanese-pilot-readiness-gate.yml
+++ b/.github/workflows/japanese-pilot-readiness-gate.yml
@@ -41,11 +41,20 @@ jobs:
       - name: Test secondary page presentation connections
         run: node scripts/test-secondary-page-presentation-connections.mjs
 
+      - name: Test Japanese route shell source contract
+        run: node scripts/test-japanese-route-shell-source.mjs
+
+      - name: Test Japanese static HTML postprocessor
+        run: npm run i18n:static-html:test
+
       - name: Build machine-readable layer
         run: npm run machine:build
 
       - name: Build public site
         run: npm run build
 
-      - name: Validate Japanese Pilot readiness and activation safety
+      - name: Validate L1 i18n foundation
+        run: npm run i18n:validate
+
+      - name: Validate Japanese Pilot public activation
         run: node scripts/validate-japanese-pilot-readiness.mjs

--- a/config/i18n-locales.json
+++ b/config/i18n-locales.json
@@ -3,6 +3,6 @@
   "default_locale": "en",
   "fallback_locale": "en",
   "supported_locales": ["en", "ja"],
-  "public_locales": ["en"],
+  "public_locales": ["en", "ja"],
   "pilot_locales": ["ja"]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/localize-static-html.mjs",
     "start": "next start",
     "lint": "next lint",
     "policy:check": "node scripts/check-repository-operations-policy.mjs",
@@ -52,6 +52,7 @@
     "compare:test": "node scripts/audit-compare-v1.mjs --self-test",
     "i18n:validate": "node scripts/validate-i18n-foundation.mjs",
     "i18n:test": "node scripts/test-i18n-foundation.mjs",
+    "i18n:static-html:test": "node scripts/localize-static-html.mjs --self-test",
     "accessibility:audit": "node scripts/audit-public-accessibility.mjs",
     "accessibility:test": "node scripts/audit-public-accessibility.mjs --self-test",
     "url-safety:audit": "node scripts/audit-public-url-safety.mjs",

--- a/scripts/audit-sitemap-canonical-routes.mjs
+++ b/scripts/audit-sitemap-canonical-routes.mjs
@@ -22,6 +22,20 @@ const STATIC_ROUTES = [
   '/donate/',
 ]
 
+const JAPANESE_STATIC_ROUTES = [
+  '/ja/',
+  '/ja/dead/',
+  '/ja/active/',
+  '/ja/explore/',
+  '/ja/stats/',
+  '/ja/quality/',
+  '/ja/updates/',
+  '/ja/incidents/',
+  '/ja/monthly/',
+  '/ja/methodology/',
+  '/ja/about/',
+]
+
 const OBSOLETE_PREFIXES = ['/all', '/registry', '/exchanges']
 const FEED_URLS = [`${origin}/feeds/updates.json`, `${origin}/feeds/updates.xml`]
 
@@ -64,7 +78,9 @@ function routeOutputFile(url, outDir) {
 function expectedUrls(publicEntities) {
   const staticUrls = STATIC_ROUTES.map((route) => `${origin}${route}`)
   const entityUrls = publicEntities.records.map((entity) => `${origin}/exchange/${entity.slug}/`)
-  return [...staticUrls, ...entityUrls]
+  const japaneseStaticUrls = JAPANESE_STATIC_ROUTES.map((route) => `${origin}${route}`)
+  const japaneseEntityUrls = publicEntities.records.map((entity) => `${origin}/ja/exchange/${entity.slug}/`)
+  return [...staticUrls, ...entityUrls, ...japaneseStaticUrls, ...japaneseEntityUrls]
 }
 
 function sorted(values) {
@@ -141,11 +157,20 @@ export function auditSitemapCanonicalRoutes(outDir = defaultOutDir) {
     findings.push({ type: 'obsolete_redirect_contract', message: error instanceof Error ? error.message : String(error) })
   }
 
-  const entityUrls = actual.filter((url) => new URL(url).pathname.startsWith('/exchange/'))
-  if (entityUrls.length !== publicEntities.records.length) {
+  const englishEntityUrls = actual.filter((url) => new URL(url).pathname.startsWith('/exchange/'))
+  if (englishEntityUrls.length !== publicEntities.records.length) {
     findings.push({
-      type: 'entity_route_count_mismatch',
-      sitemap_entity_routes: entityUrls.length,
+      type: 'english_entity_route_count_mismatch',
+      sitemap_entity_routes: englishEntityUrls.length,
+      public_entities: publicEntities.records.length,
+    })
+  }
+
+  const japaneseEntityUrls = actual.filter((url) => new URL(url).pathname.startsWith('/ja/exchange/'))
+  if (japaneseEntityUrls.length !== publicEntities.records.length) {
+    findings.push({
+      type: 'japanese_entity_route_count_mismatch',
+      sitemap_entity_routes: japaneseEntityUrls.length,
       public_entities: publicEntities.records.length,
     })
   }
@@ -155,6 +180,7 @@ export function auditSitemapCanonicalRoutes(outDir = defaultOutDir) {
     expectedUrlCount: expected.length,
     publicEntityCount: publicEntities.records.length,
     staticRouteCount: STATIC_ROUTES.length,
+    japaneseStaticRouteCount: JAPANESE_STATIC_ROUTES.length,
     findings,
   }
 }
@@ -178,6 +204,9 @@ function runSelfTest() {
       ...STATIC_ROUTES.map((route) => `${origin}${route}`),
       `${origin}/exchange/alpha/`,
       `${origin}/exchange/beta/`,
+      ...JAPANESE_STATIC_ROUTES.map((route) => `${origin}${route}`),
+      `${origin}/ja/exchange/alpha/`,
+      `${origin}/ja/exchange/beta/`,
     ]
     fs.writeFileSync(path.join(outDir, 'sitemap.xml'), `<urlset>${urls.map((url) => `<url><loc>${url}</loc></url>`).join('')}</urlset>`)
     fs.writeFileSync(path.join(outDir, '_redirects'), [
@@ -199,17 +228,17 @@ function runSelfTest() {
     fs.rmSync(outDir, { recursive: true, force: true })
   }
 
-  console.log('Sitemap and canonical route audit self-test passed.')
+  console.log('L1 sitemap and canonical route audit self-test passed.')
 }
 
 if (process.argv.includes('--self-test')) {
   runSelfTest()
 } else {
   const result = auditSitemapCanonicalRoutes()
-  console.log(`Sitemap route audit: ${result.sitemapUrlCount} URLs = ${result.staticRouteCount} static + ${result.publicEntityCount} exchange routes.`)
+  console.log(`L1 sitemap route audit: ${result.sitemapUrlCount} URLs = ${result.staticRouteCount} English static + ${result.japaneseStaticRouteCount} Japanese static + ${result.publicEntityCount * 2} bilingual exchange routes.`)
   if (result.findings.length > 0) {
     for (const finding of result.findings) console.error(JSON.stringify(finding))
-    throw new Error(`sitemap and canonical route audit found ${result.findings.length} findings`)
+    throw new Error(`L1 sitemap and canonical route audit found ${result.findings.length} findings`)
   }
-  console.log('Sitemap and canonical route audit passed with 0 findings.')
+  console.log('L1 sitemap and canonical route audit passed with 0 findings.')
 }

--- a/scripts/check-count-semantics-regression.mjs
+++ b/scripts/check-count-semantics-regression.mjs
@@ -58,8 +58,8 @@ function assertNoConflictingDuplicateRecords(canonicalRecords, bundles, field, l
   }
 }
 
-function countDetailPages() {
-  const exchangeDir = path.join(root, 'out', 'exchange')
+function countDetailPages(relativeDir) {
+  const exchangeDir = path.join(root, 'out', ...relativeDir)
   if (!fs.existsSync(exchangeDir)) return 0
   return fs.readdirSync(exchangeDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory() && fs.existsSync(path.join(exchangeDir, entry.name, 'index.html')))
@@ -179,14 +179,20 @@ equalIdSets(projectedEntities, outEntities.records, 'built entities')
 equalIdSets(projectedEvents, outEvents.records, 'built events')
 equalIdSets(projectedEvidence, outEvidence.records, 'built evidence')
 
-const detailPages = countDetailPages()
-assert(detailPages === expected.entities, `exchange detail page count mismatch: ${detailPages}`)
+const englishDetailPages = countDetailPages(['exchange'])
+const japaneseDetailPages = countDetailPages(['ja', 'exchange'])
+assert(englishDetailPages === expected.entities, `English exchange detail page count mismatch: ${englishDetailPages}`)
+assert(japaneseDetailPages === expected.entities, `Japanese exchange detail page count mismatch: ${japaneseDetailPages}`)
+
 const locations = sitemapLocations()
 assert(new Set(locations).size === locations.length, 'sitemap contains duplicate URLs')
-const entityLocations = locations.filter((location) => location.includes('/exchange/'))
-assert(entityLocations.length === expected.entities, `sitemap entity route count mismatch: ${entityLocations.length}`)
+const englishEntityLocations = locations.filter((location) => new URL(location).pathname.startsWith('/exchange/'))
+const japaneseEntityLocations = locations.filter((location) => new URL(location).pathname.startsWith('/ja/exchange/'))
+assert(englishEntityLocations.length === expected.entities, `English sitemap entity route count mismatch: ${englishEntityLocations.length}`)
+assert(japaneseEntityLocations.length === expected.entities, `Japanese sitemap entity route count mismatch: ${japaneseEntityLocations.length}`)
 for (const entity of projectedEntities) {
-  assert(entityLocations.includes(`https://hei.badjoke-lab.com/exchange/${entity.slug}/`), `sitemap missing entity route: ${entity.slug}`)
+  assert(englishEntityLocations.includes(`https://hei.badjoke-lab.com/exchange/${entity.slug}/`), `English sitemap missing entity route: ${entity.slug}`)
+  assert(japaneseEntityLocations.includes(`https://hei.badjoke-lab.com/ja/exchange/${entity.slug}/`), `Japanese sitemap missing entity route: ${entity.slug}`)
 }
 
 const report = {
@@ -216,8 +222,10 @@ const report = {
     entities: outEntities.records.length,
     events: outEvents.records.length,
     evidence: outEvidence.records.length,
-    exchange_detail_pages: detailPages,
-    sitemap_entity_routes: entityLocations.length,
+    english_exchange_detail_pages: englishDetailPages,
+    japanese_exchange_detail_pages: japaneseDetailPages,
+    english_sitemap_entity_routes: englishEntityLocations.length,
+    japanese_sitemap_entity_routes: japaneseEntityLocations.length,
     sitemap_total_routes: locations.length,
   },
   status: 'pass',
@@ -231,4 +239,4 @@ if (outputArg) {
 
 console.log(`Count semantics regression: ${expected.entities} entities, ${expected.events} events, ${expected.evidence} evidence`)
 console.log(`Reviewed bundles: ${reviewedBundles.length} total, ${newEntityBundles.length} new entities, ${repairBundles.length} repairs`)
-console.log(`Built routes: ${detailPages} exchange pages, ${entityLocations.length} sitemap exchange routes`)
+console.log(`Built bilingual routes: ${englishDetailPages} English + ${japaneseDetailPages} Japanese exchange pages; ${englishEntityLocations.length} English + ${japaneseEntityLocations.length} Japanese sitemap dossier routes`)

--- a/scripts/localize-static-html.mjs
+++ b/scripts/localize-static-html.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+const root = process.cwd()
+const selfTest = process.argv.includes('--self-test')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`static locale postprocess failed: ${message}`)
+}
+
+function localizeJapaneseHtml(html) {
+  let output = html
+  output = output.replace(/<html\s+lang=["']en["']/i, '<html lang="ja"')
+  output = output.replaceAll('"inLanguage":"en"', '"inLanguage":"ja"')
+  return output
+}
+
+function listHtmlFiles(directory) {
+  const files = []
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolute = path.join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...listHtmlFiles(absolute))
+    else if (entry.isFile() && entry.name.endsWith('.html')) files.push(absolute)
+  }
+  return files
+}
+
+function runSelfTest() {
+  const sample = '<html lang="en"><body><script>{"inLanguage":"en"}</script><a hreflang="en">English</a></body></html>'
+  const localized = localizeJapaneseHtml(sample)
+  assert(localized.includes('<html lang="ja">'), 'html lang replacement failed')
+  assert(localized.includes('"inLanguage":"ja"'), 'JSON-LD inLanguage replacement failed')
+  assert(localized.includes('hreflang="en"'), 'hreflang must not be rewritten')
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hei-ja-html-'))
+  fs.mkdirSync(path.join(tempRoot, 'nested'))
+  fs.writeFileSync(path.join(tempRoot, 'index.html'), sample)
+  fs.writeFileSync(path.join(tempRoot, 'nested', 'index.html'), sample)
+  assert(listHtmlFiles(tempRoot).length === 2, 'recursive HTML discovery failed')
+  fs.rmSync(tempRoot, { recursive: true, force: true })
+
+  console.log('Static locale postprocess self-test: pass')
+}
+
+if (selfTest) {
+  runSelfTest()
+  process.exit(0)
+}
+
+const jaRoot = path.join(root, 'out', 'ja')
+assert(fs.existsSync(jaRoot), 'out/ja does not exist; Japanese public route family was not built')
+assert(fs.existsSync(path.join(jaRoot, 'index.html')), 'Japanese root output is missing')
+
+const files = listHtmlFiles(jaRoot)
+assert(files.length > 0, 'no Japanese HTML output files found')
+
+let changed = 0
+for (const filePath of files) {
+  const before = fs.readFileSync(filePath, 'utf8')
+  const after = localizeJapaneseHtml(before)
+  assert(/<html\s+lang=["']ja["']/i.test(after), `${path.relative(root, filePath)} still lacks html lang=ja`)
+  if (before !== after) {
+    fs.writeFileSync(filePath, after)
+    changed += 1
+  }
+}
+
+assert(changed > 0, 'no Japanese HTML files required localization; verify build contract before removing this postprocessor')
+console.log(`Localized Japanese static HTML: ${changed}/${files.length} files updated.`)

--- a/scripts/test-i18n-foundation.mjs
+++ b/scripts/test-i18n-foundation.mjs
@@ -61,6 +61,10 @@ function validateCopyFields(copy, allowed) {
   }
 }
 
+assert(config.public_locales.includes('en'), 'English must remain public')
+assert(config.public_locales.includes('ja'), 'Japanese Pilot must be public in L1')
+assert(config.pilot_locales.includes('ja'), 'Japanese must remain marked as a pilot locale')
+
 const japanese = dictionaryFor('ja')
 assert(japanese.locale === 'ja', 'Japanese dictionary must resolve to ja')
 assert(japanese.fallbackUsed === false, 'Japanese dictionary must not use fallback')
@@ -139,9 +143,9 @@ const entityMergeSource = fs.readFileSync(path.join(root, 'src/lib/i18n/merge-en
 const eventMergeSource = fs.readFileSync(path.join(root, 'src/lib/i18n/merge-event-copy.ts'), 'utf8')
 
 assert(routeSource.includes('buildPublicLocalePath'), 'public-route guard helper missing')
-assert(routeSource.includes('Locale is not publicly routed yet'), 'pilot locale public-route guard missing')
+assert(routeSource.includes('Locale is not publicly routed yet'), 'public-route guard failure contract missing')
 assert(dictionarySource.includes('fallbackUsed'), 'dictionary fallback state missing')
 assert(entityMergeSource.includes('summary: localized.summary ?? entity.summary'), 'entity fallback implementation mismatch')
 assert(eventMergeSource.includes('title: localized.title ?? event.title'), 'event fallback implementation mismatch')
 
-console.log('i18n foundation behavior tests passed: dictionary fallback, safe copy merge, route identity, and invalid overlay rejection verified.')
+console.log('L1 i18n behavior tests passed: public Japanese route state, dictionary fallback, safe copy merge, route identity, and invalid overlay rejection verified.')

--- a/scripts/test-japanese-route-shell-source.mjs
+++ b/scripts/test-japanese-route-shell-source.mjs
@@ -53,7 +53,7 @@ assert(dossier.includes('entity.archived_url'), 'Japanese dossier route lacks ar
 assert(sitemap.includes('japaneseStaticPaths'), 'Japanese static sitemap routes missing')
 assert(sitemap.includes('japaneseEntityRoutes'), 'Japanese dossier sitemap routes missing')
 assert(packageJson.scripts.build.includes('localize-static-html.mjs'), 'build does not run Japanese HTML language postprocessor')
-assert(staticHtml.includes('out', 'ja'), 'static HTML postprocessor does not target Japanese output')
+assert(staticHtml.includes("path.join(root, 'out', 'ja')"), 'static HTML postprocessor does not target out/ja')
 assert(staticHtml.includes('lang="ja"'), 'static HTML postprocessor lacks Japanese language output contract')
 
 console.log(`Japanese route shell source tests passed: ${staticRoutes.length} static routes, dynamic dossier family, public locale activation, sitemap, chrome, and static HTML contract verified.`)

--- a/scripts/test-japanese-route-shell-source.mjs
+++ b/scripts/test-japanese-route-shell-source.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Japanese route shell source test failed: ${message}`)
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(root, relativePath))
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+const staticRoutes = [
+  'src/app/ja/page.tsx',
+  'src/app/ja/dead/page.tsx',
+  'src/app/ja/active/page.tsx',
+  'src/app/ja/about/page.tsx',
+  'src/app/ja/methodology/page.tsx',
+  'src/app/ja/stats/page.tsx',
+  'src/app/ja/quality/page.tsx',
+  'src/app/ja/explore/page.tsx',
+  'src/app/ja/updates/page.tsx',
+  'src/app/ja/incidents/page.tsx',
+  'src/app/ja/monthly/page.tsx',
+]
+
+for (const route of staticRoutes) assert(exists(route), `missing route source ${route}`)
+assert(exists('src/app/ja/exchange/[slug]/page.tsx'), 'missing Japanese exchange dossier route source')
+
+const config = JSON.parse(read('config/i18n-locales.json'))
+assert(config.public_locales.includes('en'), 'English public locale missing')
+assert(config.public_locales.includes('ja'), 'Japanese public pilot locale missing')
+assert(config.pilot_locales.includes('ja'), 'Japanese pilot marker missing')
+
+const layout = read('src/app/layout.tsx')
+const localeChrome = read('src/components/layout/locale-aware-site-chrome.tsx')
+const dossier = read('src/app/ja/exchange/[slug]/page.tsx')
+const sitemap = read('src/app/sitemap.ts')
+const packageJson = JSON.parse(read('package.json'))
+const staticHtml = read('scripts/localize-static-html.mjs')
+
+assert(layout.includes('<LocaleAwareSiteChrome>'), 'root layout is not using locale-aware site chrome')
+assert(localeChrome.includes('stripLocalePrefix(pathname)'), 'locale-aware chrome does not derive locale from pathname')
+assert(dossier.includes('generateStaticParams()'), 'Japanese dossier route does not statically enumerate reviewed entities')
+assert(dossier.includes('loadEntities().map'), 'Japanese dossier route params are not derived from canonical entities')
+assert(dossier.includes('safeOriginalUrl'), 'Japanese dossier route lacks URL safety helper')
+assert(dossier.includes('entity.archived_url'), 'Japanese dossier route lacks archive-first access path')
+assert(sitemap.includes('japaneseStaticPaths'), 'Japanese static sitemap routes missing')
+assert(sitemap.includes('japaneseEntityRoutes'), 'Japanese dossier sitemap routes missing')
+assert(packageJson.scripts.build.includes('localize-static-html.mjs'), 'build does not run Japanese HTML language postprocessor')
+assert(staticHtml.includes('out', 'ja'), 'static HTML postprocessor does not target Japanese output')
+assert(staticHtml.includes('lang="ja"'), 'static HTML postprocessor lacks Japanese language output contract')
+
+console.log(`Japanese route shell source tests passed: ${staticRoutes.length} static routes, dynamic dossier family, public locale activation, sitemap, chrome, and static HTML contract verified.`)

--- a/scripts/validate-i18n-foundation.mjs
+++ b/scripts/validate-i18n-foundation.mjs
@@ -98,15 +98,17 @@ assert(localeConfig.version === 1, 'locale config version must be 1')
 assert(localeConfig.default_locale === 'en', 'default locale must be en')
 assert(localeConfig.fallback_locale === 'en', 'fallback locale must be en')
 sameStringSet(localeConfig.supported_locales, ['en', 'ja'], 'supported locales')
-sameStringSet(localeConfig.public_locales, ['en'], 'public locales in F-1')
-sameStringSet(localeConfig.pilot_locales, ['ja'], 'pilot locales in F-1')
+sameStringSet(localeConfig.public_locales, ['en', 'ja'], 'public locales in L1')
+sameStringSet(localeConfig.pilot_locales, ['ja'], 'pilot locales in L1')
+assert(localeConfig.public_locales.includes(localeConfig.default_locale), 'default locale must remain public')
+assert(localeConfig.public_locales.includes('ja'), 'Japanese Pilot must be public in L1')
 
 for (const locale of localeConfig.public_locales) {
   assert(localeConfig.supported_locales.includes(locale), `public locale is not supported: ${locale}`)
 }
 for (const locale of localeConfig.pilot_locales) {
   assert(localeConfig.supported_locales.includes(locale), `pilot locale is not supported: ${locale}`)
-  assert(!localeConfig.public_locales.includes(locale), `pilot locale must not be public during F-1: ${locale}`)
+  assert(localeConfig.public_locales.includes(locale), `L1 pilot locale must be public: ${locale}`)
 }
 
 assert(overlaySchema.version === 1, 'overlay schema version must be 1')
@@ -157,4 +159,4 @@ for (const forbidden of overlaySchema.event_overlay.forbidden_fields) {
   assert(!eventMergeSource.includes(`localized.${forbidden}`), `event merge utility may override forbidden field: ${forbidden}`)
 }
 
-console.log(`Validated i18n foundation: ${localeConfig.supported_locales.length} supported locales, ${localeConfig.public_locales.length} public locale, ${localeConfig.pilot_locales.length} pilot locale, ${expectedEnums.length} enum labels, safe empty overlay seeds.`)
+console.log(`Validated L1 i18n foundation: ${localeConfig.supported_locales.length} supported locales, ${localeConfig.public_locales.length} public locales, ${localeConfig.pilot_locales.length} public pilot locale, ${expectedEnums.length} enum labels, safe overlay boundaries.`)

--- a/scripts/validate-public-output-consistency.mjs
+++ b/scripts/validate-public-output-consistency.mjs
@@ -44,17 +44,11 @@ function assertDiscovery(html, route) {
   assert(html.includes('/data/manifest.json'), `${route} is missing JSON discovery link`)
   assert(html.includes('/llms.txt'), `${route} is missing text discovery link`)
 }
-function walk(dir) {
-  if (!fs.existsSync(dir)) return []
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const fullPath = path.join(dir, entry.name)
-    return entry.isDirectory() ? walk(fullPath) : [fullPath]
-  })
-}
 
 const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
 const canonicalEvidence = readJson('data/evidence.json')
+const enCommon = readJson('src/i18n/locales/en/common.json')
 const { all: reviewedBundles, newEntityBundles, entityIdMap } = loadReviewedBundles(root, canonicalEntities)
 const entities = [...applyReviewedEntityCorrections(canonicalEntities, reviewedBundles), ...newEntityBundles.map(({ bundle }) => bundle.entity)]
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event', entityIdMap)
@@ -106,20 +100,22 @@ const incidents = readOut(path.join('incidents', 'index.html'))
 const monthly = readOut(path.join('monthly', 'index.html'))
 const firstEntity = entities[0]
 const detail = readOut(path.join('exchange', firstEntity.slug, 'index.html'))
+const jaHome = readOut(path.join('ja', 'index.html'))
+const jaDetail = readOut(path.join('ja', 'exchange', firstEntity.slug, 'index.html'))
 
 assertTextCount(home, 'Total records', expected.total, '/')
 assertTextCount(home, 'Dead-side', expected.deadSide, '/')
 assertTextCount(home, 'Active-side', expected.activeSide, '/')
 assertTextCount(dead, 'Dead-side total:', expected.deadSide, '/dead/')
 assertTextCount(active, 'Active-side total:', expected.activeSide, '/active/')
-assert(stripHtml(explore).includes('Explorer'), '/explore/ does not expose Explorer heading')
+assert(stripHtml(explore).includes(enCommon['page.explore.heading']), '/explore/ does not expose dictionary-backed Explorer heading')
 assert(stripHtml(compare).includes('Compare'), '/compare/ does not expose Compare heading')
 assertTextCount(stats, 'Total entities', expected.total, '/stats/')
 assertTextCount(stats, 'Dead-side', expected.deadSide, '/stats/')
 assertTextCount(stats, 'Active-side', expected.activeSide, '/stats/')
 assertTextCount(stats, 'Total events', expected.events, '/stats/')
 assertTextCount(stats, 'Total evidence', expected.evidence, '/stats/')
-assert(stripHtml(quality).includes('Evidence Health & Data Quality'), '/quality/ does not expose Evidence Health & Data Quality heading')
+assert(stripHtml(quality).includes(enCommon['page.quality.heading']), '/quality/ does not expose dictionary-backed Quality heading')
 assertTextCount(quality, 'Entities', expected.total, '/quality/')
 assertTextCount(quality, 'Events', expected.events, '/quality/')
 assertTextCount(quality, 'Evidence', expected.evidence, '/quality/')
@@ -127,15 +123,17 @@ assertTextValue(quality, 'Entity archive coverage', `${expected.archiveCoverage}
 assertTextValue(quality, 'High-confidence entities', `${expected.highConfidenceShare}%`, '/quality/')
 assertTextValue(quality, 'High-reliability evidence', `${expected.highReliabilityEvidenceShare}%`, '/quality/')
 assertTextCount(quality, 'Entities with 0 evidence', expected.zeroEvidenceEntities, '/quality/')
-assert(stripHtml(updates).includes('Registry Updates'), '/updates/ does not expose Registry Updates heading')
-assert(stripHtml(incidents).includes('Exchange Incident Timeline'), '/incidents/ does not expose Exchange Incident Timeline heading')
+assert(stripHtml(updates).includes(enCommon['page.updates.heading']), '/updates/ does not expose dictionary-backed Updates heading')
+assert(stripHtml(incidents).includes(enCommon['page.incidents.heading']), '/incidents/ does not expose dictionary-backed Incidents heading')
 assertTextCount(incidents, 'Timeline events', expected.incidents, '/incidents/')
-assert(stripHtml(monthly).includes('Monthly Historical Exchange Snapshot'), '/monthly/ does not expose Monthly Historical Exchange Snapshot heading')
+assert(stripHtml(monthly).includes(enCommon['page.monthly.heading']), '/monthly/ does not expose dictionary-backed Monthly heading')
 assert(stripHtml(monthly).includes(expected.monthlyMonth), `/monthly/ does not expose review month ${expected.monthlyMonth}`)
 assertTextCount(monthly, 'Recorded events', expected.monthlyEvents, '/monthly/')
 assertTextCount(monthly, 'Affected exchanges', expected.monthlyAffectedExchanges, '/monthly/')
 assertTextCount(monthly, 'Critical / high', expected.monthlyCriticalOrHigh, '/monthly/')
 assertTextCount(monthly, 'Event-linked evidence', expected.monthlyEventLinkedEvidence, '/monthly/')
+assert(stripHtml(jaHome).includes('日本語パイロット'), '/ja/ does not expose Japanese Pilot context')
+assert(stripHtml(jaDetail).includes(firstEntity.canonical_name), '/ja/exchange/[slug]/ does not expose canonical entity identity')
 
 for (const [route, html, canonical] of [
   ['/', home, `${origin}/`],
@@ -149,6 +147,8 @@ for (const [route, html, canonical] of [
   ['/incidents/', incidents, `${origin}/incidents/`],
   ['/monthly/', monthly, `${origin}/monthly/`],
   [`/exchange/${firstEntity.slug}/`, detail, `${origin}/exchange/${firstEntity.slug}/`],
+  ['/ja/', jaHome, `${origin}/ja/`],
+  [`/ja/exchange/${firstEntity.slug}/`, jaDetail, `${origin}/ja/exchange/${firstEntity.slug}/`],
 ]) {
   assertCanonical(html, canonical, route)
   assertDiscovery(html, route)
@@ -215,15 +215,18 @@ for (const [label, count] of [['Total records', expected.total],['Dead-side', ex
 
 const sitemap = readOut('sitemap.xml')
 const sitemapLocations = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((match) => match[1])
-assert(sitemapLocations.length === entities.length + 13, `sitemap URL count mismatch: ${sitemapLocations.length}`)
+const expectedSitemapCount = entities.length * 2 + 24
+assert(sitemapLocations.length === expectedSitemapCount, `bilingual sitemap URL count mismatch: ${sitemapLocations.length} != ${expectedSitemapCount}`)
 assert(sitemapLocations.includes(`${origin}/explore/`), 'sitemap is missing /explore/')
 assert(sitemapLocations.includes(`${origin}/compare/`), 'sitemap is missing /compare/')
 assert(!sitemapLocations.some((url) => url.includes('?')), 'sitemap contains query variants')
-assert(sitemapLocations.includes(`${origin}/quality/`), 'sitemap is missing /quality/')
-assert(sitemapLocations.includes(`${origin}/updates/`), 'sitemap is missing /updates/')
-assert(sitemapLocations.includes(`${origin}/incidents/`), 'sitemap is missing /incidents/')
-assert(sitemapLocations.includes(`${origin}/monthly/`), 'sitemap is missing /monthly/')
-for (const entity of entities) assert(sitemapLocations.includes(`${origin}/exchange/${entity.slug}/`), `sitemap missing ${entity.slug}`)
+for (const route of ['/ja/','/ja/dead/','/ja/active/','/ja/explore/','/ja/stats/','/ja/quality/','/ja/updates/','/ja/incidents/','/ja/monthly/','/ja/methodology/','/ja/about/']) {
+  assert(sitemapLocations.includes(`${origin}${route}`), `sitemap is missing ${route}`)
+}
+for (const entity of entities) {
+  assert(sitemapLocations.includes(`${origin}/exchange/${entity.slug}/`), `sitemap missing English dossier ${entity.slug}`)
+  assert(sitemapLocations.includes(`${origin}/ja/exchange/${entity.slug}/`), `sitemap missing Japanese dossier ${entity.slug}`)
+}
 assert(!sitemap.includes('/all/'), 'sitemap includes obsolete /all/ route')
 assert(!sitemap.includes('/registry/'), 'sitemap includes obsolete /registry/ route')
 assert(!sitemap.includes('/exchanges/'), 'sitemap includes obsolete /exchanges/ route')
@@ -232,7 +235,6 @@ const robots = readOut('robots.txt')
 assert(robots.includes(`${origin}/sitemap.xml`), 'robots.txt sitemap is incorrect')
 const redirects = readOut('_redirects')
 for (const obsolete of ['/index.html','/all','/registry','/exchanges']) assert(redirects.includes(`${obsolete} / 301`), `_redirects is missing ${obsolete}`)
-
 for (const obsoleteDir of ['all','registry','exchanges']) assert(!fs.existsSync(path.join(outDir, obsoleteDir, 'index.html')), `obsolete route output still exists: /${obsoleteDir}/`)
 
-console.log(`Validated public output consistency: ${expected.total} entities, ${expected.deadSide} dead-side, ${expected.activeSide} active-side, ${expected.events} events, ${expected.evidence} evidence, Explorer and Compare routes and crawl contracts checked.`)
+console.log(`Validated L1 bilingual public output: ${expected.total} entities, ${expected.events} events, ${expected.evidence} evidence, ${expectedSitemapCount} sitemap routes, bilingual dossier coverage, and dictionary-backed headings.`)

--- a/src/app/ja/about/page.tsx
+++ b/src/app/ja/about/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'about', pathname: '/about/' })
+}
+
+export default function JapaneseAboutPage() {
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'about')} englishHref="/about/">
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <h3>HEIとは</h3>
+          <p className="muted" style={{ lineHeight: 1.75 }}>
+            Historical Exchange Indexは、暗号資産取引所のidentity、status、重要なevent、URL履歴、evidenceを一つの歴史台帳として扱うプロジェクトです。
+          </p>
+          <p className="muted" style={{ lineHeight: 1.75 }}>
+            ランキングや投資推奨ではなく、稼働中と終了済みを同じregistryで追跡し、後から検証できる形で残すことを目的としています。
+          </p>
+        </div>
+        <div className="section">
+          <h3>日本語パイロット</h3>
+          <p className="muted" style={{ lineHeight: 1.75 }}>
+            日本語版は段階導入です。UI、概要、主要導線から始め、canonical dataは英語版と共通の単一source of truthを使います。
+          </p>
+          <Link className="btn" href="/ja/methodology/">日本語の方法論概要へ</Link>
+        </div>
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/active/page.tsx
+++ b/src/app/ja/active/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import ActiveExplorerClient from '../../../components/registry/active-explorer-client'
+import { loadEntities } from '../../../lib/data/load-entities'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+const ACTIVE_SIDE = new Set<string>(['active', 'limited', 'inactive'])
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'active', pathname: '/active/' })
+}
+
+export default function JapaneseActivePage() {
+  const entities = loadEntities()
+    .filter((item) => ACTIVE_SIDE.has(item.status))
+    .sort((a, b) => a.canonical_name.localeCompare(b.canonical_name))
+  const summary = {
+    total: entities.length,
+    active: entities.filter((item) => item.status === 'active').length,
+    limited: entities.filter((item) => item.status === 'limited').length,
+    inactive: entities.filter((item) => item.status === 'inactive').length,
+    liveVerified: entities.filter((item) => item.official_url_status === 'live_verified').length,
+    archiveCoverage: entities.length > 0 ? Math.round((entities.filter((item) => item.archived_url).length / entities.length) * 100) : 0,
+  }
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'active')} englishHref="/active/">
+      <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>レジストリを読み込み中…</div></div></section>}>
+        <ActiveExplorerClient entities={entities} summary={summary} />
+      </Suspense>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/dead/page.tsx
+++ b/src/app/ja/dead/page.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import DeadExplorerClient from '../../../components/registry/dead-explorer-client'
+import { loadEntities } from '../../../lib/data/load-entities'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+const DEAD_SIDE = new Set<string>(['dead', 'merged', 'acquired', 'rebranded'])
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'dead', pathname: '/dead/' })
+}
+
+export default function JapaneseDeadPage() {
+  const entities = loadEntities()
+    .filter((item) => DEAD_SIDE.has(item.status))
+    .sort((a, b) => {
+      const aDate = a.death_date ?? ''
+      const bDate = b.death_date ?? ''
+      if (aDate !== bDate) return aDate < bDate ? 1 : -1
+      return a.canonical_name.localeCompare(b.canonical_name)
+    })
+  const summary = {
+    total: entities.length,
+    dead: entities.filter((item) => item.status === 'dead').length,
+    merged: entities.filter((item) => item.status === 'merged').length,
+    acquired: entities.filter((item) => item.status === 'acquired').length,
+    rebranded: entities.filter((item) => item.status === 'rebranded').length,
+    archiveCoverage: entities.length > 0 ? Math.round((entities.filter((item) => item.archived_url).length / entities.length) * 100) : 0,
+  }
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'dead')} englishHref="/dead/">
+      <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>レジストリを読み込み中…</div></div></section>}>
+        <DeadExplorerClient entities={entities} summary={summary} />
+      </Suspense>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/exchange/[slug]/page.tsx
+++ b/src/app/ja/exchange/[slug]/page.tsx
@@ -1,0 +1,169 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { buildDetailView } from '../../../../lib/data/build-detail-view'
+import { loadEntities } from '../../../../lib/data/load-entities'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../../lib/i18n/page-presentations'
+import { formatDate } from '../../../../lib/utils/format-date'
+import { formatYears } from '../../../../lib/utils/format-years'
+
+type JapaneseDetailPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return loadEntities().map((entity) => ({ slug: entity.slug }))
+}
+
+export async function generateMetadata({ params }: JapaneseDetailPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const detail = buildDetailView(slug)
+
+  if (!detail) {
+    return buildLocalizedPageMetadata({
+      locale: 'ja',
+      page: 'exchange',
+      pathname: `/exchange/${slug}/`,
+      titleOverride: '取引所レコードが見つかりません',
+      descriptionOverride: 'このslugに対応するレビュー済みHEIレコードはありません。',
+    })
+  }
+
+  const { entity } = detail
+  return buildLocalizedPageMetadata({
+    locale: 'ja',
+    page: 'exchange',
+    pathname: `/exchange/${entity.slug}/`,
+    titleOverride: `${entity.canonical_name} — 取引所レコード`,
+    descriptionOverride: `${entity.canonical_name}のHEI歴史レコード。status、URL履歴、event、evidenceを確認できます。`,
+  })
+}
+
+function safeOriginalUrl(status: string | null | undefined) {
+  return status === 'live_verified' || status === 'live_unverified'
+}
+
+export default async function JapaneseExchangeDetailPage({ params }: JapaneseDetailPageProps) {
+  const { slug } = await params
+  const detail = buildDetailView(slug)
+  const presentation = getPagePresentation('ja', 'exchange')
+
+  if (!detail) {
+    return (
+      <main className="longform">
+        <section className="panel longform-panel">
+          <p className="muted">{presentation.eyebrow}</p>
+          <h2>レコードが見つかりません</h2>
+          <p className="muted">このslugに対応するレビュー済みHEIレコードはありません。</p>
+        </section>
+      </main>
+    )
+  }
+
+  const { entity, events, evidence, relatedEntities, prefersArchive } = detail
+  const originalClickable = safeOriginalUrl(entity.official_url_status)
+
+  return (
+    <main className="longform">
+      <section className="panel longform-panel">
+        <div className="muted" style={{ fontSize: '12px', marginBottom: '18px' }}>
+          <Link className="subtle-link" href="/ja/">ホーム</Link>
+          <span> / </span>
+          <Link className="subtle-link" href={['dead', 'merged', 'acquired', 'rebranded'].includes(entity.status) ? '/ja/dead/' : '/ja/active/'}>
+            {['dead', 'merged', 'acquired', 'rebranded'].includes(entity.status) ? '終了側' : '稼働側'}
+          </Link>
+          <span> / </span>
+          <span>{entity.canonical_name}</span>
+        </div>
+
+        <div className="detail-header">
+          <div>
+            <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>{presentation.eyebrow}</p>
+            <h2 style={{ margin: 0, fontSize: '34px', letterSpacing: '-0.04em' }}>{entity.canonical_name}</h2>
+            <p className="muted" style={{ marginTop: '10px', lineHeight: 1.7 }}>{entity.summary}</p>
+          </div>
+          <div className="chips">
+            <span className="chip type">{entity.type.toUpperCase()}</span>
+            <span className={`chip ${entity.status}`}>{entity.status}</span>
+            {entity.death_reason ? <span className="chip reason">{entity.death_reason}</span> : null}
+          </div>
+        </div>
+
+        {entity.aliases.length > 0 ? (
+          <p className="muted" style={{ fontSize: '13px' }}>別名: {entity.aliases.join(', ')}</p>
+        ) : null}
+      </section>
+
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <h3>基本情報</h3>
+          <div className="fact-grid">
+            <div className="fact"><div className="k">期間</div><div className="v">{formatYears(entity.launch_date, entity.death_date)}</div></div>
+            <div className="fact"><div className="k">Origin</div><div className="v">{entity.country_or_origin ?? 'Unknown'}</div></div>
+            <div className="fact"><div className="k">Confidence</div><div className="v">{entity.confidence}</div></div>
+            <div className="fact"><div className="k">Last verified</div><div className="v">{entity.last_verified_at}</div></div>
+          </div>
+        </div>
+
+        <div className="section">
+          <h3>URL履歴</h3>
+          <div className="fact-grid">
+            <div className="fact"><div className="k">Original domain</div><div className="v">{entity.official_domain_original ?? 'Unknown'}</div></div>
+            <div className="fact"><div className="k">URL status</div><div className="v">{entity.official_url_status ?? 'unknown'}</div></div>
+          </div>
+          <div className="hero-actions" style={{ marginTop: '14px' }}>
+            {entity.archived_url ? <a className="btn btn-primary" href={entity.archived_url} target="_blank" rel="noreferrer">アーカイブを見る</a> : null}
+            {entity.official_url_original && originalClickable ? <a className="btn" href={entity.official_url_original} target="_blank" rel="noreferrer">Original URL</a> : null}
+            {entity.official_url_original && !originalClickable ? <span className="muted">旧URL: {entity.official_url_original}</span> : null}
+          </div>
+          {prefersArchive ? <p className="muted">このレコードでは安全性と史料性のためarchive導線を優先します。</p> : null}
+        </div>
+
+        <div className="section">
+          <h3>Timeline</h3>
+          {events.length > 0 ? (
+            <div className="record-list">
+              {events.map((event) => (
+                <article className="record-item" key={event.id}>
+                  <div className="record-main">
+                    <strong className="record-title">{event.title}</strong>
+                    <div className="record-meta"><span>{event.event_date ? formatDate(event.event_date) : 'Unknown date'}</span><span>{event.event_type}</span><span>{event.impact_level}</span></div>
+                    <p className="muted" style={{ marginBottom: 0 }}>{event.description}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : <p className="muted">公開eventはまだありません。</p>}
+        </div>
+
+        <div className="section">
+          <h3>Evidence</h3>
+          {evidence.length > 0 ? (
+            <div className="record-list">
+              {evidence.map((source) => (
+                <article className="record-item" key={source.id}>
+                  <div className="record-main">
+                    <a className="record-title subtle-link" href={source.url} target="_blank" rel="noreferrer">{source.title}</a>
+                    <div className="record-meta"><span>{source.publisher}</span><span>{source.reliability}</span><span>{source.claim_scope ?? 'entity'}</span></div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : <p className="muted">公開evidenceはまだありません。</p>}
+        </div>
+
+        {relatedEntities.length > 0 ? (
+          <div className="section">
+            <h3>関連entity</h3>
+            <div className="hero-actions">
+              {relatedEntities.map((related) => <Link className="btn" href={`/ja/exchange/${related.slug}/`} key={related.id}>{related.canonical_name}</Link>)}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="section">
+          <Link className="btn" href={`/exchange/${entity.slug}/`} hrefLang="en">English full dossier</Link>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/app/ja/explore/page.tsx
+++ b/src/app/ja/explore/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import EntityExplorerClient from '../../../components/explorer/entity-explorer-client'
+import { loadEntities } from '../../../lib/data/load-entities'
+import { loadEvents } from '../../../lib/data/load-events'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'explore', pathname: '/explore/' })
+}
+
+export default function JapaneseExplorePage() {
+  const entities = loadEntities()
+  const events = loadEvents()
+  const reviewedOrigins = [...new Set(
+    entities
+      .map((entity) => entity.country_or_origin)
+      .filter((value): value is string => Boolean(value)),
+  )].sort((a, b) => a.localeCompare(b))
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'explore')} englishHref="/explore/">
+      <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>クエリ状態を読み込み中…</div></div></section>}>
+        <EntityExplorerClient entities={entities} events={events} reviewedOrigins={reviewedOrigins} />
+      </Suspense>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/incidents/page.tsx
+++ b/src/app/ja/incidents/page.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { buildIncidentTimeline, incidentEventTypeLabel } from '../../../lib/data/build-incident-timeline'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+import { formatDate } from '../../../lib/utils/format-date'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'incidents', pathname: '/incidents/' })
+}
+
+export default function JapaneseIncidentsPage() {
+  const incidents = buildIncidentTimeline()
+  const affectedExchanges = new Set(incidents.map((item) => item.entity.id)).size
+  const criticalEvents = incidents.filter((item) => item.event.impact_level === 'critical').length
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'incidents')} englishHref="/incidents/">
+      <section className="panel summary-strip">
+        <div className="summary-tile"><div className="label">Timeline events</div><div className="value">{incidents.length}</div><div className="hint">レビュー済み</div></div>
+        <div className="summary-tile"><div className="label">Affected exchanges</div><div className="value">{affectedExchanges}</div><div className="hint">entity count</div></div>
+        <div className="summary-tile"><div className="label">Critical events</div><div className="value">{criticalEvents}</div><div className="hint">impact level critical</div></div>
+      </section>
+
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <h3>最近のレビュー済みインシデント</h3>
+          <div className="record-list">
+            {incidents.slice(0, 12).map(({ event, entity }) => (
+              <article className="record-item" key={event.id}>
+                <div className="record-top">
+                  <div className="record-main">
+                    <Link className="record-title subtle-link" href={`/ja/exchange/${entity.slug}/`}>{entity.canonical_name}</Link>
+                    <div className="record-meta"><span>{event.event_date ? formatDate(event.event_date) : 'Unknown date'}</span><span>{incidentEventTypeLabel(event.event_type)}</span><span>{event.impact_level}</span></div>
+                    <p className="muted" style={{ marginBottom: 0 }}>{event.description}</p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/methodology/page.tsx
+++ b/src/app/ja/methodology/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'methodology', pathname: '/methodology/' })
+}
+
+const principles = [
+  ['Registry first', 'HEIはランキングではなく、取引所のidentity・status・event・evidenceを記録する歴史台帳です。'],
+  ['Entity first', '現在の集計単位はentityです。DEXのchain deploymentを別entityとして水増ししません。'],
+  ['Archive aware', '終了側の旧domainは史料として保持し、archiveを安全な主導線として優先します。'],
+  ['Uncertainty visible', '根拠が弱い場合はdeadと断定せず、inactiveやunknownを残します。'],
+]
+
+export default function JapaneseMethodologyPage() {
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'methodology')} englishHref="/methodology/">
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <h3>中核原則</h3>
+          <div className="fact-grid">
+            {principles.map(([title, body]) => (
+              <div className="fact" key={title}>
+                <div className="k">{title}</div>
+                <div className="v">{body}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="section">
+          <h3>statusとdeath_reason</h3>
+          <p className="muted" style={{ lineHeight: 1.75 }}>
+            statusは現在または終端の状態、death_reasonは消滅・終了の主因を表します。内部enum値は全言語で共通です。
+          </p>
+          <p className="muted" style={{ lineHeight: 1.75 }}>
+            dead・merged・acquired・rebrandedは終了側、active・limited・inactiveは稼働側として閲覧します。
+          </p>
+        </div>
+        <div className="section">
+          <h3>evidenceとURL安全性</h3>
+          <p className="muted" style={{ lineHeight: 1.75 }}>
+            evidenceはentity、event、status、death_reason、date、URL history、ownershipなど特定のclaimを支えるために使います。
+            repurposed・unsafe・dead_domainの旧URLは通常リンクとして扱いません。
+          </p>
+        </div>
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/monthly/page.tsx
+++ b/src/app/ja/monthly/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { buildMonthlyHistoricalSnapshot } from '../../../lib/data/build-monthly-historical-snapshot'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'monthly', pathname: '/monthly/' })
+}
+
+export default function JapaneseMonthlyPage() {
+  const snapshot = buildMonthlyHistoricalSnapshot()
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'monthly')} englishHref="/monthly/">
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <p className="muted">対象月</p>
+          <h3 style={{ fontSize: '30px', marginTop: 0 }}>{snapshot.monthLabel}</h3>
+          <p className="muted">{snapshot.periodStart} から {snapshot.periodEnd} までのレビュー済みeventを対象にします。</p>
+        </div>
+      </section>
+
+      <section className="panel summary-strip">
+        <div className="summary-tile"><div className="label">Recorded events</div><div className="value">{snapshot.summary.events}</div><div className="hint">reviewed events</div></div>
+        <div className="summary-tile"><div className="label">Affected exchanges</div><div className="value">{snapshot.summary.affectedExchanges}</div><div className="hint">entity count</div></div>
+        <div className="summary-tile"><div className="label">Critical / high</div><div className="value">{snapshot.summary.criticalOrHighEvents}</div><div className="hint">impact levels</div></div>
+        <div className="summary-tile"><div className="label">Event-linked evidence</div><div className="value">{snapshot.summary.eventLinkedEvidence}</div><div className="hint">direct evidence links</div></div>
+      </section>
+
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <h3>月次event一覧</h3>
+          <div className="record-list">
+            {snapshot.items.slice(0, 12).map(({ event, entity }) => (
+              <article className="record-item" key={event.id}>
+                <div className="record-top">
+                  <div className="record-main">
+                    <Link className="record-title subtle-link" href={`/ja/exchange/${entity.slug}/`}>{entity.canonical_name}</Link>
+                    <div className="record-meta"><span>{event.event_date ?? 'Unknown date'}</span><span>{event.event_type}</span><span>{event.impact_level}</span></div>
+                    <p className="muted" style={{ marginBottom: 0 }}>{event.description}</p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/page.tsx
+++ b/src/app/ja/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { buildRegistryView } from '../../lib/data/build-registry-view'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'home', pathname: '/' })
+}
+
+export default function JapaneseHomePage() {
+  const { summary } = buildRegistryView()
+  const presentation = getPagePresentation('ja', 'home')
+
+  return (
+    <main className="home-hub">
+      <section className="hero compact-hero">
+        <div className="panel hero-main">
+          <div className="eyebrow">{presentation.eyebrow}</div>
+          <h2>{presentation.heading}</h2>
+          <p>{presentation.intro}</p>
+          <div className="hero-actions">
+            <Link className="btn btn-primary" href="/ja/dead/">終了側を見る</Link>
+            <Link className="btn" href="/ja/active/">稼働側を見る</Link>
+            <Link className="btn" href="/ja/explore/">エクスプローラー</Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="panel summary-strip summary-strip-home">
+        <div className="summary-tile"><div className="label">取引所レコード</div><div className="value">{summary.total}</div><div className="hint">entity単位</div></div>
+        <div className="summary-tile"><div className="label">終了側</div><div className="value">{summary.deadSide}</div><div className="hint">dead・merged・acquired・rebranded</div></div>
+        <div className="summary-tile"><div className="label">稼働側</div><div className="value">{summary.activeSide}</div><div className="hint">active・limited・inactive</div></div>
+        <div className="summary-tile"><div className="label">公開言語</div><div className="value">EN / JA</div><div className="hint">日本語パイロット</div></div>
+      </section>
+
+      <section className="home-entry-grid">
+        <section className="panel home-entry-card"><div className="home-section-copy"><h3>方法論</h3><p>status、death_reason、証拠、URL安全性、不確実性の扱いを確認します。</p></div><Link className="btn" href="/ja/methodology/">開く</Link></section>
+        <section className="panel home-entry-card"><div className="home-section-copy"><h3>統計と品質</h3><p>台帳の規模、構成、カバレッジ、証拠の厚さを確認します。</p></div><div className="hero-actions"><Link className="btn" href="/ja/stats/">統計</Link><Link className="btn" href="/ja/quality/">品質</Link></div></section>
+      </section>
+    </main>
+  )
+}

--- a/src/app/ja/quality/page.tsx
+++ b/src/app/ja/quality/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { buildQualitySummary } from '../../../lib/data/build-quality-summary'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'quality', pathname: '/quality/' })
+}
+
+export default function JapaneseQualityPage() {
+  const summary = buildQualitySummary()
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'quality')} englishHref="/quality/">
+      <section className="panel summary-strip">
+        <div className="summary-tile"><div className="label">Entities</div><div className="value">{summary.totals.entities}</div><div className="hint">レビュー済み</div></div>
+        <div className="summary-tile"><div className="label">Events</div><div className="value">{summary.totals.events}</div><div className="hint">公開event</div></div>
+        <div className="summary-tile"><div className="label">Evidence</div><div className="value">{summary.totals.evidence}</div><div className="hint">公開evidence</div></div>
+        <div className="summary-tile"><div className="label">Generated</div><div className="value">{summary.generatedAt.slice(0, 10)}</div><div className="hint">quality snapshot</div></div>
+      </section>
+
+      <section className="home-entry-grid">
+        {summary.headline.slice(0, 4).map((item) => (
+          <section className="panel home-entry-card" key={item.key}>
+            <div className="home-section-copy"><h3>{item.label}</h3><p>{item.note ?? '—'}</p></div>
+            <strong style={{ fontSize: '28px' }}>{item.value}</strong>
+          </section>
+        ))}
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/stats/page.tsx
+++ b/src/app/ja/stats/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { loadEntities } from '../../../lib/data/load-entities'
+import { loadEvents } from '../../../lib/data/load-events'
+import { loadEvidence } from '../../../lib/data/load-evidence'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+const DEAD_SIDE = new Set(['dead', 'merged', 'acquired', 'rebranded'])
+const ACTIVE_SIDE = new Set(['active', 'limited', 'inactive'])
+
+export function generateMetadata(): Metadata {
+  return buildLocalizedPageMetadata({ locale: 'ja', page: 'stats', pathname: '/stats/' })
+}
+
+export default function JapaneseStatsPage() {
+  const entities = loadEntities()
+  const events = loadEvents()
+  const evidence = loadEvidence()
+  const deadSide = entities.filter((entity) => DEAD_SIDE.has(entity.status)).length
+  const activeSide = entities.filter((entity) => ACTIVE_SIDE.has(entity.status)).length
+  const archiveCoverage = entities.length > 0
+    ? Math.round((entities.filter((entity) => entity.archived_url).length / entities.length) * 100)
+    : 0
+  const highConfidence = entities.length > 0
+    ? Math.round((entities.filter((entity) => entity.confidence === 'high').length / entities.length) * 100)
+    : 0
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'stats')} englishHref="/stats/">
+      <section className="panel summary-strip">
+        <div className="summary-tile"><div className="label">Entities</div><div className="value">{entities.length}</div><div className="hint">レビュー済みentity</div></div>
+        <div className="summary-tile"><div className="label">終了側</div><div className="value">{deadSide}</div><div className="hint">dead-side total</div></div>
+        <div className="summary-tile"><div className="label">稼働側</div><div className="value">{activeSide}</div><div className="hint">active-side total</div></div>
+        <div className="summary-tile"><div className="label">Events</div><div className="value">{events.length}</div><div className="hint">timeline records</div></div>
+        <div className="summary-tile"><div className="label">Evidence</div><div className="value">{evidence.length}</div><div className="hint">supporting records</div></div>
+        <div className="summary-tile"><div className="label">Archive coverage</div><div className="value">{archiveCoverage}%</div><div className="hint">archive URLあり</div></div>
+        <div className="summary-tile"><div className="label">High confidence</div><div className="value">{highConfidence}%</div><div className="hint">entity confidence</div></div>
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/ja/updates/page.tsx
+++ b/src/app/ja/updates/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surface'
+import { loadRegistryUpdates } from '../../../lib/data/load-registry-updates'
+import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
+
+export function generateMetadata(): Metadata {
+  const base = buildLocalizedPageMetadata({ locale: 'ja', page: 'updates', pathname: '/updates/' })
+  return {
+    ...base,
+    alternates: {
+      ...base.alternates,
+      types: {
+        'application/feed+json': '/feeds/updates.json',
+        'application/rss+xml': '/feeds/updates.xml',
+      },
+    },
+  }
+}
+
+export default function JapaneseUpdatesPage() {
+  const updates = loadRegistryUpdates()
+
+  return (
+    <JapanesePilotSurface presentation={getPagePresentation('ja', 'updates')} englishHref="/updates/">
+      <section className="panel longform-panel">
+        <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
+          <h3>最新のレビュー済み更新</h3>
+          <div className="record-list">
+            {updates.slice(0, 8).map((update) => (
+              <article className="record-item" key={update.id}>
+                <div className="record-top">
+                  <div className="record-main">
+                    <strong className="record-title">{update.title}</strong>
+                    <div className="record-meta"><span>{update.date}</span><span>{update.update_type}</span></div>
+                    <p className="muted" style={{ marginBottom: 0 }}>{update.summary}</p>
+                  </div>
+                  <Link className="btn btn-compact" href={`/updates/#${update.id}`}>English detail</Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </JapanesePilotSurface>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import './home-recent-mobile-fix.css'
 import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
 import GoogleAnalytics from '../components/analytics/google-analytics'
-import SiteChrome from '../components/layout/site-chrome'
+import LocaleAwareSiteChrome from '../components/layout/locale-aware-site-chrome'
 import {
   GA_MEASUREMENT_ID,
   GSC_VERIFICATION_TOKEN,
@@ -163,7 +163,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 }
         `}</style>
 
-        <SiteChrome locale="en">{children}</SiteChrome>
+        <LocaleAwareSiteChrome>{children}</LocaleAwareSiteChrome>
       </body>
     </html>
   )

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -38,5 +38,33 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.8,
   }))
 
-  return [...staticRoutes, ...entityRoutes]
+  const japaneseStaticPaths = [
+    '/ja/',
+    '/ja/dead/',
+    '/ja/active/',
+    '/ja/explore/',
+    '/ja/stats/',
+    '/ja/quality/',
+    '/ja/updates/',
+    '/ja/incidents/',
+    '/ja/monthly/',
+    '/ja/methodology/',
+    '/ja/about/',
+  ] as const
+
+  const japaneseStaticRoutes: MetadataRoute.Sitemap = japaneseStaticPaths.map((pathname) => ({
+    url: `${SITE_URL}${pathname}`,
+    lastModified: registryLastModified,
+    changeFrequency: pathname === '/ja/monthly/' ? 'monthly' : 'weekly',
+    priority: pathname === '/ja/' ? 0.9 : 0.7,
+  }))
+
+  const japaneseEntityRoutes: MetadataRoute.Sitemap = entities.map((entity) => ({
+    url: `${SITE_URL}/ja/exchange/${entity.slug}/`,
+    lastModified: entity.last_verified_at ? new Date(`${entity.last_verified_at}T00:00:00.000Z`) : registryLastModified,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }))
+
+  return [...staticRoutes, ...entityRoutes, ...japaneseStaticRoutes, ...japaneseEntityRoutes]
 }

--- a/src/components/i18n/japanese-pilot-surface.tsx
+++ b/src/components/i18n/japanese-pilot-surface.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import type { PagePresentation } from '../../lib/i18n/page-presentations'
+
+type JapanesePilotSurfaceProps = {
+  presentation: PagePresentation
+  englishHref: string
+  children?: ReactNode
+  actions?: ReactNode
+}
+
+export default function JapanesePilotSurface({
+  presentation,
+  englishHref,
+  children,
+  actions,
+}: JapanesePilotSurfaceProps) {
+  return (
+    <main className="longform">
+      <section className="panel longform-panel">
+        <div className="detail-header">
+          <div>
+            <p className="muted" style={{ margin: '0 0 8px', fontSize: '12px' }}>
+              {presentation.eyebrow}
+            </p>
+            <h2 style={{ margin: '0 0 10px', fontSize: '34px', letterSpacing: '-0.04em' }}>
+              {presentation.heading}
+            </h2>
+            <p className="muted" style={{ lineHeight: 1.7, margin: 0, maxWidth: '82ch' }}>
+              {presentation.intro}
+            </p>
+          </div>
+          <div className="hero-actions" style={{ marginTop: 0 }}>
+            {actions}
+            <Link className="btn" href={englishHref} hrefLang="en">
+              English full view
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {children}
+
+      <section className="callout">
+        日本語パイロットでは、ナビゲーション、ページ概要、主要ラベルを日本語化しています。
+        レコード本文や一部の分析ラベルは、canonical dataを分岐させないため英語をfallback表示する場合があります。
+      </section>
+    </main>
+  )
+}

--- a/src/components/layout/locale-aware-site-chrome.tsx
+++ b/src/components/layout/locale-aware-site-chrome.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
+import { stripLocalePrefix } from '../../lib/i18n/locale-routes'
+import SiteChrome from './site-chrome'
+
+type LocaleAwareSiteChromeProps = {
+  children: ReactNode
+}
+
+export default function LocaleAwareSiteChrome({ children }: LocaleAwareSiteChromeProps) {
+  const pathname = usePathname()
+  const { locale } = stripLocalePrefix(pathname)
+
+  return <SiteChrome locale={locale}>{children}</SiteChrome>
+}


### PR DESCRIPTION
## Roadmap item

L-1 Japanese Pilot — L1-4 public route shell, metadata, sitemap, and activation gate.

## Summary

Activates the controlled Japanese public pilot while preserving a single canonical reviewed data source.

Public route scope:

```text
/ja/
/ja/dead/
/ja/active/
/ja/about/
/ja/methodology/
/ja/stats/
/ja/quality/
/ja/explore/
/ja/updates/
/ja/incidents/
/ja/monthly/
/ja/exchange/[slug]/
```

The exchange dossier family is statically generated from the same reviewed entity set as English output.

## Data boundary

- `data/entities.json`, `data/events.json`, and `data/evidence.json` remain the canonical source of truth.
- Japanese routes do not fork entity identity, status, enum values, URLs, events, evidence, or reviewed counts.
- Japanese record text may fall back to canonical English copy where no reviewed overlay exists.
- Compare remains an English-only route during this pilot and Japanese UI copy marks that boundary.

## Locale activation

Changes the shared locale contract to:

```text
supported: en, ja
public:    en, ja
pilot:     ja
fallback:  en
```

The root chrome becomes pathname-aware, while static Japanese output is postprocessed at build time so Japanese pages emit:

```text
html lang=ja
JSON-LD inLanguage=ja
```

The postprocessor is deterministic, build-time only, and limited to `out/ja/**`.

## Metadata and discovery

Japanese routes use locale-aware page metadata with:

- Japanese canonical URLs;
- reciprocal `en` / `ja` hreflang alternates;
- `og:locale=ja_JP`;
- language-aware visible chrome;
- Japanese static routes in the sitemap;
- all reviewed Japanese dossier routes in the sitemap;
- no query variants in the sitemap.

Projected sitemap state at the current 750-entity milestone:

```text
English static routes:       13
Japanese static routes:      11
English dossier routes:     750
Japanese dossier routes:    750
Total sitemap routes:      1524
```

## Safety and validation updates

Updates existing gates so they understand bilingual output rather than treating Japanese routes as count inflation or unexpected sitemap entries:

- i18n foundation validation advances from F-1 pre-public state to L1 public pilot state;
- sitemap/canonical audit validates both locale route families;
- count semantics validates 750 English + 750 Japanese dossier outputs separately;
- public output consistency validates bilingual route coverage while keeping canonical machine data English-rooted and single-source;
- Japanese readiness gate validates route source contract, static HTML postprocessor self-test, build, i18n foundation, route completeness, lang, canonical, hreflang, Open Graph locale, and sitemap coverage.

## URL safety

Japanese dossiers preserve the existing HEI URL safety model:

- archive access is exposed when available;
- original URLs are clickable only for `live_verified` and `live_unverified`;
- dead, repurposed, unsafe, redirected, and unknown historical URLs are not promoted as normal live links by the Japanese dossier shell;
- archive-first behavior remains explicit for dead-side records.

## Deployment impact

Static Next.js output only. No Cloudflare configuration changes. No database or runtime dependency is added.

## Next execution

After all gates pass and the route family is verified on merged main, record the L-1 completion checkpoint and begin controlled L1-5 Japanese copy-overlay batches rather than broad automatic translation.