### PR TITLE
Add D-1000 BX43 reviewed exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "D-1000 Reviewed Entity Milestone",
   "reviewed_counts": {
-    "entities": 967,
+    "entities": 971,
     "events": 1017,
-    "evidence": 3706
+    "evidence": 3714
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -24,7 +24,7 @@
     "l2_evidence_snapshot": "data-evaluation/l2-localization-evidence.json",
     "l2_evaluator": "scripts/evaluate-l2-localization-gate.mjs",
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
-    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX42_2026-08-02.md",
+    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX43_2026-08-03.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -38,15 +38,15 @@ The initial L2 state is expected to be HOLD because the public Japanese Pilot ha
 
 HOLD keeps the Japanese Pilot public but does not block reviewed canonical data growth.
 
-After D-1000 batch BX42, the projected reviewed state is:
+After D-1000 batch BX43, the projected reviewed state is:
 
 ```text
-Entities: 967
+Entities: 971
 Events:   1017
-Evidence: 3706
+Evidence: 3714
 ```
 
-The localization decision remains HOLD. Translation breadth is not expanded by BX42, and third-language authorization remains false.
+The localization decision remains HOLD. Translation breadth is not expanded by BX43, and third-language authorization remains false.
 
 ## 3. Evidence categories
 

--- a/docs/audits/HEI_D1000_PROGRESS_BX43_2026-08-03.md
+++ b/docs/audits/HEI_D1000_PROGRESS_BX43_2026-08-03.md
@@ -1,0 +1,88 @@
+# HEI D-1000 Progress — BX43
+
+Date: 2026-08-03  
+Milestone: D-1000 Reviewed Entity Milestone  
+Batch: BX43
+
+## Starting reviewed state
+
+```text
+Entities: 967
+Events:   1017
+Evidence: 3706
+English dossiers:   967
+Japanese dossiers:  967
+Sitemap routes:     1978
+```
+
+## Reviewed additions
+
+| Entity | ID | Type | Status | Confidence |
+| --- | --- | --- | --- | --- |
+| Brasil Bitcoin | `hei_ex_001088` | cex | active | high |
+| Digitra.com | `hei_ex_001089` | cex | active | high |
+| Coinext | `hei_ex_001090` | cex | active | high |
+| Moneybees | `hei_ex_001091` | cex | active | high |
+
+BX43 adds four reviewed entities and eight reviewed evidence records. It adds no lifecycle event.
+
+## Duplicate rejection and replacement
+
+Bitypreco was initially reviewed as a possible BX43 candidate. The direct canonical bundle check found the existing record `records/exchanges/bitypreco.json`, entity `hei_ex_000589`, including the former Bitpreco aliases and the continuing Bitypreco identity. It was rejected as a duplicate rather than added again.
+
+Moneybees replaced that candidate after its canonical path, base entity names and domain, and repository commit history returned no reviewed overlap.
+
+## Identity and overlap controls
+
+Direct canonical-path checks found no reviewed bundles at `brasil-bitcoin`, `digitra`, `coinext`, or `moneybees`. The base canonical entity array contained no matching canonical name, legal-operator name, or official domain for the four additions. Historical commit searches for Brasil Bitcoin, Digitra, Coinext, and Moneybees returned no prior additions.
+
+The four records remain separate entities:
+
+- Brasil Bitcoin is operated by Brasil Bitcoin Serviços Digitais Ltda. in Brazil.
+- Digitra.com is operated by Digitra.com Ativos Digitais Ltda. in Brazil.
+- Coinext is operated by its Brazilian Coinext service company.
+- Moneybees is operated by Moneybees Forex Corporation in the Philippines.
+
+No predecessor, successor, merger, acquisition, rebrand, or shared-entity relationship is asserted among them.
+
+## Status discipline
+
+- Brasil Bitcoin is `active` at high confidence from its current platform and terms defining cryptocurrency purchase, sale, wallets, fiat-account funding and withdrawal, OTC, and order functions.
+- Digitra.com is `active` at high confidence from its current account, app, trading, OTC, staking, and API surfaces and terms defining cryptoasset transaction intermediation.
+- Coinext is `active` at high confidence from its current markets, app and web trading, transfer, staking, advanced-order, and API surfaces and current terms.
+- Moneybees is `active` at high confidence from its current buy and sell rates, online trading desk, OTC partner locations, transaction flows, and current customer terms.
+
+No unsupported exact launch date, terminal state, lifecycle event, canonical lineage edge, volume-quality claim, or blanket regulatory endorsement is introduced.
+
+## Projected reviewed state
+
+```text
+Entities: 971
+Events:   1017
+Evidence: 3714
+English dossiers:   971
+Japanese dossiers:  971
+Sitemap routes:     1986
+Remaining to D-1000: 29
+```
+
+Canonical delta:
+
+```text
+Entities: +4
+Events:   +0
+Evidence: +8
+```
+
+The next unused event ID remains `hei_ev_010094`.  
+The next unused evidence ID becomes `hei_src_012411`.
+
+## Deployment and localization
+
+BX43 is a record-only batch. It changes no Cloudflare configuration, workflow, schema, route contract, machine-readable safety rule, or production policy. Cloudflare preview is not required.
+
+L-2 remains `HOLD`. Canonical growth continues without expanding Japanese translation breadth or authorizing a third language.
+
+## Validation requirement
+
+The complete GitHub workflow matrix must pass on the final branch head. Any duplicate, ID collision, reference-integrity, lineage, count, URL-safety, enum, country, recovery-contract, localization, or public-output failure must be repaired rather than bypassed.

--- a/docs/backlog/consumed/hei_unadded-bx43-four-reviewed-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx43-four-reviewed-exchange-records.md
@@ -1,0 +1,54 @@
+# Consumed backlog — BX43 four reviewed exchange records
+
+Status: consumed  
+Date: 2026-08-03  
+Milestone: D-1000 Reviewed Entity Milestone
+
+## Added
+
+```text
+Brasil Bitcoin  hei_ex_001088 active
+Digitra.com     hei_ex_001089 active
+Coinext         hei_ex_001090 active
+Moneybees       hei_ex_001091 active
+```
+
+## Evidence allocation
+
+```text
+Brasil Bitcoin  hei_src_012403–012404
+Digitra.com     hei_src_012405–012406
+Coinext         hei_src_012407–012408
+Moneybees       hei_src_012409–012410
+```
+
+## Event allocation
+
+No new lifecycle event is added. The next unused event ID remains `hei_ev_010094`.
+
+## Duplicate rejection
+
+Bitypreco was rejected from BX43 because `records/exchanges/bitypreco.json` already represents the same continuing Bitpreco/Bitypreco identity as `hei_ex_000589`. Moneybees replaced it.
+
+## Status handling
+
+All four entities are added as `active` at high confidence.
+
+Brasil Bitcoin, Digitra.com, and Coinext are supported by current first-party trading platforms and current legal terms defining centralized crypto purchase, sale, custody, transfer, order, or related exchange functions.
+
+Moneybees is supported by its current first-party buy and sell service, online trading desk, OTC network, and customer terms defining virtual-currency purchase and sale through the operator and its partner outlets.
+
+## Identity and overlap checks
+
+Direct canonical-path checks, base canonical name/domain checks, and historical commit searches found no reviewed entity for the four additions. No unsupported predecessor, successor, merger, acquisition, or rebrand relation is added.
+
+## Result
+
+```text
+Entities: 971
+Events:   1017
+Evidence: 3714
+Remaining to D-1000: 29
+```
+
+The next unused evidence ID is `hei_src_012411`.

--- a/records/exchanges/brasil-bitcoin.json
+++ b/records/exchanges/brasil-bitcoin.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001088",
+    "slug": "brasil-bitcoin",
+    "canonical_name": "Brasil Bitcoin",
+    "aliases": [
+      "BRASIL BITCOIN SERVIÇOS DIGITAIS LTDA.",
+      "Brasil Bitcoin Serviços Digitais Ltda."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Brazil",
+    "summary": "Brazil-based centralized cryptocurrency trading platform operated by Brasil Bitcoin Serviços Digitais Ltda., supporting crypto purchase and sale, custody wallets, fiat funding and withdrawal, OTC transactions, and related account services.",
+    "official_url_original": "https://brasilbitcoin.com.br/",
+    "official_domain_original": "brasilbitcoin.com.br",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://brasilbitcoin.com.br/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-03",
+    "notes": "The current first-party site exposes a live trading platform, app, OTC service, markets, account registration, and additional crypto services. Current terms identify Brasil Bitcoin Serviços Digitais Ltda. and define user purchase and sale orders, virtual wallets, real-denominated account funding and withdrawals, and crypto transfers. No exact launch date or lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012403",
+      "exchange_id": "hei_ex_001088",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Brasil Bitcoin cryptocurrency exchange platform",
+      "url": "https://brasilbitcoin.com.br/",
+      "publisher": "Brasil Bitcoin",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://brasilbitcoin.com.br/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes account registration, a cryptocurrency trading platform, market pages, OTC services, app downloads, and supported crypto products, confirming current operation."
+    },
+    {
+      "id": "hei_src_012404",
+      "exchange_id": "hei_ex_001088",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Brasil Bitcoin terms of use",
+      "url": "https://brasilbitcoin.com.br/termos-de-uso/",
+      "publisher": "Brasil Bitcoin Serviços Digitais Ltda.",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://brasilbitcoin.com.br/termos-de-uso/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party terms identify the operating company and define cryptocurrency purchase and sale, virtual wallets, real-denominated account balances, deposits, withdrawals, OTC, and trading-order functions."
+    }
+  ]
+}

