### PR TITLE
Add D-1000 BX42 reviewed exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "D-1000 Reviewed Entity Milestone",
   "reviewed_counts": {
-    "entities": 963,
+    "entities": 967,
     "events": 1017,
-    "evidence": 3698
+    "evidence": 3706
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -24,7 +24,7 @@
     "l2_evidence_snapshot": "data-evaluation/l2-localization-evidence.json",
     "l2_evaluator": "scripts/evaluate-l2-localization-gate.mjs",
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
-    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX41_2026-08-02.md",
+    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX42_2026-08-02.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -38,15 +38,15 @@ The initial L2 state is expected to be HOLD because the public Japanese Pilot ha
 
 HOLD keeps the Japanese Pilot public but does not block reviewed canonical data growth.
 
-After D-1000 batch BX41, the projected reviewed state is:
+After D-1000 batch BX42, the projected reviewed state is:
 
 ```text
-Entities: 963
+Entities: 967
 Events:   1017
-Evidence: 3698
+Evidence: 3706
 ```
 
-The localization decision remains HOLD. Translation breadth is not expanded by BX41, and third-language authorization remains false.
+The localization decision remains HOLD. Translation breadth is not expanded by BX42, and third-language authorization remains false.
 
 ## 3. Evidence categories
 

--- a/docs/audits/HEI_D1000_PROGRESS_BX42_2026-08-02.md
+++ b/docs/audits/HEI_D1000_PROGRESS_BX42_2026-08-02.md
@@ -1,0 +1,84 @@
+# HEI D-1000 Progress — BX42
+
+Date: 2026-08-02  
+Milestone: D-1000 Reviewed Entity Milestone  
+Batch: BX42
+
+## Starting reviewed state
+
+```text
+Entities: 963
+Events:   1017
+Evidence: 3698
+English dossiers:   963
+Japanese dossiers:  963
+Sitemap routes:     1970
+```
+
+## Reviewed additions
+
+| Entity | ID | Type | Status | Confidence |
+| --- | --- | --- | --- | --- |
+| Quidax | `hei_ex_001084` | cex | active | high |
+| Busha | `hei_ex_001085` | cex | active | high |
+| belo | `hei_ex_001086` | cex | active | high |
+| Lemon | `hei_ex_001087` | cex | active | high |
+
+BX42 adds four reviewed entities and eight reviewed evidence records. It adds no lifecycle event.
+
+## Identity and overlap controls
+
+Direct canonical-path checks found no reviewed bundles at `quidax`, `busha`, `belo`, or `lemon-cash`. The base canonical entity array contained no matching canonical name, legal-operator name, or official domain for the four additions. Historical commit searches for Quidax, Busha, Belo, and Lemon Cash returned no prior additions.
+
+The four records remain separate entities:
+
+- Quidax is the Nigeria-origin exchange operated by Quidax Technologies Limited.
+- Busha is the Nigeria-origin exchange operated by Busha Digital Limited.
+- belo is the Argentina-origin service operated for Argentine users by Belo Argentina S.A.
+- Lemon is the Argentina-origin platform whose virtual-asset services identify Bay Treasure Caramel S.A. as the registered operator.
+
+No predecessor, successor, merger, acquisition, rebrand, or shared-entity relationship is asserted among them.
+
+## Status discipline
+
+- Quidax is `active` at high confidence from its current first-party platform and Nigeria SEC registered-operator listing.
+- Busha is `active` at high confidence from its current first-party platform and Nigeria SEC registered-operator listing.
+- belo is `active` at high confidence from its current first-party platform and current terms defining crypto purchase, sale, balance, transfer, and receipt functions.
+- Lemon is `active` at high confidence from its current first-party platform and current legal disclosures identifying the virtual-asset operator.
+
+The Argentina PSAV/VASP registrations are treated as identity and compliance evidence only. BX42 does not describe them as CNV licenses, supervision, or product endorsements.
+
+No unsupported exact launch date, terminal state, lifecycle event, canonical lineage edge, volume-quality claim, or blanket regulatory endorsement is introduced.
+
+## Projected reviewed state
+
+```text
+Entities: 967
+Events:   1017
+Evidence: 3706
+English dossiers:   967
+Japanese dossiers:  967
+Sitemap routes:     1978
+Remaining to D-1000: 33
+```
+
+Canonical delta:
+
+```text
+Entities: +4
+Events:   +0
+Evidence: +8
+```
+
+The next unused event ID remains `hei_ev_010094`.  
+The next unused evidence ID becomes `hei_src_012403`.
+
+## Deployment and localization
+
+BX42 is a record-only batch. It changes no Cloudflare configuration, workflow, schema, route contract, machine-readable safety rule, or production policy. Cloudflare preview is not required.
+
+L-2 remains `HOLD`. Canonical growth continues without expanding Japanese translation breadth or authorizing a third language.
+
+## Validation requirement
+
+The complete GitHub workflow matrix must pass on the final branch head. Any duplicate, ID collision, reference-integrity, lineage, count, URL-safety, enum, country, recovery-contract, localization, or public-output failure must be repaired rather than bypassed.

--- a/docs/backlog/consumed/hei_unadded-bx42-four-reviewed-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx42-four-reviewed-exchange-records.md
@@ -1,0 +1,50 @@
+# Consumed backlog — BX42 four reviewed exchange records
+
+Status: consumed  
+Date: 2026-08-02  
+Milestone: D-1000 Reviewed Entity Milestone
+
+## Added
+
+```text
+Quidax  hei_ex_001084 active
+Busha   hei_ex_001085 active
+belo    hei_ex_001086 active
+Lemon   hei_ex_001087 active
+```
+
+## Evidence allocation
+
+```text
+Quidax  hei_src_012395–012396
+Busha   hei_src_012397–012398
+belo    hei_src_012399–012400
+Lemon   hei_src_012401–012402
+```
+
+## Event allocation
+
+No new lifecycle event is added. The next unused event ID remains `hei_ev_010094`.
+
+## Status handling
+
+All four entities are added as `active` at high confidence.
+
+Quidax and Busha are supported by current first-party exchange platforms and Nigeria SEC registered-operator listings that identify each as a Digital Assets Exchange.
+
+belo and Lemon are supported by current first-party platforms and legal terms that define active crypto purchase, sale, exchange, balance, transfer, and related services. Argentina PSAV/VASP registrations are used as operator-identity and compliance evidence only and are not described as CNV licenses or endorsements.
+
+## Identity and overlap checks
+
+Direct canonical-path checks, base canonical name/domain checks, and historical commit searches found no reviewed entity for the four additions. No unsupported predecessor, successor, merger, acquisition, or rebrand relation is added.
+
+## Result
+
+```text
+Entities: 967
+Events:   1017
+Evidence: 3706
+Remaining to D-1000: 33
+```
+
+The next unused evidence ID is `hei_src_012403`.

--- a/records/exchanges/belo.json
+++ b/records/exchanges/belo.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001086",
+    "slug": "belo",
+    "canonical_name": "belo",
+    "aliases": [
+      "Belo",
+      "Belo Argentina S.A."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Argentina",
+    "summary": "Argentina-origin custodial virtual wallet and crypto exchange service operated for Argentine users by Belo Argentina S.A., supporting cryptocurrency purchase, sale, balances, transfers, receipts, payments, and international money movement.",
+    "official_url_original": "https://www.belo.app/",
+    "official_domain_original": "belo.app",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.belo.app/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-02",
+    "notes": "The current first-party site remains live with account and international-payment products. Current general terms explicitly define crypto services including purchases, sales, balances, outgoing transfers, receipts, and yield functions, and identify Belo Argentina S.A. as Argentina PSAV registration number 52. The registration is recorded as an identity and compliance fact, not as a CNV license or product endorsement. No exact launch date or terminal lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012399",
+      "exchange_id": "hei_ex_001086",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "belo international virtual wallet platform",
+      "url": "https://www.belo.app/en-us/ar/",
+      "publisher": "belo",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.belo.app/en-us/ar/",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party platform exposes account creation, international receipt and transfer, payment, balance conversion, and app access, confirming that the service remains operational."
+    },
+    {
+      "id": "hei_src_012400",
+      "exchange_id": "hei_ex_001086",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "belo general terms and crypto services",
+      "url": "https://help.belo.app/en/articles/5362779-general-terms-and-conditions",
+      "publisher": "Belo Argentina S.A.",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://help.belo.app/en/articles/5362779-general-terms-and-conditions",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party terms identify Belo Argentina S.A., describe cryptocurrency purchase, sale, balance, transfer, and receipt services, and state Argentina PSAV registration number 52 without claiming CNV licensing."
+    }
+  ]
+}

