### PR TITLE
ui: rebuild support and project navigation

### DIFF
--- a/config/public-navigation-surfaces.json
+++ b/config/public-navigation-surfaces.json
@@ -22,6 +22,8 @@
     "/donate/"
   ],
   "footer_routes": [
+    "/dead/",
+    "/active/",
     "/explore/",
     "/compare/",
     "/updates/",
@@ -29,6 +31,7 @@
     "/monthly/",
     "/quality/",
     "/stats/",
+    "/methodology/",
     "/donate/",
     "/about/"
   ],

--- a/scripts/audit-public-navigation-discovery.mjs
+++ b/scripts/audit-public-navigation-discovery.mjs
@@ -48,7 +48,8 @@ function headerRoutes(html) {
 }
 
 function footerRoutes(html) {
-  const footer = extractFirstBlock(html, /<footer\b[^>]*class=["'][^"']*\bfooter\b[^"']*["'][^>]*>[\s\S]*?<\/footer>/i, 'footer')
+  // CSS modules hash class names, so the semantic footer element is the stable contract.
+  const footer = extractFirstBlock(html, /<footer\b[^>]*>[\s\S]*?<\/footer>/i, 'footer')
   return internalRouteSet(footer)
 }
 

--- a/scripts/audit-public-navigation-discovery.mjs
+++ b/scripts/audit-public-navigation-discovery.mjs
@@ -19,6 +19,7 @@ function readJson(filePath) {
 function normalizeRoute(value) {
   const url = new URL(value, origin)
   if (url.origin !== origin) return null
+  if (/\.[a-z0-9]+$/i.test(url.pathname)) return null
   if (url.pathname === '/') return '/'
   return `${url.pathname.replace(/\/+$/, '')}/`
 }
@@ -48,7 +49,6 @@ function headerRoutes(html) {
 }
 
 function footerRoutes(html) {
-  // CSS modules hash class names, so the semantic footer element is the stable contract.
   const footer = extractFirstBlock(html, /<footer\b[^>]*>[\s\S]*?<\/footer>/i, 'footer')
   return internalRouteSet(footer)
 }
@@ -82,13 +82,9 @@ function allSurfaceRoutes(config) {
   return [...new Set(Object.values(config.layers).flat())]
 }
 
-export function auditPublicNavigationDiscovery(
-  outDir = defaultOutDir,
-  configPath = defaultConfigPath,
-) {
+export function auditPublicNavigationDiscovery(outDir = defaultOutDir, configPath = defaultConfigPath) {
   const config = readJson(configPath)
   assert(config.version === 1, 'unsupported navigation contract version')
-
   const surfaces = allSurfaceRoutes(config)
   const findings = []
   const htmlByRoute = new Map()
@@ -112,20 +108,9 @@ export function auditPublicNavigationDiscovery(
   const actualFooter = footerRoutes(homeHtml)
   const headerDiff = setDiff(actualHeader, config.header_routes)
   const footerDiff = setDiff(actualFooter, config.footer_routes)
-
-  if (headerDiff.missing.length > 0 || headerDiff.unexpected.length > 0) {
-    findings.push({ type: 'header_route_set_mismatch', ...headerDiff })
-  }
-  if (footerDiff.missing.length > 0 || footerDiff.unexpected.length > 0) {
-    findings.push({ type: 'footer_route_set_mismatch', ...footerDiff })
-  }
-  if (actualHeader.size > config.header_internal_route_limit) {
-    findings.push({
-      type: 'header_route_limit_exceeded',
-      actual: actualHeader.size,
-      limit: config.header_internal_route_limit,
-    })
-  }
+  if (headerDiff.missing.length > 0 || headerDiff.unexpected.length > 0) findings.push({ type: 'header_route_set_mismatch', ...headerDiff })
+  if (footerDiff.missing.length > 0 || footerDiff.unexpected.length > 0) findings.push({ type: 'footer_route_set_mismatch', ...footerDiff })
+  if (actualHeader.size > config.header_internal_route_limit) findings.push({ type: 'header_route_limit_exceeded', actual: actualHeader.size, limit: config.header_internal_route_limit })
 
   const graph = new Map(surfaces.map((route) => [route, new Set()]))
   for (const route of actualHeader) graph.get('/')?.add(route)
@@ -138,11 +123,8 @@ export function auditPublicNavigationDiscovery(
       continue
     }
     const routes = contextualRoutes(html)
-    if (!routes.has(to)) {
-      findings.push({ type: 'missing_contextual_edge', from, to })
-    } else {
-      graph.get(from)?.add(to)
-    }
+    if (!routes.has(to)) findings.push({ type: 'missing_contextual_edge', from, to })
+    else graph.get(from)?.add(to)
   }
 
   const reachable = new Set(['/'])
@@ -167,19 +149,8 @@ export function auditPublicNavigationDiscovery(
   const orphans = sorted(surfaces.filter((route) => route !== '/' && (inbound.get(route) ?? 0) === 0))
   if (orphans.length > 0) findings.push({ type: 'orphan_surfaces', routes: orphans })
 
-  const layerRouteCount = Object.fromEntries(
-    Object.entries(config.layers).map(([layer, routes]) => [layer, routes.length]),
-  )
-
-  return {
-    surfaces: surfaces.length,
-    headerRoutes: actualHeader.size,
-    footerRoutes: actualFooter.size,
-    contextualEdges: config.contextual_edges.length,
-    reachableSurfaces: reachable.size,
-    layerRouteCount,
-    findings,
-  }
+  const layerRouteCount = Object.fromEntries(Object.entries(config.layers).map(([layer, routes]) => [layer, routes.length]))
+  return { surfaces: surfaces.length, headerRoutes: actualHeader.size, footerRoutes: actualFooter.size, contextualEdges: config.contextual_edges.length, reachableSurfaces: reachable.size, layerRouteCount, findings }
 }
 
 function pageHtml(header, footer, context = []) {
@@ -193,13 +164,7 @@ function runSelfTest() {
   const configPath = path.join(tempRoot, 'navigation.json')
   const config = {
     version: 1,
-    layers: {
-      registry: ['/'],
-      analysis: ['/stats/', '/quality/'],
-      change: ['/updates/'],
-      trust: [],
-      support: [],
-    },
+    layers: { registry: ['/'], analysis: ['/stats/', '/quality/'], change: ['/updates/'], trust: [], support: [] },
     header_routes: ['/', '/stats/', '/updates/'],
     footer_routes: ['/quality/', '/stats/'],
     header_internal_route_limit: 3,
@@ -216,10 +181,8 @@ function runSelfTest() {
       const context = route === '/stats/' ? ['/quality/'] : route === '/quality/' ? ['/stats/'] : []
       fs.writeFileSync(filePath, pageHtml(config.header_routes, config.footer_routes, context))
     }
-
     const clean = auditPublicNavigationDiscovery(outDir, configPath)
     assert(clean.findings.length === 0, `self-test expected 0 findings: ${JSON.stringify(clean.findings)}`)
-
     const statsFile = routeOutputFile('/stats/', outDir)
     fs.writeFileSync(statsFile, pageHtml(config.header_routes, config.footer_routes, []))
     const broken = auditPublicNavigationDiscovery(outDir, configPath)
@@ -227,13 +190,11 @@ function runSelfTest() {
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
-
   console.log('Public navigation discovery audit self-test passed.')
 }
 
-if (process.argv.includes('--self-test')) {
-  runSelfTest()
-} else {
+if (process.argv.includes('--self-test')) runSelfTest()
+else {
   const result = auditPublicNavigationDiscovery()
   console.log(`Public navigation audit: ${result.surfaces} surfaces, ${result.headerRoutes} header routes, ${result.footerRoutes} footer routes, ${result.contextualEdges} contextual edges.`)
   if (result.findings.length > 0) {

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next'
 import DonateWalletsClient from '../../components/donate/donate-wallets-client'
 
 export const metadata: Metadata = {
-  title: 'Donate',
+  title: 'Support HEI',
   description:
-    'Support Historical Exchange Index with the published wallet addresses for BTC, ETH, USDT, USDC, SOL, BNB, DOGE, AVAX, and XRP.',
+    'Support Historical Exchange Index record verification, archive checks, corrections, public data, and long-term maintenance.',
   alternates: {
     canonical: '/donate',
     languages: {
@@ -18,18 +18,17 @@ export default function DonatePage() {
   return (
     <main className="longform">
       <section className="panel longform-panel">
-        <p className="muted">Donate</p>
+        <p className="muted">Support</p>
         <h1 style={{ marginTop: 0, fontSize: '34px' }}>Support HEI</h1>
         <p className="muted" style={{ lineHeight: 1.75, maxWidth: '80ch' }}>
-          HEI includes a public support page for people who want to help maintain and expand the registry.
-          Donation support is optional, but it can help sustain the slow work of record building, cleanup,
-          archive checks, and record verification.
+          Optional support helps maintain and expand the public registry. It can sustain the slow work of record
+          building, archive checks, source review, corrections, machine-readable publishing, and long-term maintenance.
         </p>
       </section>
 
       <section className="panel longform-panel">
         <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
-          <h2>What donations support</h2>
+          <h2>What support funds</h2>
           <div className="fact-grid">
             <div className="fact">
               <div className="k">Record expansion</div>
@@ -40,48 +39,51 @@ export default function DonatePage() {
               <div className="v">Improving archived URL coverage and safer historical linking.</div>
             </div>
             <div className="fact">
-              <div className="k">Verification work</div>
-              <div className="v">Reviewing dates, causes, and classification details where records remain uncertain.</div>
+              <div className="k">Verification and corrections</div>
+              <div className="v">Reviewing dates, causes, classifications, sources, and submitted corrections.</div>
             </div>
             <div className="fact">
-              <div className="k">Maintenance</div>
-              <div className="v">Keeping the public registry readable, usable, and up to date over time.</div>
+              <div className="k">Public maintenance</div>
+              <div className="v">Maintaining the website, public data files, monitoring, and visual review workflows.</div>
             </div>
           </div>
         </div>
 
         <div className="section">
-          <h2>Wallet addresses</h2>
+          <h2>Support options</h2>
           <p className="muted" style={{ marginTop: 0, lineHeight: 1.75 }}>
-            Send only the named asset on the listed network. Double-check address and network before sending.
-            Wallet cards below include a copy button for each address.
+            Send only the named asset on the listed network. Double-check the asset, chain, and address before sending.
+            Primary options are shown first; less common networks remain collapsed until needed.
           </p>
-
-          <DonateWalletsClient />
+          <DonateWalletsClient locale="en" />
         </div>
 
         <div className="section">
-          <h2>Notes</h2>
+          <h2>Editorial independence</h2>
           <div className="fact-grid">
             <div className="fact">
-              <div className="k">Network caution</div>
-              <div className="v">Do not send assets on the wrong network. Funds sent on unsupported networks may be lost.</div>
+              <div className="k">What support does not buy</div>
+              <div className="v">Support does not guarantee inclusion, removal, status changes, rankings, or favorable descriptions.</div>
             </div>
             <div className="fact">
-              <div className="k">XRP note</div>
-              <div className="v">No destination tag is listed on this page. Confirm your sending service can send without one before using the XRP address.</div>
+              <div className="k">Evidence standards</div>
+              <div className="v">Evidence and review requirements remain the same regardless of who provides support.</div>
             </div>
             <div className="fact">
-              <div className="k">Final check</div>
-              <div className="v">Always verify the copied address on your own device before submitting a transaction.</div>
+              <div className="k">Corrections remain open</div>
+              <div className="v">Corrections are reviewed whether or not the submitter has supported HEI.</div>
+            </div>
+            <div className="fact">
+              <div className="k">Final transaction check</div>
+              <div className="v">Verify every copied address and network on your own device before submitting a transaction.</div>
             </div>
           </div>
         </div>
       </section>
 
       <section className="callout">
-        Support is optional. Donations do not affect record selection, status classification, evidence standards,
-        or editorial decisions. HEI remains a public registry regardless of whether you donate.
+        Support is optional. It does not affect record selection, classification, evidence standards, corrections,
+        or editorial decisions. HEI remains a public registry regardless of whether you provide support.
       </section>
     </main>
   )

--- a/src/app/ja/donate/page.tsx
+++ b/src/app/ja/donate/page.tsx
@@ -4,7 +4,7 @@ import DonateWalletsClient from '../../../components/donate/donate-wallets-clien
 import { CONTACT_HREF, SITE_NAME, SITE_URL } from '../../../lib/site-constants'
 
 const title = 'HEIを支援する'
-const description = 'Historical Exchange Indexのレコード追加、アーカイブ確認、evidence検証、公開サイト保守を任意の寄付で支援できます。'
+const description = 'Historical Exchange Indexのレコード検証、アーカイブ確認、訂正対応、公開データ、長期保守を任意の支援で維持できます。'
 
 export const metadata: Metadata = {
   title,
@@ -36,11 +36,11 @@ export default function JapaneseDonatePage() {
   return (
     <main className="longform">
       <section className="panel longform-panel">
-        <p className="muted">寄付</p>
+        <p className="muted">支援</p>
         <h1 style={{ marginTop: 0, fontSize: '34px' }}>{title}</h1>
         <p className="muted" style={{ lineHeight: 1.75, maxWidth: '80ch' }}>
-          HEIは、暗号資産取引所の歴史をentity・event・evidenceとして整理し、公開する独立したレジストリです。
-          寄付は任意であり、レコード追加、アーカイブ確認、情報の再検証、公開サイトの維持に使用されます。
+          HEIは、暗号資産取引所の歴史をentity・event・evidenceとして整理する独立した公開レジストリです。
+          任意の支援は、レコード追加、アーカイブ確認、出典検証、訂正対応、機械可読データ、長期保守に使用されます。
         </p>
         <div className="hero-actions">
           <Link className="btn" href="/donate/" hrefLang="en">English</Link>
@@ -50,37 +50,37 @@ export default function JapaneseDonatePage() {
 
       <section className="panel longform-panel">
         <div className="section" style={{ borderTop: 'none', paddingTop: 0 }}>
-          <h2>寄付で支援される作業</h2>
+          <h2>支援対象</h2>
           <div className="fact-grid">
             <div className="fact"><div className="k">レコード拡充</div><div className="v">稼働側・終了側のentity、event、evidenceを追加します。</div></div>
             <div className="fact"><div className="k">アーカイブ確認</div><div className="v">過去サイトの保存URLを確認し、安全な歴史導線を増やします。</div></div>
-            <div className="fact"><div className="k">検証</div><div className="v">日付、終了理由、status、出典の不確実な箇所を再確認します。</div></div>
-            <div className="fact"><div className="k">保守</div><div className="v">公開レジストリ、機械可読データ、監査workflowを維持します。</div></div>
+            <div className="fact"><div className="k">検証と訂正</div><div className="v">日付、終了理由、status、出典、送付された訂正を再確認します。</div></div>
+            <div className="fact"><div className="k">公開保守</div><div className="v">公開サイト、機械可読データ、監視、画面監査workflowを維持します。</div></div>
           </div>
         </div>
 
         <div className="section">
-          <h2>ウォレットアドレス</h2>
+          <h2>支援方法</h2>
           <p className="muted" style={{ marginTop: 0, lineHeight: 1.75 }}>
-            表示された資産を、表示されたネットワークでのみ送付してください。送付前にネットワークとアドレスを必ず確認してください。
-            下のカードでは各アドレスをコピーできます。
+            表示された資産を、表示されたネットワークでのみ送付してください。送付前に資産、チェーン、アドレスを確認してください。
+            主な送付方法を先に表示し、その他のネットワークは必要な場合だけ開けます。
           </p>
-          <DonateWalletsClient />
+          <DonateWalletsClient locale="ja" />
         </div>
 
         <div className="section">
-          <h2>重要事項</h2>
+          <h2>編集上の独立性</h2>
           <div className="fact-grid">
-            <div className="fact"><div className="k">編集上の独立性</div><div className="v">寄付の有無や金額は、掲載、status、evidence基準、編集判断に影響しません。</div></div>
-            <div className="fact"><div className="k">ネットワーク</div><div className="v">誤ったネットワークへの送付は資産を失う可能性があります。</div></div>
-            <div className="fact"><div className="k">XRP</div><div className="v">このページにはDestination Tagを記載していません。Tagなし送付に対応するサービスか確認してください。</div></div>
-            <div className="fact"><div className="k">最終確認</div><div className="v">取引を確定する前に、コピーしたアドレスを自身の端末上で再確認してください。</div></div>
+            <div className="fact"><div className="k">支援で買えないもの</div><div className="v">掲載、削除、status変更、ランキング、有利な説明は保証されません。</div></div>
+            <div className="fact"><div className="k">Evidence基準</div><div className="v">支援者にかかわらず、証拠とレビューの基準は同じです。</div></div>
+            <div className="fact"><div className="k">訂正窓口</div><div className="v">支援の有無にかかわらず、送付された訂正を確認します。</div></div>
+            <div className="fact"><div className="k">送付前確認</div><div className="v">取引を確定する前に、コピーしたアドレスとネットワークを自身の端末で再確認してください。</div></div>
           </div>
         </div>
       </section>
 
       <section className="callout">
-        支援は任意です。HEIは寄付の有無にかかわらず、公開レジストリとして利用できる状態を維持する方針です。
+        支援は任意です。掲載、分類、evidence基準、訂正、編集判断には影響しません。HEIは支援の有無にかかわらず公開レジストリとして利用できます。
       </section>
     </main>
   )

--- a/src/components/donate/donate-wallets-client.module.css
+++ b/src/components/donate/donate-wallets-client.module.css
@@ -1,0 +1,155 @@
+.wrapper {
+  display: grid;
+  gap: 18px;
+}
+
+.groupTitle {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.card {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255,255,255,0.018);
+}
+
+.top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.asset {
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.network {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.copyButton {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  padding: 8px 11px;
+  border: 1px solid rgba(184,135,70,0.3);
+  border-radius: 10px;
+  color: #f5dfbf;
+  background: rgba(184,135,70,0.08);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.copyButton:hover,
+.copyButton:focus-visible {
+  background: rgba(184,135,70,0.16);
+  outline: none;
+}
+
+.note,
+.warning {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.note {
+  margin: 12px 0 0;
+}
+
+.addressLabel {
+  display: block;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.address {
+  display: block;
+  margin-top: 5px;
+  padding: 10px 11px;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  color: #dce5ef;
+  background: #0d1116;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.warning {
+  margin: 10px 0 0;
+}
+
+.additional {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255,255,255,0.012);
+}
+
+.additional summary {
+  min-height: 48px;
+  padding: 13px 16px;
+  cursor: pointer;
+  color: #dce4ed;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.additional[open] summary {
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.additional .grid {
+  padding: 14px;
+}
+
+@media (max-width: 699px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    padding: 14px;
+  }
+
+  .top {
+    display: grid;
+    grid-template-columns: minmax(0,1fr) auto;
+  }
+
+  .copyButton {
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 439px) {
+  .top {
+    grid-template-columns: 1fr;
+  }
+
+  .copyButton {
+    width: 100%;
+  }
+}

--- a/src/components/donate/donate-wallets-client.tsx
+++ b/src/components/donate/donate-wallets-client.tsx
@@ -1,24 +1,73 @@
 'use client'
 
 import { useState } from 'react'
+import styles from './donate-wallets-client.module.css'
+
+type Locale = 'en' | 'ja'
 
 type WalletItem = {
   id: string
   asset: string
   network: string
   address: string
+  note?: string
+  addressLabel?: string
 }
 
-const WALLETS: WalletItem[] = [
-  { id: 'btc', asset: 'BTC', network: 'Bitcoin', address: 'bc1qdzxgxg6qt0sjceercxhfngq47qyr2gyqdpd7tj' },
-  { id: 'eth', asset: 'ETH', network: 'ERC-20', address: '0x64afa8201ab478573243a852251d46abe124acd1' },
-  { id: 'usdt', asset: 'USDT', network: 'ERC-20', address: '0x64afa8201ab478573243a852251d46abe124acd1' },
-  { id: 'usdc', asset: 'USDC', network: 'ERC-20', address: '0x64afa8201ab478573243a852251d46abe124acd1' },
-  { id: 'sol', asset: 'SOL', network: 'Solana', address: 'FsymgjzjxKyEZQeJDuAcDd8fyX7Ny7yxzZX9UKvCzfen' },
-  { id: 'bnb', asset: 'BNB', network: 'BEP-20', address: '0x64afa8201ab478573243a852251d46abe124acd1' },
-  { id: 'doge', asset: 'DOGE', network: 'Dogecoin', address: 'DLThxkLh5skugJnofdm5WRARadX83x4Zmz' },
-  { id: 'avax', asset: 'AVAX', network: 'Avalanche C-Chain', address: '0x64afa8201ab478573243a852251d46abe124acd1' },
-  { id: 'xrp', asset: 'XRP', network: 'XRPL', address: 'rfNBaSjUQ8r7vCR2aMJKYVG3gNKiQ2Q9uh' },
+const EVM_ADDRESS = '0x64afa8201ab478573243a852251d46abe124acd1'
+
+const PRIMARY_WALLETS: WalletItem[] = [
+  {
+    id: 'btc',
+    asset: 'BTC',
+    network: 'Bitcoin',
+    address: 'bc1qdzxgxg6qt0sjceercxhfngq47qyr2gyqdpd7tj',
+  },
+  {
+    id: 'evm-primary',
+    asset: 'ETH · USDT · USDC',
+    network: 'Ethereum / ERC-20',
+    address: EVM_ADDRESS,
+    note: 'One EVM address for ETH, ERC-20 USDT, and ERC-20 USDC.',
+    addressLabel: 'EVM address',
+  },
+]
+
+const ADDITIONAL_WALLETS: WalletItem[] = [
+  {
+    id: 'sol',
+    asset: 'SOL',
+    network: 'Solana',
+    address: 'FsymgjzjxKyEZQeJDuAcDd8fyX7Ny7yxzZX9UKvCzfen',
+  },
+  {
+    id: 'bnb',
+    asset: 'BNB',
+    network: 'BNB Smart Chain / BEP-20',
+    address: EVM_ADDRESS,
+    note: 'Uses the EVM address shown in Primary options.',
+    addressLabel: 'EVM address',
+  },
+  {
+    id: 'doge',
+    asset: 'DOGE',
+    network: 'Dogecoin',
+    address: 'DLThxkLh5skugJnofdm5WRARadX83x4Zmz',
+  },
+  {
+    id: 'avax',
+    asset: 'AVAX',
+    network: 'Avalanche C-Chain',
+    address: EVM_ADDRESS,
+    note: 'Uses the EVM address shown in Primary options.',
+    addressLabel: 'EVM address',
+  },
+  {
+    id: 'xrp',
+    asset: 'XRP',
+    network: 'XRPL · no destination tag listed',
+    address: 'rfNBaSjUQ8r7vCR2aMJKYVG3gNKiQ2Q9uh',
+  },
 ]
 
 async function copyText(text: string) {
@@ -38,45 +87,87 @@ async function copyText(text: string) {
   document.body.removeChild(textArea)
 }
 
-export default function DonateWalletsClient() {
-  const [copiedId, setCopiedId] = useState<string | null>(null)
+function WalletCard({
+  wallet,
+  locale,
+  copied,
+  onCopy,
+}: {
+  wallet: WalletItem
+  locale: Locale
+  copied: boolean
+  onCopy: () => void
+}) {
+  const ja = locale === 'ja'
+  return (
+    <article className={styles.card}>
+      <div className={styles.top}>
+        <div>
+          <div className={styles.asset}>{wallet.asset}</div>
+          <div className={styles.network}>{wallet.network}</div>
+        </div>
+        <button
+          type="button"
+          className={styles.copyButton}
+          onClick={onCopy}
+          aria-label={ja
+            ? `${wallet.asset}（${wallet.network}）のアドレスをコピー`
+            : `Copy ${wallet.asset} address for ${wallet.network}`}
+        >
+          {copied ? (ja ? 'コピー済み' : 'Copied') : (ja ? 'コピー' : 'Copy address')}
+        </button>
+      </div>
+      {wallet.note && <p className={styles.note}>{ja
+        ? wallet.note
+            .replace('One EVM address for ETH, ERC-20 USDT, and ERC-20 USDC.', 'ETH、ERC-20 USDT、ERC-20 USDCで共通のEVMアドレスです。')
+            .replace('Uses the EVM address shown in Primary options.', 'Primary optionsに表示されたEVMアドレスを使用します。')
+        : wallet.note}</p>}
+      <span className={styles.addressLabel}>{wallet.addressLabel ?? (ja ? 'アドレス' : 'Address')}</span>
+      <code className={styles.address}>{wallet.address}</code>
+      <p className={styles.warning}>{ja
+        ? '送付前に資産、チェーン、アドレスを自身の端末で再確認してください。誤ったネットワークへの送付は復旧できない場合があります。'
+        : 'Verify the asset, chain, and address on your own device before sending. Transfers on the wrong network may be unrecoverable.'}</p>
+    </article>
+  )
+}
 
-  const handleCopy = async (id: string, address: string) => {
+export default function DonateWalletsClient({ locale = 'en' }: { locale?: Locale }) {
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const ja = locale === 'ja'
+
+  const handleCopy = async (wallet: WalletItem) => {
     try {
-      await copyText(address)
-      setCopiedId(id)
+      await copyText(wallet.address)
+      setCopiedId(wallet.id)
       window.setTimeout(() => {
-        setCopiedId((current) => (current === id ? null : current))
-      }, 1600)
+        setCopiedId((current) => (current === wallet.id ? null : current))
+      }, 2000)
     } catch {
       setCopiedId(null)
     }
   }
 
+  const renderWallet = (wallet: WalletItem) => (
+    <WalletCard
+      key={wallet.id}
+      wallet={wallet}
+      locale={locale}
+      copied={copiedId === wallet.id}
+      onCopy={() => void handleCopy(wallet)}
+    />
+  )
+
   return (
-    <div className="donate-wallet-grid">
-      {WALLETS.map((wallet) => (
-        <article className="donate-wallet-card" key={wallet.id}>
-          <div className="donate-wallet-top">
-            <div className="donate-wallet-copy">
-              <div className="donate-wallet-asset">{wallet.asset}</div>
-              <div className="donate-wallet-network">{wallet.network}</div>
-            </div>
+    <div className={styles.wrapper}>
+      <section aria-labelledby="hei-primary-support-options">
+        <h3 id="hei-primary-support-options" className={styles.groupTitle}>{ja ? '主な送付方法' : 'Primary options'}</h3>
+        <div className={styles.grid}>{PRIMARY_WALLETS.map(renderWallet)}</div>
+      </section>
 
-            <div className="donate-wallet-copy">
-              <button
-                type="button"
-                className="btn btn-ghost"
-                onClick={() => void handleCopy(wallet.id, wallet.address)}
-              >
-                {copiedId === wallet.id ? 'Copied' : 'Copy'}
-              </button>
-            </div>
-          </div>
-
-          <code className="donate-address">{wallet.address}</code>
-        </article>
-      ))}
+      <details className={styles.additional}>
+        <summary>{ja ? 'その他のネットワーク' : 'Additional networks'}</summary>
+        <div className={styles.grid}>{ADDITIONAL_WALLETS.map(renderWallet)}</div>
+      </details>
     </div>
   )
 }

--- a/src/components/layout/project-footer.module.css
+++ b/src/components/layout/project-footer.module.css
@@ -1,0 +1,138 @@
+.footer {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.25fr) repeat(3, minmax(170px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+  padding: 32px 0 8px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.summary {
+  align-self: start;
+}
+
+.summary strong {
+  display: block;
+  font-size: 15px;
+}
+
+.summary p {
+  max-width: 34ch;
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.group {
+  min-width: 0;
+}
+
+.group h2 {
+  margin: 0 0 10px;
+  color: #d9e1ea;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.links {
+  display: grid;
+  gap: 3px;
+}
+
+.links > a,
+.current,
+.networkLink {
+  min-height: 44px;
+  padding: 8px 9px;
+  border-radius: 10px;
+}
+
+.links > a,
+.networkLink {
+  display: flex;
+  align-items: center;
+  color: #cdd6e0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.links > a:hover,
+.links > a:focus-visible,
+.networkLink:hover,
+.networkLink:focus-visible {
+  color: var(--text);
+  background: rgba(255,255,255,0.045);
+  outline: none;
+}
+
+.networkLink,
+.current {
+  display: grid;
+  align-content: center;
+  gap: 2px;
+}
+
+.networkLink small,
+.current small {
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.current {
+  border: 1px solid rgba(184,135,70,0.24);
+  color: #f5dfbf;
+  background: rgba(184,135,70,0.08);
+  font-size: 12px;
+}
+
+.supportLink {
+  border: 1px solid rgba(184,135,70,0.32);
+  color: #f5dfbf !important;
+  background: rgba(184,135,70,0.09);
+  font-weight: 650;
+}
+
+@media (max-width: 1023px) {
+  .footer {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 599px) {
+  .footer {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    margin-top: 24px;
+    padding-top: 24px;
+  }
+
+  .summary p {
+    max-width: none;
+  }
+
+  .group {
+    padding-top: 4px;
+  }
+
+  .group h2 {
+    margin-bottom: 6px;
+  }
+
+  .links > a,
+  .current,
+  .networkLink {
+    width: 100%;
+    min-height: 44px;
+    padding: 9px 10px;
+    border-bottom: 1px solid var(--line-soft);
+    border-radius: 8px;
+  }
+
+  .current {
+    border: 1px solid rgba(184,135,70,0.24);
+  }
+}

--- a/src/components/layout/project-footer.tsx
+++ b/src/components/layout/project-footer.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link'
+import type { SupportedLocale } from '../../i18n/config'
+import { buildLocalePath } from '../../lib/i18n/locale-routes'
+import { CONTACT_HREF, ISSUES_HREF } from '../../lib/site-constants'
+import { PROJECT_NETWORK } from '../../lib/project-network'
+import styles from './project-footer.module.css'
+
+type Props = {
+  locale: SupportedLocale
+  supportHref: string
+}
+
+function localHref(pathname: string, locale: SupportedLocale) {
+  if (locale === 'en') return pathname
+  return buildLocalePath(pathname, locale)
+}
+
+export default function ProjectFooter({ locale, supportHref }: Props) {
+  const ja = locale === 'ja'
+  const siteLinks = [
+    { label: ja ? '終了済み取引所' : 'Dead exchanges', href: localHref('/dead', locale) },
+    { label: ja ? '稼働側取引所' : 'Active exchanges', href: localHref('/active', locale) },
+    { label: ja ? 'エクスプローラー' : 'Explorer', href: localHref('/explore', locale) },
+    { label: ja ? '比較' : 'Compare', href: '/compare' },
+    { label: ja ? 'インシデント' : 'Incidents', href: localHref('/incidents', locale) },
+    { label: ja ? '月次アーカイブ' : 'Monthly archive', href: localHref('/monthly', locale) },
+    { label: ja ? '統計' : 'Statistics', href: localHref('/stats', locale) },
+  ]
+  const projectLinks = [
+    { label: ja ? '方法論' : 'Methodology', href: localHref('/methodology', locale) },
+    { label: ja ? '概要' : 'About', href: localHref('/about', locale) },
+    { label: ja ? '品質' : 'Quality', href: localHref('/quality', locale) },
+    { label: ja ? '更新履歴' : 'Updates', href: localHref('/updates', locale) },
+  ]
+
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.summary}>
+        <strong>Historical Exchange Index</strong>
+        <p>{ja ? '取引所の状態変化、終了、統合、根拠資料を記録する歴史台帳。' : 'A reviewed historical registry of crypto exchanges, active and gone.'}</p>
+      </div>
+
+      <section className={styles.group} aria-labelledby="hei-footer-network">
+        <h2 id="hei-footer-network">{ja ? 'プロジェクトネットワーク' : 'Project network'}</h2>
+        <div className={styles.links}>
+          {PROJECT_NETWORK.map((project) => project.id === 'hei' ? (
+            <span key={project.id} className={styles.current} aria-current="page">
+              <span>{project.name}</span>
+              <small>{ja ? '現在のプロジェクト' : 'Current project'}</small>
+            </span>
+          ) : (
+            <a key={project.id} href={project.url} className={styles.networkLink}>
+              <span>{project.name}</span>
+              <small>{project.description}</small>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.group} aria-labelledby="hei-footer-explore">
+        <h2 id="hei-footer-explore">{ja ? 'HEIを探索' : 'Explore HEI'}</h2>
+        <nav className={styles.links} aria-label={ja ? 'HEI探索リンク' : 'HEI exploration links'}>
+          {siteLinks.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}
+        </nav>
+      </section>
+
+      <section className={styles.group} aria-labelledby="hei-footer-project">
+        <h2 id="hei-footer-project">{ja ? 'プロジェクト' : 'Project'}</h2>
+        <nav className={styles.links} aria-label={ja ? 'プロジェクト情報' : 'Project information'}>
+          {projectLinks.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}
+          <a href={CONTACT_HREF} target="_blank" rel="noreferrer">{ja ? '連絡・訂正' : 'Contact / Corrections'}</a>
+          <a href={ISSUES_HREF} target="_blank" rel="noreferrer">GitHub Issues</a>
+        </nav>
+      </section>
+
+      <section className={`${styles.group} ${styles.supportGroup}`} aria-labelledby="hei-footer-support">
+        <h2 id="hei-footer-support">{ja ? '支援と公開データ' : 'Support & public data'}</h2>
+        <nav className={styles.links} aria-label={ja ? '支援と公開データ' : 'Support and public data'}>
+          <Link className={styles.supportLink} href={supportHref}>{ja ? 'HEIを支援' : 'Support HEI'}</Link>
+          <a href="/version.json">Version JSON</a>
+          <a href="/data/manifest.json">Data manifest</a>
+          <a href="/llms.txt">LLM guide</a>
+          <a href="/ai.txt">AI guide</a>
+        </nav>
+      </section>
+    </footer>
+  )
+}

--- a/src/components/layout/site-chrome.module.css
+++ b/src/components/layout/site-chrome.module.css
@@ -50,6 +50,10 @@
   white-space: nowrap;
 }
 
+.brandTitleShort {
+  display: none;
+}
+
 .brandTagline {
   display: block;
   margin: 2px 0 0;
@@ -118,6 +122,12 @@
   border: 1px solid rgba(184, 135, 70, 0.28);
   color: #f5dfbf;
   background: linear-gradient(180deg, rgba(184, 135, 70, 0.14), rgba(184, 135, 70, 0.08));
+}
+
+.mobileUtilityLink {
+  min-height: 36px;
+  padding-inline: 10px;
+  font-weight: 650;
 }
 
 .desktopLocale :global(.locale-switcher),
@@ -230,10 +240,11 @@
 @media (max-width: 599px) {
   .topbar {
     min-height: 58px;
+    gap: 8px;
   }
 
   .brandLink {
-    gap: 9px;
+    gap: 8px;
   }
 
   .brandMark {
@@ -243,7 +254,15 @@
   }
 
   .brandTitle {
-    font-size: 13px;
+    font-size: 12px;
+  }
+
+  .brandTitleLong {
+    display: none;
+  }
+
+  .brandTitleShort {
+    display: block;
   }
 
   .brandTagline {
@@ -252,31 +271,38 @@
 
   .mobileLocale :global(.nav-link) {
     min-height: 34px;
-    padding: 7px 6px;
+    padding: 7px 5px;
+    font-size: 9px;
+  }
+
+  .mobileUtilityLink {
+    min-height: 34px;
+    padding: 7px 8px;
     font-size: 10px;
   }
 
   .mobileSummary {
     min-height: 34px;
-    padding: 8px 10px;
+    padding: 8px 9px;
+    font-size: 10px;
+  }
+}
+
+@media (max-width: 379px) {
+  .brandTitleShort {
     font-size: 11px;
   }
-}
 
-@media (max-width: 420px) {
-  .brandTitle {
-    max-width: 108px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-}
-
-@media (max-width: 359px) {
-  .brandTitle {
-    max-width: 92px;
+  .mobileControls {
+    gap: 4px;
   }
 
   .mobileLocale :global(.nav-link) {
-    padding-inline: 5px;
+    padding-inline: 4px;
+  }
+
+  .mobileUtilityLink,
+  .mobileSummary {
+    padding-inline: 7px;
   }
 }

--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -3,13 +3,11 @@ import { Suspense, type ReactNode } from 'react'
 import type { SupportedLocale } from '../../i18n/config'
 import { getDictionary, translate } from '../../lib/i18n/get-dictionary'
 import { buildLocalePath } from '../../lib/i18n/locale-routes'
-import {
-  CONTACT_HREF,
-  ISSUES_HREF,
-} from '../../lib/site-constants'
 import ExchangeCompareContextLink from '../navigation/exchange-compare-context-link'
 import SiteNavigation, { type SiteNavigationItem } from '../navigation/site-navigation'
+import SupportStrip from '../support/support-strip'
 import headingStyles from './semantic-heading-compat.module.css'
+import ProjectFooter from './project-footer'
 import styles from './site-chrome.module.css'
 
 type SiteChromeProps = {
@@ -25,7 +23,7 @@ function localHref(pathname: string, locale: SupportedLocale) {
 export default function SiteChrome({ locale, children }: SiteChromeProps) {
   const dictionary = getDictionary(locale).common
   const t = (key: string, fallback?: string) => translate(dictionary, key, fallback)
-  const donateHref = localHref('/donate', locale)
+  const supportHref = localHref('/donate', locale)
 
   const navItems: SiteNavigationItem[] = [
     { label: t('nav.home'), href: localHref('/', locale) },
@@ -62,7 +60,7 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
           <SiteNavigation
             primaryAriaLabel={primaryAriaLabel}
             items={navItems}
-            donateHref={donateHref}
+            donateHref={supportHref}
             donateLabel={t('nav.donate')}
             menuLabel={locale === 'ja' ? 'メニュー' : 'Menu'}
             closeLabel={locale === 'ja' ? '閉じる' : 'Close'}
@@ -75,55 +73,8 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
 
       <ExchangeCompareContextLink />
       {children}
-
-      <footer className="footer">
-        <div className="footer-copy">{t('footer.registryTagline')}</div>
-        <div className="footer-links">
-          <a className="archive-link" href="https://badjoke-lab.com/">
-            BadJoke-Lab project hub
-          </a>
-          <span className="muted footer-sep"> · </span>
-          <span className="muted">HEI</span>
-          <span className="muted footer-sep"> · </span>
-          <a className="archive-link" href="https://www.stableorgone.com/">
-            SOG
-          </a>
-          <span className="muted footer-sep"> · </span>
-          <a className="archive-link" href="https://cya.badjoke-lab.com/">
-            CYA
-          </a>
-          <span className="muted footer-sep"> · </span>
-          <a className="archive-link" href="https://bir.badjoke-lab.com/">
-            BIR
-          </a>
-          <span className="muted footer-sep"> · </span>
-          <a className="archive-link" href={CONTACT_HREF} target="_blank" rel="noreferrer">
-            {t('footer.contactCorrections')}
-          </a>
-          <span className="muted footer-sep"> · </span>
-          <a className="archive-link" href={ISSUES_HREF} target="_blank" rel="noreferrer">
-            {t('footer.githubIssues')}
-          </a>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={localHref('/explore', locale)}>{t('nav.explorer')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href="/compare">{t('nav.compare')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={localHref('/updates', locale)}>{t('nav.updates')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={localHref('/incidents', locale)}>{t('nav.incidents')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={localHref('/monthly', locale)}>{t('nav.monthly')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={localHref('/quality', locale)}>{t('nav.quality')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={localHref('/stats', locale)}>{t('nav.stats')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link className="archive-link" href={donateHref}>{t('footer.supportHei')}</Link>
-          <span className="muted footer-sep"> · </span>
-          <Link href={localHref('/about', locale)}>{t('nav.about')}</Link>
-        </div>
-      </footer>
+      <SupportStrip locale={locale} href={supportHref} />
+      <ProjectFooter locale={locale} supportHref={supportHref} />
     </div>
   )
 }

--- a/src/components/layout/site-chrome.tsx
+++ b/src/components/layout/site-chrome.tsx
@@ -51,7 +51,8 @@ export default function SiteChrome({ locale, children }: SiteChromeProps) {
         >
           <span className={styles.brandMark} aria-hidden="true">HEI</span>
           <span className={styles.brandCopy}>
-            <span className={styles.brandTitle}>{brandTitle}</span>
+            <span className={`${styles.brandTitle} ${styles.brandTitleLong}`}>{brandTitle}</span>
+            <span className={`${styles.brandTitle} ${styles.brandTitleShort}`}>Exchange Index</span>
             <span className={styles.brandTagline}>{t('brand.tagline', 'A quiet registry of crypto exchanges, active and gone.')}</span>
           </span>
         </Link>

--- a/src/components/navigation/site-navigation.tsx
+++ b/src/components/navigation/site-navigation.tsx
@@ -151,6 +151,14 @@ export default function SiteNavigation({
           </Suspense>
         </div>
 
+        <Link
+          className={`${styles.utilityLink} ${styles.mobileUtilityLink} ${donateActive ? styles.activeLink : ''}`}
+          href={donateHref}
+          aria-current={donateActive ? 'page' : undefined}
+        >
+          {donateLabel}
+        </Link>
+
         <details
           key={pathname}
           ref={detailsRef}
@@ -169,14 +177,6 @@ export default function SiteNavigation({
           <div className={styles.mobilePanel}>
             <nav id="hei-mobile-navigation" className={styles.mobileMenuNav} aria-label={primaryAriaLabel}>
               {items.map((item, index) => renderItem(item, true, index))}
-              <Link
-                className={`${styles.utilityLink} ${donateActive ? styles.activeLink : ''}`}
-                href={donateHref}
-                aria-current={donateActive ? 'page' : undefined}
-                onClick={() => closeMenu(false)}
-              >
-                {donateLabel}
-              </Link>
             </nav>
           </div>
         </details>

--- a/src/components/support/support-strip.module.css
+++ b/src/components/support/support-strip.module.css
@@ -1,0 +1,68 @@
+.strip {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 24px;
+  margin-top: 28px;
+  padding: 22px 24px;
+  border: 1px solid rgba(184,135,70,0.28);
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, rgba(184,135,70,0.12), rgba(255,255,255,0.018));
+}
+
+.kicker {
+  margin: 0 0 5px !important;
+  color: #e8cfaa !important;
+  font-size: 11px !important;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.strip h2 {
+  margin: 0;
+  font-size: clamp(19px, 2vw, 24px);
+  letter-spacing: -0.03em;
+}
+
+.strip p:not(.kicker) {
+  max-width: 78ch;
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.action {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border: 1px solid rgba(184,135,70,0.38);
+  border-radius: 12px;
+  color: #f5dfbf;
+  background: rgba(184,135,70,0.1);
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.action:hover,
+.action:focus-visible {
+  background: rgba(184,135,70,0.18);
+  outline: none;
+}
+
+@media (max-width: 699px) {
+  .strip {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    margin-top: 20px;
+    padding: 18px;
+  }
+
+  .action {
+    width: 100%;
+  }
+}

--- a/src/components/support/support-strip.tsx
+++ b/src/components/support/support-strip.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { SupportedLocale } from '../../i18n/config'
+import styles from './support-strip.module.css'
+
+type Props = {
+  locale: SupportedLocale
+  href: string
+}
+
+export default function SupportStrip({ locale, href }: Props) {
+  const pathname = usePathname()
+  if (pathname === '/donate' || pathname === '/donate/' || pathname === '/ja/donate' || pathname === '/ja/donate/') {
+    return null
+  }
+
+  const ja = locale === 'ja'
+  return (
+    <aside className={styles.strip} aria-labelledby="hei-support-strip-title">
+      <div>
+        <p className={styles.kicker}>{ja ? '独立した公開台帳' : 'Independent public registry'}</p>
+        <h2 id="hei-support-strip-title">{ja ? '公開記録の維持を支援する' : 'Help maintain the public record'}</h2>
+        <p>{ja
+          ? 'レコード検証、アーカイブ確認、訂正対応、長期保守への任意の支援を受け付けています。支援は掲載や分類、証拠基準に影響しません。'
+          : 'Optional support helps with record verification, archive checks, corrections, and long-term maintenance. Support never changes inclusion, classification, or evidence standards.'}</p>
+      </div>
+      <Link className={styles.action} href={href}>{ja ? 'HEIを支援' : 'Support HEI'}</Link>
+    </aside>
+  )
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -11,7 +11,7 @@
   "nav.monthly": "Monthly",
   "nav.methodology": "Methodology",
   "nav.about": "About",
-  "nav.donate": "Donate",
+  "nav.donate": "Support",
   "action.submitCorrection": "Submit correction",
   "action.openIssue": "Open an issue",
   "action.clearFilters": "Clear all filters",

--- a/src/lib/project-network.ts
+++ b/src/lib/project-network.ts
@@ -1,0 +1,52 @@
+export type ProjectNetworkItem = {
+  id: 'hub' | 'hei' | 'sog' | 'cya' | 'bir' | 'mag'
+  name: string
+  shortName: string
+  url: string
+  description: string
+}
+
+export const PROJECT_NETWORK: readonly ProjectNetworkItem[] = [
+  {
+    id: 'hub',
+    name: 'BadJoke-Lab Hub',
+    shortName: 'Hub',
+    url: 'https://badjoke-lab.com/',
+    description: 'Canonical directory for BadJoke-Lab public projects.',
+  },
+  {
+    id: 'hei',
+    name: 'Historical Exchange Index',
+    shortName: 'HEI',
+    url: 'https://hei.badjoke-lab.com/',
+    description: 'Reviewed historical registry of crypto exchanges.',
+  },
+  {
+    id: 'sog',
+    name: 'Stable or Gone',
+    shortName: 'SOG',
+    url: 'https://www.stableorgone.com/',
+    description: 'Evidence-backed stablecoin lifecycle registry.',
+  },
+  {
+    id: 'cya',
+    name: 'Crypto Yield Archive',
+    shortName: 'CYA',
+    url: 'https://cya.badjoke-lab.com/',
+    description: 'Historical archive of crypto yield and lending platforms.',
+  },
+  {
+    id: 'bir',
+    name: 'Bridge Incident Registry',
+    shortName: 'BIR',
+    url: 'https://bir.badjoke-lab.com/',
+    description: 'Registry of bridge incidents and their aftermath.',
+  },
+  {
+    id: 'mag',
+    name: 'Minted & Gone',
+    shortName: 'MAG',
+    url: 'https://mag.badjoke-lab.com/',
+    description: 'Historical archive of NFT marketplaces.',
+  },
+] as const


### PR DESCRIPTION
## Summary

- keep Support visible in the mobile header instead of hiding it inside Menu
- replace the truncated mobile brand with a compact `Exchange Index` label
- replace the single-line footer with grouped Project Network, Explore HEI, Project, and Support/Public Data sections
- show full project names and mark HEI as the non-linked current project
- add one contextual support strip after page content while suppressing it on the Support page itself
- rename English Donate UI to Support
- group support methods into Primary options and collapsed Additional networks
- consolidate the repeated EVM address while preserving chain-specific warnings and copy controls
- localize copy controls and support-page content in English and Japanese

## Constraints respected

- no Cloudflare changes
- no Search Console changes