### PR TITLE
Link HEI to the BadJoke-Lab project hub

### DIFF
--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -76,6 +76,10 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
       <footer className="footer">
         <div className="footer-copy">{t('footer.registryTagline')}</div>
         <div className="footer-links">
+          <a className="archive-link" href="https://badjoke-lab.com/">
+            BadJoke-Lab project hub
+          </a>
+          <span className="muted footer-sep"> · </span>
           <a className="archive-link" href={CONTACT_HREF} target="_blank" rel="noreferrer">
             {t('footer.contactCorrections')}
           </a>


### PR DESCRIPTION
## What changed

- add a normal HTML link from the site-wide HEI footer to the canonical BadJoke-Lab project hub;
- keep all existing HEI navigation, localization, and external correction links unchanged.

## Why

The domain-level Search Console audit showed weak publisher and project relationships between the root domain and its subdomain projects. This link makes HEI's shared publisher relationship explicit on every ordinary page and gives crawlers a direct path back to the root project hub.

## Validation

- the link must render in both English and Japanese route output;
- existing localized navigation and footer links must remain unchanged;
- the production HTML must contain a direct `https://badjoke-lab.com/` anchor.