--- a/records/exchanges/busha.json
+++ b/records/exchanges/busha.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001085",
+    "slug": "busha",
+    "canonical_name": "Busha",
+    "aliases": [
+      "Busha Digital Limited",
+      "Busha Ltd"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Nigeria",
+    "summary": "Nigeria-origin centralized digital-asset exchange operated by Busha Digital Limited, providing cryptocurrency purchase, sale, conversion, spot wallets, limit orders, custody, fiat ramps, payments, and business services.",
+    "official_url_original": "https://busha.io/",
+    "official_domain_original": "busha.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://busha.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-02",
+    "notes": "The current first-party platform exposes buy, sell, convert, wallet, limit-order, payments, and business products. Current terms identify Busha Digital Limited and define the service as a virtual-asset exchange platform. Nigeria's SEC registered-operator page separately lists Busha as a Digital Assets Exchange participant. No exact launch date or terminal lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012397",
+      "exchange_id": "hei_ex_001085",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Busha digital-money and digital-asset exchange platform",
+      "url": "https://busha.io/",
+      "publisher": "Busha",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://busha.io/",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes sign-up, buy, sell, convert, limit-order, wallet, payment, and business-service functions for digital assets."
+    },
+    {
+      "id": "hei_src_012398",
+      "exchange_id": "hei_ex_001085",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "Registered FinTech Operators",
+      "url": "https://home.sec.gov.ng/fintech-and-innovation-hub-finport/registered-fintech-operators/",
+      "publisher": "Securities and Exchange Commission, Nigeria",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://home.sec.gov.ng/fintech-and-innovation-hub-finport/registered-fintech-operators/",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official regulator directory lists Busha Digital Limited, trading as Busha, with the function Digital Assets Exchange."
+    }
+  ]
+}

