### PR TITLE
Record Dango, Odos, and Cascade lifecycle changes

### DIFF
--- a/records/exchanges/cascade.json
+++ b/records/exchanges/cascade.json
@@ -1,0 +1,109 @@
+{
+  "entity": {
+    "id": "hei_ex_001035",
+    "slug": "cascade",
+    "canonical_name": "Cascade",
+    "aliases": [
+      "Cascade XYZ",
+      "Cascade Perpetuals",
+      "cascade.xyz"
+    ],
+    "type": "dex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Arbitrum ecosystem",
+    "summary": "Invite-only perpetual markets platform in private beta. Cascade paused all trading and withdrawals after a July 2026 economic exploit of its Cascade Liquidity Strategy vault caused approximately 1.34 million USDC in user-fund losses.",
+    "official_url_original": "https://cascade.xyz/",
+    "official_domain_original": "cascade.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://cascade.xyz/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-07-25",
+    "notes": "Cascade remains publicly described as a private-beta perpetuals platform, and its website remains live. The operator confirmed that all trading and withdrawals were paused after the 15 July 2026 CLS vault exploit. HEI uses limited rather than inactive or dead because no verified shutdown announcement or permanent closure has been published. The investigation and recovery outcome remain unresolved."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010089",
+      "exchange_id": "hei_ex_001035",
+      "event_type": "exploit",
+      "event_date": "2026-07-15",
+      "title": "CLS vault exploit halted Cascade trading and withdrawals",
+      "description": "Attackers accumulated long positions in thin-liquidity markets, manipulated mark prices upward, and caused the Cascade Liquidity Strategy vault's opposing positions to be liquidated and auto-deleveraged. Cascade reported approximately 1.34 million USDC in losses and paused all trading and withdrawals.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "limited",
+      "source_count": 3,
+      "sort_order": 1,
+      "amount_text": "Approximately 1.34 million USDC",
+      "currency_text": "USDC",
+      "is_major_event": true,
+      "notes": "This records the confirmed economic exploit and operational pause. It does not classify unverified shutdown rumors as a terminal event and does not claim recovery, reimbursement, or resumed withdrawals."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012292",
+      "exchange_id": "hei_ex_001035",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Cascade perpetual markets application",
+      "url": "https://cascade.xyz/",
+      "publisher": "Cascade",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://cascade.xyz/",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site identifies Cascade as an invite-only platform for 24/7 perpetual markets and provides a live login surface."
+    },
+    {
+      "id": "hei_src_012293",
+      "exchange_id": "hei_ex_001035",
+      "event_id": "hei_ev_010089",
+      "source_type": "official_social",
+      "title": "Cascade CLS exploit disclosure",
+      "url": "https://x.com/cascade_xyz/status/2077747846011306123",
+      "publisher": "Cascade",
+      "published_at": "2026-07-16",
+      "archived_url": "https://web.archive.org/web/*/https://x.com/cascade_xyz/status/2077747846011306123",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party disclosure explains the thin-market position buildup, mark-price manipulation, CLS liquidations and ADL closures, approximately 1.34 million USDC loss, and pause of trading and withdrawals."
+    },
+    {
+      "id": "hei_src_012294",
+      "exchange_id": "hei_ex_001035",
+      "event_id": "hei_ev_010089",
+      "source_type": "news_article",
+      "title": "Cascade loses $1.3M in vault exploit after months of warnings",
+      "url": "https://www.cryptopolitan.com/cascade-exploit-after-months-of-warnings/",
+      "publisher": "Cryptopolitan",
+      "published_at": "2026-07-16",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptopolitan.com/cascade-exploit-after-months-of-warnings/",
+      "accessed_at": "2026-07-25",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Independent reporting corroborates the CLS vault loss, operational pause, private-beta deposit context, and cross-chain movement of the stolen funds. Unverified allegations in the article are not promoted into the canonical record."
+    },
+    {
+      "id": "hei_src_012295",
+      "exchange_id": "hei_ex_001035",
+      "event_id": "hei_ev_010089",
+      "source_type": "news_article",
+      "title": "Polychain-Backed Cascade Hacked for $1.34M in Locked User Funds",
+      "url": "https://www.cryptotimes.io/2026/07/16/polychain-backed-cascade-hacked-for-1-34m-in-locked-user-funds/",
+      "publisher": "The Crypto Times",
+      "published_at": "2026-07-16",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptotimes.io/2026/07/16/polychain-backed-cascade-hacked-for-1-34m-in-locked-user-funds/",
+      "accessed_at": "2026-07-25",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Independent report corroborates the approximate 1.34 million USDC loss and the Cascade CLS vault as the affected exchange-liquidity component."
+    }
+  ]
+}