--- a/records/exchanges/coinext.json
+++ b/records/exchanges/coinext.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001090",
+    "slug": "coinext",
+    "canonical_name": "Coinext",
+    "aliases": [
+      "Coinext Serviços Digitais S.A.",
+      "Coinext Sociedade Prestadora de Serviços Digitais S.A."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Brazil",
+    "summary": "Brazil-based centralized cryptocurrency exchange operated by Coinext, providing spot purchase and sale, custody, staking, fiat and crypto transfers, advanced orders, web and mobile trading, and API services.",
+    "official_url_original": "https://coinext.com.br/",
+    "official_domain_original": "coinext.com.br",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://coinext.com.br/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-03",
+    "notes": "The current first-party site exposes live markets, registration, app and web trading, spot purchase and sale, deposits and withdrawals, staking, advanced orders, and API services. Current terms identify the operating company and define crypto purchase, sale, storage, and transaction services. No exact launch date or lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012407",
+      "exchange_id": "hei_ex_001090",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Coinext cryptocurrency exchange platform",
+      "url": "https://coinext.com.br/",
+      "publisher": "Coinext",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinext.com.br/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes registration, live markets, spot purchase and sale, mobile and web trading, deposits and withdrawals, staking, advanced orders, and API services."
+    },
+    {
+      "id": "hei_src_012408",
+      "exchange_id": "hei_ex_001090",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Coinext terms of use and services",
+      "url": "https://coinext.com.br/institucional/termos-de-uso-e-condicoes",
+      "publisher": "Coinext Serviços Digitais S.A.",
+      "published_at": "2026-01-29",
+      "archived_url": "https://web.archive.org/web/*/https://coinext.com.br/institucional/termos-de-uso-e-condicoes",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party terms identify the operating company and govern platform services for cryptocurrency purchase, sale, storage, and account-based transactions."
+    }
+  ]
+}

