### PR TITLE
navigation: add BadJoke Lab project links

### DIFF
--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -83,6 +83,22 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
             BadJoke-Lab project hub
           </a>
           <span className="muted footer-sep"> · </span>
+          <a className="archive-link" href="https://hei.badjoke-lab.com/" aria-current="page">
+            HEI
+          </a>
+          <span className="muted footer-sep"> · </span>
+          <a className="archive-link" href="https://www.stableorgone.com/">
+            SOG
+          </a>
+          <span className="muted footer-sep"> · </span>
+          <a className="archive-link" href="https://cya.badjoke-lab.com/">
+            CYA
+          </a>
+          <span className="muted footer-sep"> · </span>
+          <a className="archive-link" href="https://bir.badjoke-lab.com/">
+            BIR
+          </a>
+          <span className="muted footer-sep"> · </span>
           <a className="archive-link" href={CONTACT_HREF} target="_blank" rel="noreferrer">
             {t('footer.contactCorrections')}
           </a>

--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -83,9 +83,7 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
             BadJoke-Lab project hub
           </a>
           <span className="muted footer-sep"> · </span>
-          <a className="archive-link" href="https://hei.badjoke-lab.com/" aria-current="page">
-            HEI
-          </a>
+          <span className="muted">HEI</span>
           <span className="muted footer-sep"> · </span>
           <a className="archive-link" href="https://www.stableorgone.com/">
             SOG


### PR DESCRIPTION
## Summary

Adds a compact BadJoke Lab project network to the existing HEI footer:

- Hub
- HEI
- SOG
- CYA
- BIR

SOG uses its official canonical origin, `https://www.stableorgone.com/`.

## Traceability

- Roadmap item: post-v1 cross-surface integration and public navigation maintenance
- Specifications: `docs/HEI_PRODUCT_SURFACES_SPEC.md` and `docs/HEI_V1_INTEGRATION_BASELINE_SPEC.md`
- Canonical count impact: none
- Deployment impact: public footer HTML changes
- Preview requirement: not required; this is a bounded extension of the existing text-link footer and does not change routes, metadata, build configuration, or layout structure

## Validation plan

- run repository CI
- verify English and Japanese generated routes retain the existing footer and navigation
- verify all five project targets are present in built output

## Production verification plan

After merge and publication, confirm the deployed commit through `/version.json` and verify the five footer targets on the English and Japanese home routes.