### PR TITLE
Add D-1000 BX33 reviewed exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "D-1000 Reviewed Entity Milestone",
   "reviewed_counts": {
-    "entities": 927,
+    "entities": 931,
     "events": 1014,
-    "evidence": 3624
+    "evidence": 3632
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -24,7 +24,7 @@
     "l2_evidence_snapshot": "data-evaluation/l2-localization-evidence.json",
     "l2_evaluator": "scripts/evaluate-l2-localization-gate.mjs",
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
-    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX32_2026-07-28.md",
+    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX33_2026-07-28.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -38,15 +38,15 @@ The initial L2 state is expected to be HOLD because the public Japanese Pilot ha
 
 HOLD keeps the Japanese Pilot public but does not block reviewed canonical data growth.
 
-After D-1000 batch BX32, the projected reviewed state is:
+After D-1000 batch BX33, the projected reviewed state is:
 
 ```text
-Entities: 927
+Entities: 931
 Events:   1014
-Evidence: 3624
+Evidence: 3632
 ```
 
-The localization decision remains HOLD. Translation breadth is not expanded by BX32, and third-language authorization remains false.
+The localization decision remains HOLD. Translation breadth is not expanded by BX33, and third-language authorization remains false.
 
 ## 3. Evidence categories
 

--- a/docs/audits/HEI_D1000_PROGRESS_BX33_2026-07-28.md
+++ b/docs/audits/HEI_D1000_PROGRESS_BX33_2026-07-28.md
@@ -1,0 +1,88 @@
+# HEI D-1000 Progress Checkpoint — BX33
+
+Date: 2026-07-28  
+Status: IN PROGRESS  
+Project: Historical Exchange Index (HEI)
+
+## 1. Starting state
+
+BX33 starts from current `main` commit `a195b8056c9dd4794cd7d618e0075d05eca57ace` after the reviewed BX32 merge.
+
+```text
+Entities: 927
+Events:   1014
+Evidence: 3624
+```
+
+The values use reviewed public aggregation semantics rather than base-array lengths.
+
+## 2. Direct overlap controls
+
+Repository search, historical pull-request search, and direct canonical-path reads were performed before drafting.
+
+Several current derivatives-exchange candidates were rejected after direct reads found existing reviewed records, including GRVT, edgeX, Paradex, Pacifica, Hibachi, Reya, Extended, and Avantis. Byte Exchange and Niza.io were also already represented.
+
+Gate US and OKJ were held rather than added because they could represent regional or successor surfaces of existing Gate.io and OKCoin / OKX lineages. BX33 does not create regional product splits without explicit entity-level evidence.
+
+The final BX33 paths and common alternate slugs were confirmed absent from current main before IDs were assigned:
+
+```text
+LeveX       -> records/exchanges/levex.json
+NonKYC.io   -> records/exchanges/nonkyc-io.json
+MAX Exchange -> records/exchanges/max-exchange.json
+Tokpie      -> records/exchanges/tokpie.json
+```
+
+## 3. Final batch
+
+```text
+LeveX        hei_ex_001048 active
+NonKYC.io    hei_ex_001049 active
+MAX Exchange hei_ex_001050 active
+Tokpie       hei_ex_001051 active
+```
+
+BX33 adds no lifecycle event. The next event ID remains `hei_ev_010091`.
+
+## 4. Projected reviewed state
+
+```text
+Entities: 931
+Events:   1014
+Evidence: 3632
+```
+
+```text
+Entities: +4
+Events:   +0
+Evidence: +8
+```
+
+```text
+English dossiers:   931
+Japanese dossiers:  931
+Sitemap routes:     1906
+Remaining to D-1000: 69
+```
+
+## 5. Status and evidence discipline
+
+LeveX is `active` from current first-party exchange, product, support, legal, and proof-of-reserves surfaces plus current independent markets, volume, and reserves. Origin remains `Global / Panama` and confidence remains `medium` because the public materials do not establish one globally supervising regulator or a fully resolved operating-group structure.
+
+NonKYC.io is `active` from current first-party technical repositories and announcement channels plus current independent markets, volume, and reserves. The official homepage was not independently fetched during this pass, so `official_url_status` remains `live_unverified` and confidence remains `medium`.
+
+MAX Exchange is `active` from current first-party MaiCoin Group history, operator information, exchange and support surfaces, and current independent TWD and USDT markets. MAX is modeled as its own exchange venue while the sibling MaiCoin retail platform is not collapsed into an alias-only duplicate.
+
+Tokpie is `active` from the current first-party exchange, live market table, product surfaces, and Panama operator footer plus current independent markets and volume. The independent Hong Kong registration/address is retained as an unresolved discrepancy rather than replacing the current first-party operating origin.
+
+No unsupported terminal state, exact launch day, broad regulatory authorization, predecessor, successor, or artificial regional product split is introduced.
+
+## 6. Boundaries
+
+BX33 changes reviewed exchange bundles and checkpoint authority only. It does not change L-2 HOLD, Japanese Pilot scope, third-language authorization, schemas, machine-readable safety rules, Cloudflare configuration, route contracts, or production verification policy.
+
+## 7. Validation gate
+
+The final head must pass Records validation, Backlog dedupe, Candidate scan, Watchlist resolution, Count semantics, Maintainer recovery, Machine/public consistency, Japanese Pilot readiness, L2 localization evaluation, URL safety, Country origin, CI, and the remaining normal HEI audits.
+
+Any duplicate, ID collision, reference-integrity, count, URL-safety, enum, lifecycle, country, or recovery-contract failure must be repaired rather than bypassed.

--- a/docs/backlog/consumed/hei_unadded-bx33-four-reviewed-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx33-four-reviewed-exchange-records.md
@@ -1,0 +1,61 @@
+# HEI BX33 Consumed Candidate Note
+
+Date: 2026-07-28
+
+## Starting state
+
+BX33 starts from `main` commit `a195b8056c9dd4794cd7d618e0075d05eca57ace` after the reviewed BX32 merge.
+
+```text
+Entities: 927
+Events:   1014
+Evidence: 3624
+```
+
+## Rejected overlap and split set
+
+Search-index results alone were not treated as authoritative. Direct canonical-path reads found GRVT, edgeX, Paradex, Pacifica, Hibachi, Reya, Extended, Avantis, Byte Exchange, and Niza.io already represented.
+
+Gate US and OKJ were held because the available review did not justify separate entities from existing Gate.io and OKCoin / OKX lineages. Regional or successor surfaces are not promoted merely because an independent directory lists them separately.
+
+## Promoted
+
+```text
+LeveX        -> hei_ex_001048 active
+NonKYC.io    -> hei_ex_001049 active
+MAX Exchange -> hei_ex_001050 active
+Tokpie       -> hei_ex_001051 active
+```
+
+## Review basis
+
+### LeveX
+
+- Current first-party material exposes spot, perpetual futures, social trading, competitions, API, support, and proof-of-reserves-related services.
+- Current independent data reports recently updated markets, non-zero activity, reserves, a 2023 establishment year, and Panama registration.
+- The first-party material does not establish one globally supervising regulator, so confidence remains `medium`.
+
+### NonKYC.io
+
+- Current first-party GitHub repositories expose maintained REST, websocket, HMAC, Python, Hummingbot, and exchange-adapter resources.
+- Current first-party announcement channels continue publishing asset, deposit, and delisting notices.
+- Current independent data reports current markets, non-zero activity, reserves, a 2023 establishment year, and Seychelles registration.
+- The official homepage was not independently fetched in this pass, so URL status remains `live_unverified` and confidence remains `medium`.
+
+### MAX Exchange
+
+- Current first-party MaiCoin Group history identifies the operating group and states that MAX Exchange launched in Taiwan in 2018.
+- Current first-party exchange and support surfaces expose trading, staking, bots, APIs, TWD bank-trust arrangements, operator information, and recent announcements.
+- Current independent data reports recently updated TWD and USDT markets, non-zero activity, Taiwan registration, and VASP AML-registration context.
+- MAX is retained as a distinct exchange venue from the sibling MaiCoin retail platform.
+
+### Tokpie
+
+- Current first-party site exposes live markets, trading, token listing, lending and borrowing, launchpad, card purchase, API, and bounty-stake products.
+- The current first-party footer identifies Graceful Globe S.A. in Panama.
+- Current independent data reports recently updated markets, non-zero activity, a 2018 establishment year, and a Hong Kong registration/address.
+- The Panama / Hong Kong discrepancy is retained rather than resolved through unsupported inference.
+
+## Safety note
+
+Current operation was not inferred from a live homepage alone. Each active classification uses current product, technical, legal, or operator surfaces together with independent market activity. No unsupported exact launch day, global licensing conclusion, terminal event, predecessor, successor, or regional product split is introduced.

--- a/records/exchanges/levex.json
+++ b/records/exchanges/levex.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001048",
+    "slug": "levex",
+    "canonical_name": "LeveX",
+    "aliases": ["LeveX Exchange", "LeveX Trading Platform", "levex.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2023-10-01",
+    "death_date": null,
+    "country_or_origin": "Global / Panama",
+    "summary": "Community-oriented centralized cryptocurrency exchange launched in October 2023 and providing current spot, perpetual-futures, social-trading, tournament, API, and proof-of-reserves-related services.",
+    "official_url_original": "https://levex.com/",
+    "official_domain_original": "levex.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://levex.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-07-28",
+    "notes": "Current first-party About, support, and legal materials describe an operating global exchange with spot and futures trading, deposits, withdrawals, social features, competitions, proof-of-reserves disclosures, and an October 2023 launch. First-party support states that LeveX is based across multiple cities and is not overseen by one specific national regulator, while current independent exchange data reports Panama registration, recently updated markets, non-zero volume, and reserves. HEI therefore records Global / Panama origin and does not convert narrow registrations or self-descriptions into a broad licensing claim. October 1 is used as a month-level launch marker because the first-party source gives October 2023 without an exact day."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012321",
+      "exchange_id": "hei_ex_001048",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "About LeveX",
+      "url": "https://levex.com/en/about",
+      "publisher": "LeveX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://levex.com/en/about",
+      "accessed_at": "2026-07-28",
+      "reliability": "high",
+      "claim_scope": "launch_date",
+      "notes": "First-party About material identifies the current exchange, its community and trading features, proof-of-reserves posture, and an October 2023 launch."
+    },
+    {
+      "id": "hei_src_012322",
+      "exchange_id": "hei_ex_001048",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "LeveX exchange profile and current markets",
+      "url": "https://www.coingecko.com/en/exchanges/levex",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-07-28",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current independent profile reports recently updated spot markets, non-zero trading activity, exchange reserves, a 2023 establishment year, and Panama registration."
+    }
+  ]
+}