--- a/records/exchanges/digitra.json
+++ b/records/exchanges/digitra.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001089",
+    "slug": "digitra",
+    "canonical_name": "Digitra.com",
+    "aliases": [
+      "Digitra",
+      "DIGITRA.COM ATIVOS DIGITAIS LTDA"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Brazil",
+    "summary": "Brazil-based centralized cryptoasset exchange operated by Digitra.com Ativos Digitais Ltda., providing account-based crypto trading, deposits, withdrawals, custody, staking, OTC services, and API access.",
+    "official_url_original": "https://digitra.com/",
+    "official_domain_original": "digitra.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://digitra.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-03",
+    "notes": "The current first-party site exposes login, account opening, app access, crypto purchase, staking, OTC, and API surfaces. Current terms identify Digitra.com Ativos Digitais Ltda. and define cryptoasset purchase and sale intermediation, deposits, withdrawals, custody, order-book trading, and asset-to-asset exchange. No exact launch date or lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012405",
+      "exchange_id": "hei_ex_001089",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Digitra.com crypto exchange platform",
+      "url": "https://digitra.com/",
+      "publisher": "Digitra.com",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://digitra.com/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes account creation, login, app access, cryptocurrency purchase, staking, OTC, liquidity, and API entry points."
+    },
+    {
+      "id": "hei_src_012406",
+      "exchange_id": "hei_ex_001089",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Digitra.com terms of use",
+      "url": "https://digitra.com/en/article/terms-of-use/",
+      "publisher": "Digitra.com Ativos Digitais Ltda.",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://digitra.com/en/article/terms-of-use/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party terms identify the operating company and describe cryptoasset purchase and sale intermediation, deposits, withdrawals, storage, order-book trading, and exchanges between supported cryptoassets."
+    }
+  ]
+}