--- a/records/exchanges/dango.json
+++ b/records/exchanges/dango.json
@@ -1,0 +1,105 @@
+{
+  "entity": {
+    "id": "hei_ex_001034",
+    "slug": "dango",
+    "canonical_name": "Dango",
+    "aliases": [
+      "Dango Exchange",
+      "The Endgame Exchange",
+      "dango.exchange"
+    ],
+    "type": "dex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": "2026-04-08",
+    "death_date": null,
+    "country_or_origin": "Dango L1 ecosystem",
+    "summary": "Perpetual futures decentralized exchange built on the Dango Layer 1 network. Dango announced an orderly project wind-down on 24 July 2026, with trading scheduled to halt on 29 July and the underlying chain scheduled to stop on 13 August.",
+    "official_url_original": "https://dango.exchange/",
+    "official_domain_original": "dango.exchange",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://dango.exchange/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-07-25",
+    "notes": "Dango remains in a phased wind-down rather than a completed shutdown. HEI therefore uses limited, leaves death_reason and death_date null, and records only the shutdown announcement. The scheduled 29 July trading halt and 13 August chain stop require later verification before a shutdown_effective event or dead classification is added."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010086",
+      "exchange_id": "hei_ex_001034",
+      "event_type": "launched",
+      "event_date": "2026-04-08",
+      "title": "Dango perpetuals exchange went live",
+      "description": "Dango announced that its perpetual futures exchange was live on the Dango Layer 1 network.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "The event records the public perps launch rather than an earlier testnet or chain-development milestone."
+    },
+    {
+      "id": "hei_ev_010087",
+      "exchange_id": "hei_ex_001034",
+      "event_type": "shutdown_announced",
+      "event_date": "2026-07-24",
+      "title": "Dango announced project wind-down",
+      "description": "Dango announced that trading would halt on 29 July 2026 at 12:00 UTC and that the Dango Layer 1 network would stop on 13 August 2026 at 12:00 UTC.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "limited",
+      "source_count": 2,
+      "sort_order": 2,
+      "notes": "Remaining positions are scheduled to close at oracle prices, DLP vault deposits are scheduled to unlock, and funds are scheduled to return as USDC. This is an announcement event; future completion is not pre-recorded."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012287",
+      "exchange_id": "hei_ex_001034",
+      "event_id": "hei_ev_010086",
+      "source_type": "official_social",
+      "title": "Dango perps are live",
+      "url": "https://x.com/dango/status/2041949548419973123",
+      "publisher": "Dango",
+      "published_at": "2026-04-08",
+      "archived_url": "https://web.archive.org/web/*/https://x.com/dango/status/2041949548419973123",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "launch_date",
+      "notes": "First-party launch announcement for the public perpetual futures exchange."
+    },
+    {
+      "id": "hei_src_012288",
+      "exchange_id": "hei_ex_001034",
+      "event_id": "hei_ev_010087",
+      "source_type": "official_social",
+      "title": "Dango project wind-down announcement",
+      "url": "https://x.com/dango/status/2080707796144705625",
+      "publisher": "Dango",
+      "published_at": "2026-07-24",
+      "archived_url": "https://web.archive.org/web/*/https://x.com/dango/status/2080707796144705625",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice gives the trading-halt, position-closure, DLP unlock, USDC return, chain-stop, and residual-deposit refund schedule."
+    },
+    {
+      "id": "hei_src_012289",
+      "exchange_id": "hei_ex_001034",
+      "event_id": "hei_ev_010087",
+      "source_type": "news_article",
+      "title": "Perp DEX Dango to Wind Down, Will Halt Trading July 29",
+      "url": "https://thedefiant.io/news/defi/perp-dex-dango-to-wind-down-will-halt-trading-july-29",
+      "publisher": "The Defiant",
+      "published_at": "2026-07-24",
+      "archived_url": "https://web.archive.org/web/*/https://thedefiant.io/news/defi/perp-dex-dango-to-wind-down-will-halt-trading-july-29",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Independent reporting corroborates the phased shutdown schedule and identifies Dango as a perpetuals DEX on its own Layer 1."
+    }
+  ]
+}