--- a/records/exchanges/max-exchange.json
+++ b/records/exchanges/max-exchange.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001050",
+    "slug": "max-exchange",
+    "canonical_name": "MAX Exchange",
+    "aliases": ["MAX Maicoin", "MaiCoin | MAX", "MAX Digital Asset Exchange", "max.maicoin.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2018-01-01",
+    "death_date": null,
+    "country_or_origin": "Taiwan",
+    "summary": "Taiwan-based centralized digital-asset exchange launched in 2018 by the MaiCoin group and currently providing New Taiwan dollar and crypto spot markets, staking, trading bots, APIs, and bank-trust-supported fiat services.",
+    "official_url_original": "https://max.maicoin.com/",
+    "official_domain_original": "max.maicoin.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://max.maicoin.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-07-28",
+    "notes": "Current first-party MaiCoin Group material identifies Modernity Financial Technologies Co., Ltd., states that MAX Exchange launched in Taiwan in 2018, and distinguishes MAX from the sibling MaiCoin platform while presenting both within one operating group. Current first-party exchange and support surfaces expose live trading, staking, bots, API documentation, TWD bank-trust arrangements, operator details, and July 2026 announcements. Current independent data reports recently updated TWD and USDT markets, non-zero volume, a 2018 establishment year, Taiwan registration, and VASP AML registration. HEI models MAX Exchange as its own trading venue rather than treating the separate MaiCoin retail platform as an alias-only duplicate. January 1 is used as a year-level launch marker because the reviewed sources do not provide an exact public launch day."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012325",
+      "exchange_id": "hei_ex_001050",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "MaiCoin Group company history and MAX Exchange launch",
+      "url": "https://group.maicoin.com/about",
+      "publisher": "MaiCoin Group",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://group.maicoin.com/about",
+      "accessed_at": "2026-07-28",
+      "reliability": "high",
+      "claim_scope": "ownership",
+      "notes": "First-party group history identifies the operating companies, distinguishes MaiCoin and MAX Exchange, and records the MAX Exchange launch in Taiwan in 2018."
+    },
+    {
+      "id": "hei_src_012326",
+      "exchange_id": "hei_ex_001050",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "MAX Exchange profile and current markets",
+      "url": "https://www.coingecko.com/en/exchanges/max-maicoin",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-07-28",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current independent profile reports recently updated markets, non-zero trading activity, a 2018 establishment year, Taiwan registration, and Taiwan VASP AML registration context."
+    }
+  ]
+}