--- a/records/exchanges/moneybees.json
+++ b/records/exchanges/moneybees.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001091",
+    "slug": "moneybees",
+    "canonical_name": "Moneybees",
+    "aliases": [
+      "Moneybees Forex Corporation",
+      "Moneybees Forex Corp."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Philippines",
+    "summary": "Philippines-based centralized virtual-asset exchange service operated by Moneybees Forex Corporation, offering cryptocurrency purchase and sale through an online trading desk and partner over-the-counter outlets.",
+    "official_url_original": "https://www.moneybees.ph/",
+    "official_domain_original": "moneybees.ph",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.moneybees.ph/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-03",
+    "notes": "The current first-party site publishes buy and sell rates, an online trading desk, wallet-to-cash and cash-to-wallet flows, transaction limits, and a nationwide OTC partner network. Current terms identify Moneybees Forex Corporation and define virtual-currency purchase and sale through supervised partner outlets or online trading desks. No exact launch date or lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012409",
+      "exchange_id": "hei_ex_001091",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Moneybees cryptocurrency OTC and online trading platform",
+      "url": "https://www.moneybees.ph/",
+      "publisher": "Moneybees",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.moneybees.ph/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes cryptocurrency buy and sell rates, online desk access, wallet funding and cash-out flows, KYC limits, and active partner outlet locations."
+    },
+    {
+      "id": "hei_src_012410",
+      "exchange_id": "hei_ex_001091",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Moneybees customer terms and conditions",
+      "url": "https://www.moneybees.ph/terms/",
+      "publisher": "Moneybees Forex Corporation",
+      "published_at": "2025-02-28",
+      "archived_url": "https://web.archive.org/web/*/https://www.moneybees.ph/terms/",
+      "accessed_at": "2026-08-03",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party terms identify Moneybees Forex Corporation and define virtual-currency purchase and sale over the counter through partner outlets or through online trading desks."
+    }
+  ]
+}


### PR DESCRIPTION
## D-1000 BX43

Roadmap item: `D-1000 Reviewed Entity Milestone`

Starting main: `aa16ecd014a6338d194fa2f0b00f4ca28c869a4f`

Starting reviewed state:

```text
Entities: 967
Events: 1017
Evidence: 3706
English dossiers: 967
Japanese dossiers: 967
Sitemap routes: 1978
```

Reviewed additions:

```text
Brasil Bitcoin  hei_ex_001088 active / high
Digitra.com     hei_ex_001089 active / high
Coinext         hei_ex_001090 active / high
Moneybees       hei_ex_001091 active / high
```

Bitypreco was initially reviewed but rejected because `records/exchanges/bitypreco.json` already represents the continuing Bitpreco/Bitypreco identity as `hei_ex_000589`. Moneybees replaced it.

All four accepted records are supported by current first-party operating surfaces and legal terms defining centralized cryptocurrency purchase, sale, custody, transfer, trading, OTC, or related exchange functions. Direct canonical-path checks, base canonical name/domain checks, and historical commit searches found no reviewed overlap for the accepted entities.

No unsupported exact launch date, terminal state, lifecycle event, lineage edge, volume-quality claim, or blanket regulatory endorsement is added.

Projected reviewed state:

```text
Entities: 971
Events: 1017
Evidence: 3714
English dossiers: 971
Japanese dossiers: 971
Sitemap routes: 1986
Remaining to D-1000: 29
```

Delta: `+4 entities / +0 events / +8 evidence`.

The next unused event ID remains `hei_ev_010094`; the next unused evidence ID becomes `hei_src_012411`.

Deployment impact: record-only batch. No Cloudflare configuration, workflow, schema, or route-contract changes. Preview deployment is not required.

Localization impact: L-2 remains `HOLD`; no translation-breadth expansion or third-language authorization.

Validation requirement: all 20 standard GitHub workflows must pass. Any duplicate, ID collision, reference-integrity, lineage, count, URL-safety, enum, country, recovery-contract, localization, or public-output failure will be repaired rather than bypassed.