--- a/records/exchanges/odos.json
+++ b/records/exchanges/odos.json
@@ -1,1 +1,119 @@
-{"entity":{"id":"hei_ex_000929","slug":"odos","canonical_name":"Odos","aliases":["Odos Router"],"type":"dex","status":"active","death_reason":null,"launch_date":null,"death_date":null,"country_or_origin":"Multichain ecosystem","summary":"Multichain decentralized exchange aggregator routing token swaps across EVM networks through a public application, API, quote and execution endpoints, and liquidity-source integrations.","official_url_original":"https://app.odos.xyz/","official_domain_original":"odos.xyz","official_url_status":"live_verified","archived_url":"https://web.archive.org/web/*/https://app.odos.xyz/","predecessor_id":null,"successor_id":null,"confidence":"high","last_verified_at":"2026-07-15","notes":"Current first-party documentation links the live Odos application and identifies the protocol as an active on-chain liquidity aggregator and swap router. It documents quote, assemble, execution, token-swap, liquidity-zap, contract, API, and multichain functions. No exact launch date, legal jurisdiction, predecessor, successor, or terminal lifecycle fact is asserted."},"events":[],"evidence":[{"id":"hei_src_012072","exchange_id":"hei_ex_000929","event_id":null,"source_type":"official_statement","title":"Odos documentation introduction","url":"https://docs.odos.xyz/","publisher":"Odos","published_at":null,"archived_url":"https://web.archive.org/web/*/https://docs.odos.xyz/","accessed_at":"2026-07-15","reliability":"high","claim_scope":"entity","notes":"First-party documentation describes Odos as a DeFi liquidity aggregation and routing system integrating DEXs, AMMs, order books, lending sources, and RFQ systems for on-chain swaps."},{"id":"hei_src_012073","exchange_id":"hei_ex_000929","event_id":null,"source_type":"official_statement","title":"Odos live application and API status","url":"https://app.odos.xyz/","publisher":"Odos","published_at":null,"archived_url":"https://web.archive.org/web/*/https://app.odos.xyz/","accessed_at":"2026-07-15","reliability":"high","claim_scope":"status","notes":"The current first-party documentation links the live application and reports live API v3 routing, token swaps, quote and execution endpoints, liquidity zaps, supported networks, and deployed contracts."}]}
+{
+  "entity": {
+    "id": "hei_ex_000929",
+    "slug": "odos",
+    "canonical_name": "Odos",
+    "aliases": [
+      "Odos Router"
+    ],
+    "type": "dex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Multichain ecosystem",
+    "summary": "Multichain decentralized exchange aggregator winding down after announcing that its application will become read-only on 27 July 2026 and all company-operated services will end on 30 July 2026.",
+    "official_url_original": "https://app.odos.xyz/",
+    "official_domain_original": "odos.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://app.odos.xyz/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-07-25",
+    "notes": "Odos announced a phased wind-down on 23 July 2026. New registrations, social-login wallet creation, and new limit orders stopped immediately; the app is scheduled to become read-only on 27 July, and all company-operated services are scheduled to stop on 30 July. Because swaps remain available during the transition and the final shutdown is in the future, HEI uses limited and leaves death_reason and death_date null. The ODOS token and Odos DAO remain separate from the operating company."
+  },
+  "entity_correction": {
+    "entity_id": "hei_ex_000929",
+    "expected": {
+      "status": "active",
+      "summary": "Multichain decentralized exchange aggregator routing token swaps across EVM networks through a public application, API, quote and execution endpoints, and liquidity-source integrations.",
+      "last_verified_at": "2026-07-15",
+      "notes": "Current first-party documentation links the live Odos application and identifies the protocol as an active on-chain liquidity aggregator and swap router. It documents quote, assemble, execution, token-swap, liquidity-zap, contract, API, and multichain functions. No exact launch date, legal jurisdiction, predecessor, successor, or terminal lifecycle fact is asserted."
+    },
+    "changes": {
+      "status": "limited",
+      "summary": "Multichain decentralized exchange aggregator winding down after announcing that its application will become read-only on 27 July 2026 and all company-operated services will end on 30 July 2026.",
+      "last_verified_at": "2026-07-25",
+      "notes": "Odos announced a phased wind-down on 23 July 2026. New registrations, social-login wallet creation, and new limit orders stopped immediately; the app is scheduled to become read-only on 27 July, and all company-operated services are scheduled to stop on 30 July. Because swaps remain available during the transition and the final shutdown is in the future, HEI uses limited and leaves death_reason and death_date null. The ODOS token and Odos DAO remain separate from the operating company."
+    }
+  },
+  "events": [
+    {
+      "id": "hei_ev_010088",
+      "exchange_id": "hei_ex_000929",
+      "event_type": "shutdown_announced",
+      "event_date": "2026-07-23",
+      "title": "Odos announced permanent service shutdown",
+      "description": "The company operating Odos announced that the application would move to read-only mode on 27 July 2026 and that all company-operated services would shut down permanently on 30 July 2026.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "limited",
+      "source_count": 2,
+      "sort_order": 10,
+      "notes": "New registrations, Odos-created wallets, and new limit orders stopped with the announcement. A shutdown_effective event and dead classification require verification after the scheduled service termination."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012072",
+      "exchange_id": "hei_ex_000929",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Odos documentation introduction",
+      "url": "https://docs.odos.xyz/",
+      "publisher": "Odos",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.odos.xyz/",
+      "accessed_at": "2026-07-15",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation describes Odos as a DeFi liquidity aggregation and routing system integrating DEXs, AMMs, order books, lending sources, and RFQ systems for on-chain swaps."
+    },
+    {
+      "id": "hei_src_012073",
+      "exchange_id": "hei_ex_000929",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Odos live application and API status",
+      "url": "https://app.odos.xyz/",
+      "publisher": "Odos",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.odos.xyz/",
+      "accessed_at": "2026-07-15",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "The current first-party documentation links the live application and reports live API v3 routing, token swaps, quote and execution endpoints, liquidity zaps, supported networks, and deployed contracts."
+    },
+    {
+      "id": "hei_src_012290",
+      "exchange_id": "hei_ex_000929",
+      "event_id": "hei_ev_010088",
+      "source_type": "official_social",
+      "title": "Odos operating company wind-down announcement",
+      "url": "https://x.com/odosprotocol/status/2080337624922018014",
+      "publisher": "Odos",
+      "published_at": "2026-07-23",
+      "archived_url": "https://web.archive.org/web/*/https://x.com/odosprotocol/status/2080337624922018014",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party announcement gives the read-only and permanent shutdown dates, confirms non-custodial operation, separates the token and DAO from the operating company, and warns against fake migrations or claim sites."
+    },
+    {
+      "id": "hei_src_012291",
+      "exchange_id": "hei_ex_000929",
+      "event_id": "hei_ev_010088",
+      "source_type": "news_article",
+      "title": "Odos to Shut Down DEX Aggregator on July 30",
+      "url": "https://thedefiant.io/news/defi/odos-to-shut-down-dex-aggregator-on-july-30",
+      "publisher": "The Defiant",
+      "published_at": "2026-07-24",
+      "archived_url": "https://web.archive.org/web/*/https://thedefiant.io/news/defi/odos-to-shut-down-dex-aggregator-on-july-30",
+      "accessed_at": "2026-07-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Independent reporting corroborates the service timeline and distinguishes self-custody wallet users from social-login wallet users who must transfer assets or export keys."
+    }
+  ]
+}