--- a/records/exchanges/nonkyc-io.json
+++ b/records/exchanges/nonkyc-io.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001049",
+    "slug": "nonkyc-io",
+    "canonical_name": "NonKYC.io",
+    "aliases": ["NonKyc.io", "NonKYC Exchange", "NonKYCExchange", "nonkyc.io"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2023-01-01",
+    "death_date": null,
+    "country_or_origin": "Seychelles",
+    "summary": "Privacy-oriented centralized spot cryptocurrency exchange established in 2023 and providing current account-based deposit, trading, withdrawal, API, websocket, and privacy-coin market services.",
+    "official_url_original": "https://nonkyc.io/",
+    "official_domain_original": "nonkyc.io",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://nonkyc.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-07-28",
+    "notes": "Current first-party GitHub organization and repositories link the nonkyc.io domain and expose maintained REST, HMAC, websocket, Python, and trading-bot integration resources. Current first-party announcement channels continue publishing asset, deposit, and delisting notices. Current independent exchange data reports recently updated spot markets, non-zero volume, reserves, a 2023 establishment year, and Seychelles registration. The official homepage could not be independently fetched during this review pass, so official_url_status remains live_unverified and confidence remains medium. No regulatory authorization, operator legal entity, lineage, or relationship to other exchanges is asserted. January 1 is used as a year-level launch marker."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012323",
+      "exchange_id": "hei_ex_001049",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "NonKYC.io official GitHub organization",
+      "url": "https://github.com/NonKYCExchange",
+      "publisher": "NonKYC.io",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://github.com/NonKYCExchange",
+      "accessed_at": "2026-07-28",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party organization links nonkyc.io and maintains API, websocket, Python-client, HMAC, Hummingbot, and adapter repositories supporting the active exchange identity and technical surface."
+    },
+    {
+      "id": "hei_src_012324",
+      "exchange_id": "hei_ex_001049",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "NonKYC.io exchange profile and current markets",
+      "url": "https://www.coingecko.com/en/exchanges/nonkyc-io",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-07-28",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current independent profile reports recently updated markets, non-zero spot volume, exchange reserves, a 2023 establishment year, and Seychelles registration."
+    }
+  ]
+}

