### PR TITLE
Add D-1000 BX46 reviewed regulated exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "D-1000 Reviewed Entity Milestone",
   "reviewed_counts": {
-    "entities": 979,
-    "events": 1020,
-    "evidence": 3735
+    "entities": 984,
+    "events": 1022,
+    "evidence": 3748
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -24,7 +24,7 @@
     "l2_evidence_snapshot": "data-evaluation/l2-localization-evidence.json",
     "l2_evaluator": "scripts/evaluate-l2-localization-gate.mjs",
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
-    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX45_2026-08-03.md",
+    "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX46_2026-08-05.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -38,15 +38,15 @@ The initial L2 state is expected to be HOLD because the public Japanese Pilot ha
 
 HOLD keeps the Japanese Pilot public but does not block reviewed canonical data growth.
 
-After the reconciled D-1000 batch BX45 state, including the concurrent BTCBOX lifecycle update, the reviewed state is:
+After D-1000 batch BX46, the reviewed state is:
 
 ```text
-Entities: 979
-Events:   1020
-Evidence: 3735
+Entities: 984
+Events:   1022
+Evidence: 3748
 ```
 
-The localization decision remains HOLD. Translation breadth is not expanded by BX45, and third-language authorization remains false.
+The localization decision remains HOLD. Translation breadth is not expanded by BX46, and third-language authorization remains false.
 
 ## 3. Evidence categories
 

--- a/docs/audits/HEI_D1000_PROGRESS_BX46_2026-08-05.md
+++ b/docs/audits/HEI_D1000_PROGRESS_BX46_2026-08-05.md
@@ -46,7 +46,7 @@ No predecessor, successor, merger, acquisition, rebrand, regional split, or shar
 - YAX is `active` at high confidence from the current Hong Kong SFC licensed-platform list and a parent-company licensing and service announcement. Its official site returned an access-control response, so the URL is `live_unverified` rather than `live_verified`.
 - Bixin.com is `active` at high confidence from its current first-party user agreement and the current Hong Kong SFC licensed-platform list. Its main site returned an access-control response, so the URL is `live_unverified`.
 - Ofza is `active` at high confidence from its current first-party operating surface and active VARA public-register entry.
-- MB.IO is `active` at high confidence from its current first-party trading surface and active VARA public-register entry. A single country of origin is not inferred because the platform identifies jurisdiction-specific operating entities.
+- MB.IO is `active` at high confidence from its current first-party trading surface and active VARA public-register entry. `country_or_origin` follows the reviewed Dubai-licensed operator MBIO FZE, while the Australian spot-product entity remains documented as a jurisdiction-specific alias and scope note.
 
 Regulatory references support operator identity, licensed activities, licence references, issue dates, and current register status. They are not converted into performance, safety, liquidity, product-quality, or cross-jurisdiction endorsements.
 

--- a/docs/audits/HEI_D1000_PROGRESS_BX46_2026-08-05.md
+++ b/docs/audits/HEI_D1000_PROGRESS_BX46_2026-08-05.md
@@ -1,0 +1,91 @@
+# HEI D-1000 Progress — BX46
+
+Date: 2026-08-05  
+Milestone: D-1000 Reviewed Entity Milestone  
+Batch: BX46
+
+## Starting reviewed state
+
+```text
+Entities: 980
+Events:   1022
+Evidence: 3740
+English dossiers:   980
+Japanese dossiers:  980
+Sitemap routes:     2004
+```
+
+BX46 starts from reviewed `main` commit `06ae9eca147703ec977480d8320a57e8aa680356`.
+
+## Reviewed additions
+
+| Entity | ID | Type | Status | Confidence |
+| --- | --- | --- | --- | --- |
+| YAX | `hei_ex_001101` | cex | active | high |
+| Bixin.com | `hei_ex_001102` | cex | active | high |
+| Ofza | `hei_ex_001103` | cex | active | high |
+| MB.IO | `hei_ex_001104` | cex | active | high |
+
+BX46 adds four reviewed entities and eight reviewed evidence records. It adds no lifecycle event.
+
+## Identity and overlap controls
+
+Direct current-main repository searches, canonical-name checks, official-domain checks, and record-path checks found no reviewed YAX, Bixin.com, Ofza, or MB.IO entity before drafting.
+
+The records use distinct operator and regulatory identities:
+
+- YAX — YAX (Hong Kong) Limited — Hong Kong SFC CE reference `BUT913`
+- Bixin.com — NewBX Limited — Hong Kong SFC CE reference `BUY737`
+- Ofza — OFZA Fintech Virtual Asset Exchange Services LLC — VARA reference `VL/24/12/002`
+- MB.IO — MBIO FZE / jurisdiction-specific platform entities — VARA reference `VL/24/06/001`
+
+No predecessor, successor, merger, acquisition, rebrand, regional split, or shared-entity relationship is asserted among the four additions.
+
+## Status discipline
+
+- YAX is `active` at high confidence from the current Hong Kong SFC licensed-platform list and a parent-company licensing and service announcement. Its official site returned an access-control response, so the URL is `live_unverified` rather than `live_verified`.
+- Bixin.com is `active` at high confidence from its current first-party user agreement and the current Hong Kong SFC licensed-platform list. Its main site returned an access-control response, so the URL is `live_unverified`.
+- Ofza is `active` at high confidence from its current first-party operating surface and active VARA public-register entry.
+- MB.IO is `active` at high confidence from its current first-party trading surface and active VARA public-register entry. A single country of origin is not inferred because the platform identifies jurisdiction-specific operating entities.
+
+Regulatory references support operator identity, licensed activities, licence references, issue dates, and current register status. They are not converted into performance, safety, liquidity, product-quality, or cross-jurisdiction endorsements.
+
+No unsupported exact launch date, lifecycle event, terminal state, canonical lineage edge, trading-volume claim, or broader regulatory conclusion is introduced.
+
+## Projected reviewed state
+
+```text
+Entities: 984
+Events:   1022
+Evidence: 3748
+English dossiers:   984
+Japanese dossiers:  984
+Sitemap routes:     2012
+Remaining to D-1000: 16
+```
+
+Canonical delta:
+
+```text
+Entities: +4
+Events:   +0
+Evidence: +8
+```
+
+Next unused identifiers:
+
+```text
+Entity:   hei_ex_001105
+Event:    hei_ev_010099
+Evidence: hei_src_012445
+```
+
+## Deployment and localization
+
+BX46 is a record-only batch. It changes no Cloudflare configuration, workflow, schema, route contract, machine-readable safety rule, or production policy. Cloudflare preview is not required.
+
+L-2 remains `HOLD`. Canonical growth continues without expanding Japanese translation breadth or authorizing a third language.
+
+## Validation requirement
+
+The complete GitHub workflow matrix must pass on the final branch head. Any duplicate, identity overlap, ID collision, reference-integrity, lineage, count, URL-safety, enum, country, recovery-contract, localization, or public-output failure must be repaired rather than bypassed.

--- a/docs/backlog/consumed/hei_unadded-bx46-four-regulated-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx46-four-regulated-exchange-records.md
@@ -36,7 +36,7 @@ The regulatory evidence is used for operator identity, platform identity, licenc
 
 YAX and Bixin.com use `live_unverified` URL status because their main sites returned access-control responses during verification. Ofza and MB.IO use `live_verified` from directly reviewed first-party operating surfaces.
 
-MB.IO does not receive a single country-of-origin value because the first-party and regulatory surfaces identify jurisdiction-specific operating entities.
+MB.IO uses `United Arab Emirates` for `country_or_origin` from the reviewed Dubai-licensed platform operator MBIO FZE. The Australian spot-product entity remains documented as an alias and jurisdiction-specific scope note rather than a second canonical exchange or lineage edge.
 
 ## Identity and overlap checks
 

--- a/docs/backlog/consumed/hei_unadded-bx46-four-regulated-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx46-four-regulated-exchange-records.md
@@ -1,0 +1,62 @@
+# Consumed backlog — BX46 four reviewed regulated exchange records
+
+Status: consumed  
+Date: 2026-08-05  
+Milestone: D-1000 Reviewed Entity Milestone
+
+## Added
+
+```text
+YAX        hei_ex_001101 active
+Bixin.com  hei_ex_001102 active
+Ofza       hei_ex_001103 active
+MB.IO      hei_ex_001104 active
+```
+
+## Evidence allocation
+
+```text
+YAX        hei_src_012437–012438
+Bixin.com  hei_src_012439–012440
+Ofza       hei_src_012441–012442
+MB.IO      hei_src_012443–012444
+```
+
+## Event allocation
+
+No new lifecycle event is added. The next unused event ID remains `hei_ev_010099`.
+
+## Status handling
+
+All four entities are added as `active` at high confidence.
+
+YAX and Bixin.com are supported by current first-party or parent-company service material and the Hong Kong Securities and Futures Commission licensed-platform list. Ofza and MB.IO are supported by current first-party operating surfaces and active Dubai Virtual Assets Regulatory Authority public-register entries.
+
+The regulatory evidence is used for operator identity, platform identity, licence reference, licensed activities, issue date, and current register status, not as a performance or safety endorsement.
+
+YAX and Bixin.com use `live_unverified` URL status because their main sites returned access-control responses during verification. Ofza and MB.IO use `live_verified` from directly reviewed first-party operating surfaces.
+
+MB.IO does not receive a single country-of-origin value because the first-party and regulatory surfaces identify jurisdiction-specific operating entities.
+
+## Identity and overlap checks
+
+Direct current-main name, path, domain, alias, and operator checks found no reviewed YAX, Bixin.com, Ofza, or MB.IO entity before drafting.
+
+No unsupported predecessor, successor, merger, acquisition, rebrand, regional split, or shared-entity relation is added.
+
+## Result
+
+```text
+Entities: 984
+Events:   1022
+Evidence: 3748
+Remaining to D-1000: 16
+```
+
+Next unused identifiers:
+
+```text
+Entity:   hei_ex_001105
+Event:    hei_ev_010099
+Evidence: hei_src_012445
+```

--- a/docs/backlog/consumed/hei_unadded-bx46-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx46-source-review-note.md
@@ -1,0 +1,40 @@
+# BX46 source review boundaries
+
+Date: 2026-08-05  
+Status: reviewed support note
+
+## Scope
+
+BX46 uses first-party operating or parent-company material together with current regulatory public-register entries.
+
+## YAX
+
+The Hong Kong SFC licensed-platform list establishes operator identity, trading name, CE reference, and licensing date. Tiger Brokers' announcement establishes the parent relationship, official domain, and described custody and trading service scope.
+
+The YAX site returned an access-control response during review. This is not treated as evidence that the domain is dead or the platform is inactive. The URL is therefore `live_unverified`.
+
+## Bixin.com
+
+The current Bixin user agreement establishes NewBX Limited as operator and describes virtual asset trading, OTC, request-for-quote, and custody services. The Hong Kong SFC licensed-platform list establishes the Bixin.com trading name, CE reference, and licensing date.
+
+The Bixin.com main site returned an access-control response during review. This is not treated as a terminal-state signal. The URL is therefore `live_unverified`.
+
+## Ofza
+
+The current first-party site exposes account registration, fiat deposits, and cryptocurrency buying and selling. The VARA public register establishes the licensed operator, reference, activities, licence issue date, and active status.
+
+## MB.IO
+
+The current first-party site exposes fiat and cryptocurrency funding and trading and identifies an Australian operating entity for spot products. The VARA register separately identifies MBIO FZE and its Dubai exchange and broker-dealer licence.
+
+The entity record preserves the shared MB.IO platform identity but does not infer a single country of origin from the jurisdiction-specific operating entities.
+
+## Exclusions
+
+BX46 does not infer:
+
+- exact platform launch dates;
+- trading volume, liquidity, solvency, or security quality;
+- regulatory approval outside the cited jurisdiction;
+- predecessor, successor, merger, acquisition, or rebrand relationships;
+- lifecycle events from licensing dates alone.

--- a/docs/backlog/consumed/hei_unadded-bx46-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx46-source-review-note.md
@@ -27,7 +27,7 @@ The current first-party site exposes account registration, fiat deposits, and cr
 
 The current first-party site exposes fiat and cryptocurrency funding and trading and identifies an Australian operating entity for spot products. The VARA register separately identifies MBIO FZE and its Dubai exchange and broker-dealer licence.
 
-The entity record preserves the shared MB.IO platform identity but does not infer a single country of origin from the jurisdiction-specific operating entities.
+The canonical country field follows the reviewed Dubai-licensed platform operator MBIO FZE. The Australian entity remains preserved as an alias and jurisdiction-specific scope note; it is not converted into a second canonical exchange record or a lineage assertion.
 
 ## Exclusions
 

--- a/records/exchanges/bixin-com.json
+++ b/records/exchanges/bixin-com.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001102",
+    "slug": "bixin-com",
+    "canonical_name": "Bixin.com",
+    "aliases": [
+      "Bixin",
+      "NewBX Limited"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Hong Kong",
+    "summary": "Hong Kong-based licensed centralized virtual asset trading platform operated by NewBX Limited, providing virtual asset trading, over-the-counter and request-for-quote services, and custody arrangements.",
+    "official_url_original": "https://www.bixin.com/",
+    "official_domain_original": "bixin.com",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bixin.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-05",
+    "notes": "NewBX Limited's current user agreement identifies it as the operator of Bixin software and services under CE reference BUY737 and describes virtual asset acquisition, disposal, OTC, request-for-quote, and custody services. Hong Kong's Securities and Futures Commission lists NewBX Limited, trading as Bixin.com, with a licensing date of 2026-05-18. The main site returned an access-control response during verification, so the URL is recorded as live_unverified. No exact launch date or historical lineage is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012439",
+      "exchange_id": "hei_ex_001102",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Bixin User Agreement",
+      "url": "https://support.bixin.com/hc/en-hk/articles/16541529688979-User-Agreement",
+      "publisher": "Bixin",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://support.bixin.com/hc/en-hk/articles/16541529688979-User-Agreement",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party agreement identifies NewBX Limited as the platform operator under CE reference BUY737 and describes virtual asset trading, OTC, RFQ, and custody services."
+    },
+    {
+      "id": "hei_src_012440",
+      "exchange_id": "hei_ex_001102",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "Lists of virtual asset trading platforms",
+      "url": "https://www.sfc.hk/en/Welcome-to-the-Fintech-Contact-Point/Virtual-assets/Virtual-asset-trading-platforms-operators/Lists-of-virtual-asset-trading-platforms",
+      "publisher": "Securities and Futures Commission of Hong Kong",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.sfc.hk/en/Welcome-to-the-Fintech-Contact-Point/Virtual-assets/Virtual-asset-trading-platforms-operators/Lists-of-virtual-asset-trading-platforms",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official SFC list identifies NewBX Limited, trading as Bixin.com, under CE reference BUY737 with a licensing date of 2026-05-18."
+    }
+  ]
+}