--- a/records/exchanges/odos.json
+++ b/records/exchanges/odos.json
@@ -23,21 +23,6 @@
     "last_verified_at": "2026-07-25",
     "notes": "Odos announced a phased wind-down on 23 July 2026. New registrations, social-login wallet creation, and new limit orders stopped immediately; the app is scheduled to become read-only on 27 July, and all company-operated services are scheduled to stop on 30 July. Because swaps remain available during the transition and the final shutdown is in the future, HEI uses limited and leaves death_reason and death_date null. The ODOS token and Odos DAO remain separate from the operating company."
   },
-  "entity_correction": {
-    "entity_id": "hei_ex_000929",
-    "expected": {
-      "status": "active",
-      "summary": "Multichain decentralized exchange aggregator routing token swaps across EVM networks through a public application, API, quote and execution endpoints, and liquidity-source integrations.",
-      "last_verified_at": "2026-07-15",
-      "notes": "Current first-party documentation links the live Odos application and identifies the protocol as an active on-chain liquidity aggregator and swap router. It documents quote, assemble, execution, token-swap, liquidity-zap, contract, API, and multichain functions. No exact launch date, legal jurisdiction, predecessor, successor, or terminal lifecycle fact is asserted."
-    },
-    "changes": {
-      "status": "limited",
-      "summary": "Multichain decentralized exchange aggregator winding down after announcing that its application will become read-only on 27 July 2026 and all company-operated services will end on 30 July 2026.",
-      "last_verified_at": "2026-07-25",
-      "notes": "Odos announced a phased wind-down on 23 July 2026. New registrations, social-login wallet creation, and new limit orders stopped immediately; the app is scheduled to become read-only on 27 July, and all company-operated services are scheduled to stop on 30 July. Because swaps remain available during the transition and the final shutdown is in the future, HEI uses limited and leaves death_reason and death_date null. The ODOS token and Odos DAO remain separate from the operating company."
-    }
-  },
   "events": [
     {
       "id": "hei_ev_010088",


### PR DESCRIPTION
## Trigger

Three exchange lifecycle changes announced or confirmed in July 2026 require canonical HEI treatment.

- Dango announced on 24 July that perpetuals trading is scheduled to halt on 29 July 2026 at 12:00 UTC and its Layer 1 is scheduled to stop on 13 August 2026 at 12:00 UTC.
- Odos announced on 23 July that its application is scheduled to become read-only on 27 July and that all company-operated services are scheduled to end on 30 July 2026.
- Cascade confirmed a 15 July exploit of its CLS vault, approximately 1.34 million USDC in user-fund losses, and a pause of all trading and withdrawals.

## Canonical changes

### Dango

Adds Dango as `hei_ex_001034` with:

```text
status: limited
launch_date: 2026-04-08
death_reason: null
death_date: null
```

The record includes the public perps launch and the shutdown announcement. It does not pre-create either the 29 July trading halt or the 13 August chain stop as completed events.

### Odos

Updates existing record bundle `hei_ex_000929`:

```text
status: active -> limited
death_reason: null
death_date: null
```

Adds a `shutdown_announced` event for 23 July. The future read-only and shutdown dates remain in the announcement description and require later verification.

### Cascade

Adds Cascade as `hei_ex_001035` with:

```text
status: limited
type: dex
death_reason: null
death_date: null
```

Adds the 15 July CLS vault exploit with an approximately 1.34 million USDC loss and confirmed trading/withdrawal pause. No shutdown, recovery, reimbursement, or resumed-withdrawal event is inferred.

## IDs

```text
entities   hei_ex_001034–hei_ex_001035
events     hei_ev_010086–hei_ev_010089
evidence   hei_src_012287–hei_src_012295
```

## Evidence

- first-party Dango launch and wind-down posts
- first-party Odos wind-down post
- first-party Cascade site and exploit disclosure
- independent reporting for all three cases

## Status discipline

None of the three entities is classified `dead` in this PR.

- Dango trading and the underlying chain have future scheduled stop dates.
- Odos swaps remain available during its planned transition.
- Cascade remains a live private-beta surface but has paused all trading and withdrawals after the exploit; permanent closure is not verified.

Future `shutdown_effective`, `death_reason`, `death_date`, recovery, or reopening changes require later verification.

## Scope boundaries

- The Dango April exploit is not added in this bounded lifecycle PR.
- The ODOS token and Odos DAO are not treated as successor exchange services.
- Cascade shutdown rumors are not promoted; only the confirmed exploit and pause are recorded.
- No schema, localization, Cloudflare, deployment, count-semantics, or public-safety rule changes are included.

All normal HEI pull-request workflows remain authoritative.