--- a/records/exchanges/lemon-cash.json
+++ b/records/exchanges/lemon-cash.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001087",
+    "slug": "lemon-cash",
+    "canonical_name": "Lemon",
+    "aliases": [
+      "Lemon Cash",
+      "Bay Treasure Caramel S.A."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Argentina",
+    "summary": "Argentina-origin custodial digital-money and crypto exchange platform operating under the Lemon brand, providing cryptocurrency and stablecoin purchase, sale, swaps, transfers, balances, payments, cards, and regional financial-app services.",
+    "official_url_original": "https://lemon.me/",
+    "official_domain_original": "lemon.me",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://lemon.me/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-02",
+    "notes": "The current first-party platform exposes digital-dollar and Bitcoin purchase and sale, app accounts, transfers, payments, cards, and investment functions. Current legal materials identify Bay Treasure Caramel S.A. as Argentina VASP registration number 162. The registration is recorded as an identity and compliance fact, not as a CNV license or product endorsement. No exact launch date or terminal lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012401",
+      "exchange_id": "hei_ex_001087",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Lemon digital-money and crypto platform",
+      "url": "https://lemon.me/en/",
+      "publisher": "Lemon",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://lemon.me/en/",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party platform exposes account access, digital-dollar and Bitcoin purchase and sale, transfers, payments, cards, and app-based financial services."
+    },
+    {
+      "id": "hei_src_012402",
+      "exchange_id": "hei_ex_001087",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Lemon legal and virtual-asset service disclosures",
+      "url": "https://lemon.me/en/terms",
+      "publisher": "Lemon",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://lemon.me/en/terms",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party legal hub identifies Bay Treasure Caramel S.A. as the virtual-asset service provider registered under number 162 in Argentina and links the operating terms for regional crypto services."
+    }
+  ]
+}