--- a/records/exchanges/mb-io.json
+++ b/records/exchanges/mb-io.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001104",
+    "slug": "mb-io",
+    "canonical_name": "MB.IO",
+    "aliases": [
+      "MBIO FZE",
+      "MB.IO Pty Ltd"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized digital asset trading platform providing fiat and cryptocurrency funding, spot trading, conversion, and related exchange services through jurisdiction-specific operating entities.",
+    "official_url_original": "https://mb.io/en",
+    "official_domain_original": "mb.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://mb.io/en",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-05",
+    "notes": "The current first-party site exposes account opening, fiat funding, cryptocurrency trading, and fiat and crypto pairs and identifies MB.IO Pty Ltd for Australian spot products. Dubai's Virtual Assets Regulatory Authority separately lists MBIO FZE, trading as MB.IO, under reference VL/24/06/001 with broker-dealer and exchange services, a licence issue date of 2024-07-18, and active status. Because the platform is presented through jurisdiction-specific entities, no single unsupported country of origin is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012443",
+      "exchange_id": "hei_ex_001104",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "MB.IO digital asset trading platform",
+      "url": "https://mb.io/en",
+      "publisher": "MB.IO",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://mb.io/en",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party platform exposes account opening, fiat funding, cryptocurrency trading, conversion, and fiat and crypto pairs and identifies MB.IO Pty Ltd for Australian spot products."
+    },
+    {
+      "id": "hei_src_012444",
+      "exchange_id": "hei_ex_001104",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "MBIO FZE public register entry",
+      "url": "https://www.vara.ae/en/licenses-and-register/public-register/mbio-fze-mbio/",
+      "publisher": "Virtual Assets Regulatory Authority",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.vara.ae/en/licenses-and-register/public-register/mbio-fze-mbio/",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official VARA register lists MBIO FZE, trading as MB.IO, under reference VL/24/06/001 with broker-dealer and exchange services, licence issued 2024-07-18, and active status."
+    }
+  ]
+}

