### PR TITLE
Repair Boltz IDs and trigger reviewed production refresh

### DIFF
--- a/records/exchanges/boltz.json
+++ b/records/exchanges/boltz.json
@@ -26,7 +26,7 @@
   },
   "events": [
     {
-      "id": "hei_ev_010097",
+      "id": "hei_ev_010098",
       "exchange_id": "hei_ex_001100",
       "event_type": "trading_halted",
       "event_date": "2026-08-03",
@@ -43,9 +43,9 @@
   ],
   "evidence": [
     {
-      "id": "hei_src_012432",
+      "id": "hei_src_012434",
       "exchange_id": "hei_ex_001100",
-      "event_id": "hei_ev_010097",
+      "event_id": "hei_ev_010098",
       "source_type": "official_social",
       "title": "Boltz swaps remain disabled until further notice",
       "url": "https://x.com/Boltzhq/status/2084311537502630319",
@@ -58,7 +58,7 @@
       "notes": "First-party statement says all swaps remain disabled until further notice because escalating automated AI-assisted probing, multiple contained exploits, and internal security findings outpaced the team's ability to remediate safely. It states that refund paths and support remain available and that no user funds were at risk."
     },
     {
-      "id": "hei_src_012433",
+      "id": "hei_src_012435",
       "exchange_id": "hei_ex_001100",
       "event_id": null,
       "source_type": "official_statement",
@@ -73,9 +73,9 @@
       "notes": "Current first-party site identifies Boltz as a non-custodial Bitcoin bridge for swaps across Bitcoin layers and stablecoins. The site remains reachable while swap creation is unavailable."
     },
     {
-      "id": "hei_src_012434",
+      "id": "hei_src_012436",
       "exchange_id": "hei_ex_001100",
-      "event_id": "hei_ev_010097",
+      "event_id": "hei_ev_010098",
       "source_type": "official_statement",
       "title": "Boltz API claims and refunds documentation",
       "url": "https://api.docs.boltz.exchange/claiming-swaps.html",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
 } from '../lib/i18n/page-presentations'
 import { SITE_NAME, SITE_URL } from '../lib/site-constants'
 
+// Keep the home surface bound to the latest reviewed registry build.
 export function generateMetadata(): Metadata {
   const { summary } = buildRegistryView()
   const presentation = getPagePresentation('en', 'home')


### PR DESCRIPTION
## Purpose

Repair the ID collision introduced when the AscendEX lifecycle correction and Boltz addition were prepared concurrently, then force a normal production-eligible build of the resulting reviewed state.

## Collision repair

AscendEX merged first and validly occupied:

```text
hei_ev_010097
hei_src_012432–012433
```

Boltz is renumbered without changing its identity or classification:

```text
entity    hei_ex_001100  unchanged
event     hei_ev_010097  -> hei_ev_010098
evidence  hei_src_012432–012434 -> hei_src_012434–012436
```

All internal evidence-to-event references are updated.

## Production refresh

The public HEI surface continued to expose the preceding 979-entity build. A non-functional source comment touches a Cloudflare Pages production-watch path. This PR intentionally does not use `[CF-Pages-Skip]`.

## Expected reviewed state

```text
Entities: 980
Events:   1022
Evidence: 3740
```

## Production verification URLs

- https://hei.badjoke-lab.com/?verification=06ae9eca
- https://hei.badjoke-lab.com/version.json?verification=06ae9eca
- https://hei.badjoke-lab.com/exchange/boltz/?verification=06ae9eca

## Completion

All 20 pull-request workflows passed before merge. Merge commit: `06ae9eca147703ec977480d8320a57e8aa680356`.