--- a/records/exchanges/quidax.json
+++ b/records/exchanges/quidax.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001084",
+    "slug": "quidax",
+    "canonical_name": "Quidax",
+    "aliases": [
+      "Quidax Technologies Limited",
+      "Quidax.com"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Nigeria",
+    "summary": "Nigeria-origin centralized cryptocurrency exchange operated by Quidax Technologies Limited, providing spot trading, instant buy and sell, order-book, OTC, wallet, API, ramp, and stablecoin infrastructure services.",
+    "official_url_original": "https://www.quidax.io/",
+    "official_domain_original": "quidax.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.quidax.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-02",
+    "notes": "The current first-party site exposes registration, individual and business exchange products, order-book, OTC, API, ramp, and stablecoin services. Nigeria's SEC registered-operator page identifies Quidax Technologies Limited, trading as Quidax, as a Digital Assets Exchange participant. No exact launch date or terminal lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012395",
+      "exchange_id": "hei_ex_001084",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Quidax digital-asset exchange and infrastructure platform",
+      "url": "https://www.quidax.io/",
+      "publisher": "Quidax",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.quidax.io/",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes account access, order-book, OTC, instant swap, API, ramp, stablecoin, and institutional exchange services."
+    },
+    {
+      "id": "hei_src_012396",
+      "exchange_id": "hei_ex_001084",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "Registered FinTech Operators",
+      "url": "https://home.sec.gov.ng/fintech-and-innovation-hub-finport/registered-fintech-operators/",
+      "publisher": "Securities and Exchange Commission, Nigeria",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://home.sec.gov.ng/fintech-and-innovation-hub-finport/registered-fintech-operators/",
+      "accessed_at": "2026-08-02",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official regulator directory lists Quidax Technologies Limited, trading as Quidax, with the function Digital Assets Exchange."
+    }
+  ]
+}


### PR DESCRIPTION
## D-1000 BX42

Roadmap item: `D-1000 Reviewed Entity Milestone`

Specification: `docs/HEI_DATA_GROWTH_MILESTONES_SPEC.md`

Starting main: `4f263e525221f377ad167b84fd694b1e04f56909`

Starting reviewed state:

```text
Entities: 963
Events: 1017
Evidence: 3698
English dossiers: 963
Japanese dossiers: 963
Sitemap routes: 1970
```

Reviewed additions:

```text
Quidax  hei_ex_001084 active / high
Busha   hei_ex_001085 active / high
belo    hei_ex_001086 active / high
Lemon   hei_ex_001087 active / high
```

Quidax and Busha are supported by current first-party exchange platforms and Nigeria SEC registered-operator listings identifying each as a Digital Assets Exchange.

belo and Lemon are supported by current first-party platforms and legal disclosures defining crypto purchase, sale, exchange, balance, transfer, and related functions. Argentina PSAV/VASP registrations are used only as operator-identity and compliance evidence; BX42 does not describe them as CNV licenses, supervision, or product endorsements.

Direct canonical-path checks, base canonical name/domain checks, and historical commit searches found no reviewed duplicates. No unsupported exact launch date, terminal state, lifecycle event, lineage edge, volume-quality claim, or blanket regulatory endorsement is added.

Projected reviewed state:

```text
Entities: 967
Events: 1017
Evidence: 3706
English dossiers: 967
Japanese dossiers: 967
Sitemap routes: 1978
Remaining to D-1000: 33
```

Delta: `+4 entities / +0 events / +8 evidence`.

The next unused event ID remains `hei_ev_010094`; the next unused evidence ID becomes `hei_src_012403`.

Deployment impact: record-only batch. No Cloudflare configuration, workflow, schema, or route-contract changes. Preview deployment is not required.

Localization impact: L-2 remains `HOLD`; no translation-breadth expansion or third-language authorization.

Validation requirement: all 20 standard GitHub workflows must pass. Any duplicate, ID collision, reference-integrity, lineage, count, URL-safety, enum, country, recovery-contract, localization, or public-output failure will be repaired rather than bypassed.