--- a/records/exchanges/tokpie.json
+++ b/records/exchanges/tokpie.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001051",
+    "slug": "tokpie",
+    "canonical_name": "Tokpie",
+    "aliases": ["TOKPIE Exchange", "Graceful Globe S.A.", "tokpie.io", "tokpie.com"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2018-01-01",
+    "death_date": null,
+    "country_or_origin": "Panama",
+    "summary": "Panama-operated centralized cryptocurrency exchange launched in 2018 and providing current spot trading, token listing, lending and borrowing, launchpad, card purchase, API, and bounty-stake-related services.",
+    "official_url_original": "https://tokpie.io/",
+    "official_domain_original": "tokpie.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://tokpie.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-07-28",
+    "notes": "Current first-party website exposes live market data, trading entry points, 100+ crypto assets, lending and borrowing, token listing, launchpad, card purchase, API, and bounty-stake products, and identifies Graceful Globe S.A. in Panama in the current footer. Current independent exchange data reports recently updated markets, non-zero volume, a 2018 establishment year, and a Hong Kong registration/address. HEI uses Panama for the current first-party operating origin and retains the independent Hong Kong discrepancy in notes rather than asserting a resolved group structure. January 1 is a year-level launch marker."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012327",
+      "exchange_id": "hei_ex_001051",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Tokpie official exchange platform",
+      "url": "https://tokpie.io/",
+      "publisher": "Tokpie",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://tokpie.io/",
+      "accessed_at": "2026-07-28",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party site exposes live markets, trading and account entry points, exchange products, and identifies Graceful Globe S.A. in Panama."
+    },
+    {
+      "id": "hei_src_012328",
+      "exchange_id": "hei_ex_001051",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Tokpie exchange profile and current markets",
+      "url": "https://www.coingecko.com/en/exchanges/tokpie",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-07-28",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current independent profile reports recently updated markets, non-zero trading activity, a 2018 establishment year, and a Hong Kong registration/address."
+    }
+  ]
+}