--- a/records/exchanges/mb-io.json
+++ b/records/exchanges/mb-io.json
@@ -12,8 +12,8 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
-    "summary": "Centralized digital asset trading platform providing fiat and cryptocurrency funding, spot trading, conversion, and related exchange services through jurisdiction-specific operating entities.",
+    "country_or_origin": "United Arab Emirates",
+    "summary": "Dubai-licensed centralized digital asset trading platform providing fiat and cryptocurrency funding, spot trading, conversion, and related exchange services through jurisdiction-specific operating entities.",
     "official_url_original": "https://mb.io/en",
     "official_domain_original": "mb.io",
     "official_url_status": "live_verified",
@@ -22,7 +22,7 @@
     "successor_id": null,
     "confidence": "high",
     "last_verified_at": "2026-08-05",
-    "notes": "The current first-party site exposes account opening, fiat funding, cryptocurrency trading, and fiat and crypto pairs and identifies MB.IO Pty Ltd for Australian spot products. Dubai's Virtual Assets Regulatory Authority separately lists MBIO FZE, trading as MB.IO, under reference VL/24/06/001 with broker-dealer and exchange services, a licence issue date of 2024-07-18, and active status. Because the platform is presented through jurisdiction-specific entities, no single unsupported country of origin is asserted."
+    "notes": "Dubai's Virtual Assets Regulatory Authority lists MBIO FZE, trading as MB.IO, under reference VL/24/06/001 with broker-dealer and exchange services, a licence issue date of 2024-07-18, and active status; the country field follows this reviewed licensed-platform operator. The current first-party site exposes account opening, fiat funding, cryptocurrency trading, and fiat and crypto pairs and also identifies MB.IO Pty Ltd for Australian spot products. The Australian product entity is preserved as an alias and scope note rather than converted into a second canonical exchange record or an unsupported lineage claim."
   },
   "events": [],
   "evidence": [

--- a/records/exchanges/ofza.json
+++ b/records/exchanges/ofza.json
@@ -1,0 +1,59 @@
+{
+  "entity": {
+    "id": "hei_ex_001103",
+    "slug": "ofza",
+    "canonical_name": "Ofza",
+    "aliases": [
+      "OFZA Fintech Virtual Asset Exchange Services LLC"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "United Arab Emirates",
+    "summary": "Dubai-based licensed centralized cryptocurrency exchange providing account registration, fiat funding, real-time cryptocurrency buying and selling, and related regulated virtual asset services.",
+    "official_url_original": "https://ofza.com/en",
+    "official_domain_original": "ofza.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://ofza.com/en",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-05",
+    "notes": "The current first-party site exposes account registration, deposits, and real-time cryptocurrency buying and selling and identifies Ofza as a Dubai VARA-licensed virtual asset service provider. Dubai's Virtual Assets Regulatory Authority lists OFZA Fintech Virtual Asset Exchange Services LLC under reference VL/24/12/002 with exchange, broker-dealer, and management and investment services, a licence issue date of 2024-12-30, and active status. No exact platform launch date is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012441",
+      "exchange_id": "hei_ex_001103",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Ofza cryptocurrency exchange",
+      "url": "https://ofza.com/en",
+      "publisher": "Ofza",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://ofza.com/en",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes registration, fiat deposits, and real-time cryptocurrency buying and selling and identifies Ofza as a Dubai VARA-licensed virtual asset service provider."
+    },
+    {
+      "id": "hei_src_012442",
+      "exchange_id": "hei_ex_001103",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "OFZA Fintech Virtual Asset Exchange Services LLC public register entry",
+      "url": "https://www.vara.ae/en/licenses-and-register/public-register/ofza-fintech-virtual-asset-exchange-services-llc/",
+      "publisher": "Virtual Assets Regulatory Authority",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.vara.ae/en/licenses-and-register/public-register/ofza-fintech-virtual-asset-exchange-services-llc/",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official VARA register lists OFZA Fintech Virtual Asset Exchange Services LLC under reference VL/24/12/002 with exchange, broker-dealer, and management and investment services, licence issued 2024-12-30, and active status."
+    }
+  ]
+}

--- a/records/exchanges/yax.json
+++ b/records/exchanges/yax.json
@@ -1,0 +1,59 @@
+{
+  "entity": {
+    "id": "hei_ex_001101",
+    "slug": "yax",
+    "canonical_name": "YAX",
+    "aliases": [
+      "YAX (Hong Kong) Limited"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Hong Kong",
+    "summary": "Hong Kong-based licensed centralized virtual asset trading platform operated by YAX (Hong Kong) Limited, with virtual asset custody and trading services described for retail and other eligible clients.",
+    "official_url_original": "https://www.yax.hk/",
+    "official_domain_original": "yax.hk",
+    "official_url_status": "live_unverified",
+    "archived_url": "https://web.archive.org/web/*/https://www.yax.hk/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-05",
+    "notes": "Hong Kong's Securities and Futures Commission lists YAX (Hong Kong) Limited, trading as YAX, under CE reference BUT913 with a licensing date of 2025-01-27. A Tiger Brokers announcement identifies YAX as its wholly owned subsidiary and describes virtual asset custody and cryptocurrency trading services. The official site returned an access-control response during verification, so the URL is recorded as live_unverified. No exact public launch date or lifecycle event is asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012437",
+      "exchange_id": "hei_ex_001101",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "YAX receives digital asset trading platform license from Hong Kong SFC",
+      "url": "https://www.prnewswire.com/apac/news-releases/yax-receives-digital-asset-trading-platform-license-from-hong-kong-sfc-302360675.html",
+      "publisher": "Tiger Brokers",
+      "published_at": "2025-01-27",
+      "archived_url": "https://web.archive.org/web/*/https://www.prnewswire.com/apac/news-releases/yax-receives-digital-asset-trading-platform-license-from-hong-kong-sfc-302360675.html",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Parent-company announcement identifies YAX as a wholly owned Tiger Brokers subsidiary, provides its official website, and describes licensed virtual asset custody and trading services."
+    },
+    {
+      "id": "hei_src_012438",
+      "exchange_id": "hei_ex_001101",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "Lists of virtual asset trading platforms",
+      "url": "https://www.sfc.hk/en/Welcome-to-the-Fintech-Contact-Point/Virtual-assets/Virtual-asset-trading-platforms-operators/Lists-of-virtual-asset-trading-platforms",
+      "publisher": "Securities and Futures Commission of Hong Kong",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.sfc.hk/en/Welcome-to-the-Fintech-Contact-Point/Virtual-assets/Virtual-asset-trading-platforms-operators/Lists-of-virtual-asset-trading-platforms",
+      "accessed_at": "2026-08-05",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official SFC list identifies YAX (Hong Kong) Limited, trading as YAX, under CE reference BUT913 with a licensing date of 2025-01-27."
+    }
+  ]
+}


### PR DESCRIPTION
## D-1000 BX46

Roadmap item: `D-1000 Reviewed Entity Milestone`

Starting `main`:

```text
06ae9eca147703ec977480d8320a57e8aa680356
```

Starting reviewed state:

```text
Entities: 980
Events:   1022
Evidence: 3740
English dossiers: 980
Japanese dossiers: 980
Sitemap routes: 2004
```

## Reviewed additions

```text
YAX        hei_ex_001101 active / high
Bixin.com  hei_ex_001102 active / high
Ofza       hei_ex_001103 active / high
MB.IO      hei_ex_001104 active / high
```

YAX and Bixin.com are supported by current first-party or parent-company service material and the Hong Kong Securities and Futures Commission licensed-platform list. Ofza and MB.IO are supported by current first-party operating surfaces and active Dubai Virtual Assets Regulatory Authority public-register entries.

## Identity and scope controls

Direct current-main name, path, domain, alias, and operator checks found no reviewed YAX, Bixin.com, Ofza, or MB.IO entity before drafting.

The records use distinct operator and regulatory identities:

```text
YAX        YAX (Hong Kong) Limited                           SFC BUT913
Bixin.com  NewBX Limited                                     SFC BUY737
Ofza       OFZA Fintech Virtual Asset Exchange Services LLC  VARA VL/24/12/002
MB.IO      MBIO FZE / jurisdiction-specific entities         VARA VL/24/06/001
```

YAX and Bixin.com use `live_unverified` because their main sites returned access-control responses during verification. That condition is not converted into an inactive or terminal-state claim.

MB.IO uses `United Arab Emirates` for `country_or_origin` from the reviewed Dubai-licensed operator MBIO FZE. Its Australian spot-product entity remains preserved as an alias and jurisdiction-specific scope note rather than a second canonical exchange record or lineage edge.

No unsupported exact launch date, lifecycle event, terminal state, lineage edge, trading-volume claim, safety claim, or cross-jurisdiction regulatory conclusion is added.

## Projected reviewed state

```text
Entities: 984
Events:   1022
Evidence: 3748
English dossiers: 984
Japanese dossiers: 984
Sitemap routes: 2012
Remaining to D-1000: 16
```

Delta: `+4 entities / +0 events / +8 evidence`.

Next unused identifiers:

```text
entity:   hei_ex_001105
event:    hei_ev_010099
evidence: hei_src_012445
```

## Checkpoint reconciliation

The maintainer recovery contract, L-2 evaluation plan, BX46 audit, consumed backlog, and source-review boundaries are advanced together.

L-2 remains `HOLD`. No localization-breadth expansion or third-language authorization is included.

## Deployment impact

Record-only batch plus checkpoint documentation. No Cloudflare configuration, workflow, schema, route-contract, or public-product implementation changes.

Preview deployment is not required under `CLOUDFLARE_DEPLOYMENT_POLICY.md`. Intermediate commits use `[CF-Pages-Skip]`; production publication should occur only from the reviewed merged `main` state.

## Validation

The first workflow pass correctly rejected the initial null MB.IO country field through both the strict country and permanent entity-quality gates. The record and support documents now use the reviewed Dubai-licensed operator origin.

All standard GitHub workflows must pass on the final head. Any identity overlap, duplicate, ID collision, reference-integrity, count, URL-safety, enum, country, localization, machine/public consistency, or recovery-contract failure will be repaired rather than bypassed.