### PR DESCRIPTION
## Roadmap item

D-1000 Reviewed Entity Milestone — BX33 reviewed canonical growth.

## Starting state

BX33 starts from current `main` commit `a195b8056c9dd4794cd7d618e0075d05eca57ace` after BX32.

```text
Entities: 927
Events:   1014
Evidence: 3624
English dossiers:   927
Japanese dossiers:  927
Sitemap routes:     1898
```

## Direct overlap controls

Search-index results were not trusted without direct reads. GRVT, edgeX, Paradex, Pacifica, Hibachi, Reya, Extended, Avantis, Byte Exchange, and Niza.io were rejected after current-main canonical-path checks found existing reviewed records.

Gate US and OKJ were held because the available evidence did not justify separate entities from existing Gate.io and OKCoin / OKX lineages. BX33 does not create regional or successor splits merely because an independent directory lists a separate market surface.

Direct current-main alternate-slug checks and historical PR search found no existing reviewed records for the final BX33 set.

## Reviewed additions

```text
LeveX        hei_ex_001048 active
NonKYC.io    hei_ex_001049 active
MAX Exchange hei_ex_001050 active
Tokpie       hei_ex_001051 active
```

BX33 adds no lifecycle event. The next event ID remains `hei_ev_010091`.

## Projected reviewed state

```text
Entities: 931
Events:   1014
Evidence: 3632
English dossiers:   931
Japanese dossiers:  931
Sitemap routes:     1906
Remaining to D-1000: 69
```

Canonical delta:

```text
Entities: +4
Events:   +0
Evidence: +8
```

## Status discipline

- LeveX is `active` from current first-party exchange, product, support, legal, and proof-of-reserves surfaces plus current independent markets, volume, and reserves. Confidence remains `medium` and origin remains `Global / Panama`; no broad regulatory-supervision claim is introduced.
- NonKYC.io is `active` from current first-party technical repositories and announcement channels plus current independent markets, volume, and reserves. Its homepage could not be independently fetched during this pass, so `official_url_status` remains `live_unverified` and confidence remains `medium`.
- MAX Exchange is `active` from current first-party MaiCoin Group history, operator, exchange, support, and TWD bank-trust surfaces plus current independent markets. MAX remains a distinct exchange venue from the sibling MaiCoin retail platform.
- Tokpie is `active` from current first-party live markets, exchange products, and Panama operator footer plus current independent markets and volume. The independent Hong Kong registration/address is retained as an unresolved discrepancy rather than replacing the first-party operating origin.

No unsupported terminal state, exact launch day, broad regulatory authorization, predecessor, successor, or artificial regional product split is introduced.

## Deployment impact

None. This PR changes reviewed record bundles and checkpoint documentation only. It does not change Cloudflare configuration, workflows, build configuration, schemas, route contracts, localization breadth, machine-readable safety rules, or production verification policy.

Cloudflare preview is not required for this record-only batch.

## Validation

The complete GitHub workflow matrix must pass on the final head. Any duplicate, ID collision, reference-integrity, count, URL-safety, enum, lifecycle, country, recovery-contract, localization, or public-output failure will be repaired rather than bypassed.

## Production verification plan

No manual deployment-sensitive verification is required before merge. After merge, ordinary reviewed-public aggregation should expose four additional English and Japanese dossier routes, and count-sensitive output remains covered by the normal machine/public consistency and production contracts.