### PR TITLE
Add post-D-1000 BX51 reviewed Thailand exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1000,
+    "entities": 1004,
     "events": 1025,
-    "evidence": 3781
+    "evidence": 3789
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,6 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX51_2026-08-09.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -38,7 +38,7 @@ D-1000 is complete. The remaining blocker before Language Selection is the L-2 e
 
 HOLD keeps the Japanese Pilot public and does not block reviewed canonical data or quality growth.
 
-The D-1000 reviewed state is complete at:
+The D-1000 milestone completion baseline is:
 
 ```text
 Entities: 1000
@@ -52,7 +52,21 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion does not expand translation breadth and does not authorize a third language.
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX51, the current reviewed state is:
+
+```text
+Entities: 1004
+Events:   1025
+Evidence: 3789
+```
+
+Current post-D-1000 growth authority:
+
+```text
+docs/audits/HEI_POST_D1000_GROWTH_BX51_2026-08-09.md
+```
+
+The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.
 
 ## 3. Evidence categories
 

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX51_2026-08-09.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX51_2026-08-09.md
@@ -1,0 +1,61 @@
+# HEI Post-D-1000 Growth — BX51
+
+Date: 2026-08-09  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX51 resumes reviewed canonical growth after completion of the D-1000 milestone.
+
+Added reviewed entities:
+
+```text
+WAANX       active / cex / Thailand
+TDX         active / cex / Thailand
+Z.com EX    active / cex / Thailand
+Binance TH  active / cex / Thailand
+```
+
+Added evidence: 8  
+Added events: 0
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1004
+Events:   1025
+Evidence: 3789
+```
+
+## Evidence standard
+
+Each addition has:
+
+- a current first-party operating source;
+- current Thailand SEC Digital Asset Exchange license evidence;
+- explicit current status handling;
+- URL verification dated 2026-08-09;
+- no synthetic launch date derived from registration, incorporation, or licensing dates.
+
+## Identity controls
+
+Orbix was screened and rejected as a new addition because a reviewed Orbix/Satang record already exists as `hei_ex_001038`.
+
+Binance TH is kept separate from the global Binance entity because Gulf Binance Co., Ltd. is a distinct Thai licensed joint-venture operator and the existing global Binance record already treats separately operated regional platforms as distinct entities.
+
+## L-2 relationship
+
+This batch does not change the L-2 localization decision. Canonical growth is explicitly allowed during HOLD. The L-2 evidence snapshot remains the authority for search, usage, quality, and operations signals.
+
+## Next identifiers
+
+```text
+Entity:   hei_ex_001125
+Event:    hei_ev_010102
+Evidence: hei_src_012486
+```
+
+## Completion condition
+
+BX51 is complete only after normal record validation, reviewed-public count aggregation, machine/public consistency checks, localization output checks, recovery validation, and merge to `main` succeed.

--- a/docs/backlog/consumed/hei_unadded-bx51-four-reviewed-thailand-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx51-four-reviewed-thailand-exchange-records.md
@@ -1,0 +1,57 @@
+# Consumed backlog — BX51 reviewed Thailand exchange records
+
+Status: consumed  
+Date: 2026-08-09  
+Lane: post-D-1000 canonical growth
+
+## Added
+
+```text
+WAANX       hei_ex_001121 active
+TDX         hei_ex_001122 active
+Z.com EX    hei_ex_001123 active
+Binance TH  hei_ex_001124 active
+```
+
+## Evidence allocation
+
+```text
+WAANX       hei_src_012478–012479
+TDX         hei_src_012480–012481
+Z.com EX    hei_src_012482–012483
+Binance TH  hei_src_012484–012485
+```
+
+No new event IDs are consumed in BX51. The next unused event ID remains `hei_ev_010102`.
+
+## Review basis
+
+All four records are current Thai centralized digital-asset exchange operators supported by both current first-party operating material and the Thailand Securities and Exchange Commission's current Digital Asset Exchange license list.
+
+The batch does not treat regulator licensing as an investment endorsement, does not infer exact launch dates from licensing or company-incorporation dates, and does not add trading-volume, solvency, security-quality, or custody-quality claims.
+
+## Identity and overlap checks
+
+Direct current-main record/path/name checks found no reviewed record for WAANX, TDX, Z.com EX, or Binance TH before this branch.
+
+Orbix was initially considered for the same Thai-operator batch, but direct file creation detected the existing reviewed `records/exchanges/orbix.json` record (`hei_ex_001038`). Orbix was therefore excluded rather than duplicated.
+
+Binance TH is recorded as a separate regional operator because Gulf Binance Co., Ltd. is a distinct Thai licensed joint-venture operator on `binance.th`; the existing global Binance record already preserves a boundary between Binance.com and separately operated regional entities.
+
+## Projected reviewed result
+
+```text
+Entities: 1004
+Events:   1025
+Evidence: 3789
+```
+
+Next unused identifiers after BX51:
+
+```text
+Entity:   hei_ex_001125
+Event:    hei_ev_010102
+Evidence: hei_src_012486
+```
+
+These counts remain subject to the normal reviewed-public aggregation, identity-resolution, and validation semantics at merge time.

--- a/docs/backlog/consumed/hei_unadded-bx51-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx51-source-review-note.md
@@ -1,0 +1,46 @@
+# BX51 source review boundaries
+
+Date: 2026-08-09  
+Status: reviewed support note
+
+## Scope
+
+BX51 adds four Thailand-based centralized digital-asset exchange operators using current first-party operating surfaces plus the Thailand Securities and Exchange Commission's current Digital Asset Exchange license list.
+
+## WAANX
+
+WAANX's current company and trading-support surfaces identify Waan Exchange Co., Ltd. as an operator of digital asset exchange and broker services and show an active cryptocurrency trading platform. The current Thailand SEC license list identifies WAANX / Waan Exchange Company Limited as a Digital Asset Exchange.
+
+The company page states that Waan Exchange was founded on 2022-01-28. BX51 does not infer that corporate foundation date as the exact public exchange launch date.
+
+## TDX
+
+Current Stock Exchange of Thailand material identifies Thai Digital Assets Exchange Co., Ltd. as a SET subsidiary operating a Digital Asset Exchange for trading and exchanging digital assets. Current TDX pages expose account opening, token trading, token information, and fee information. The Thailand SEC current license list identifies TDX as a Digital Asset Exchange.
+
+TDX's official history gives company establishment on 2020-09-14 and licensing on 2022-03-25. Neither is treated as a synthetic exact exchange launch date.
+
+## Z.com EX
+
+Current Z.com EX support material documents website cryptocurrency trading, deposits and withdrawals, and a July 2026 maintenance cycle that completed with service reopening. The current Thailand SEC license list identifies Z.COMEX / GMO-Z.COM Cryptonomics (Thailand) Company Limited as a Digital Asset Exchange.
+
+BX51 does not confuse the Thai exchange with other Z.com-branded group businesses. A first-party 2025 clarification explicitly states that the Thai exchange and OTC service remained operational despite service discontinuation at another group company.
+
+## Binance TH
+
+Current Binance TH first-party material identifies Gulf Binance Co., Ltd. as the licensed Thai operator, a joint venture between Gulf Edge and a Binance-group affiliate. The current Thailand SEC license list identifies GULF BINANCE as a Digital Asset Exchange, and current July 2026 first-party announcements show ongoing platform activity.
+
+BX51 keeps Binance TH separate from the global Binance.com entity because it is a distinct licensed Thai legal operator on a separate regional platform. The existing global Binance record already preserves a regional-entity boundary rather than merging separately operated regional platforms into the global entity.
+
+## Dedupe exclusion — Orbix
+
+Orbix was reviewed as a possible fourth Thai addition. Direct repository path resolution showed that it is already reviewed as `records/exchanges/orbix.json` / `hei_ex_001038`, including the Satang Pro lineage. It is excluded from BX51 and no duplicate record is created.
+
+## Exclusions
+
+BX51 does not infer:
+
+- exact launch dates from incorporation or licensing dates;
+- investment recommendation or safety endorsement from regulator licensing;
+- volume, liquidity, solvency, custody quality, or security quality;
+- a duplicate Orbix/Satang entity;
+- identity between Binance TH and the global Binance.com legal/operator entity.

--- a/records/exchanges/binance-th.json
+++ b/records/exchanges/binance-th.json
@@ -1,0 +1,62 @@
+{
+  "entity": {
+    "id": "hei_ex_001124",
+    "slug": "binance-th",
+    "canonical_name": "Binance TH",
+    "aliases": [
+      "BINANCE TH",
+      "BINANCE TH by Gulf Binance",
+      "Gulf Binance",
+      "Gulf Binance Co., Ltd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Thailand",
+    "summary": "Thailand-licensed centralized digital-asset exchange and brokerage platform operated by Gulf Binance Co., Ltd., a joint venture separate from the global Binance.com exchange entity.",
+    "official_url_original": "https://www.binance.th/",
+    "official_domain_original": "binance.th",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.binance.th/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party Binance TH material identifies Gulf Binance Co., Ltd. as a Thai licensed digital asset exchange and broker and describes the operator as a joint venture between Gulf Edge and a Binance-group affiliate. Current July 2026 first-party trading-pair announcements confirm ongoing service activity. Thailand SEC's current licensed-operator page lists GULF BINANCE under Digital Asset Exchange. HEI treats Binance TH as a separate regional operator from the global Binance.com entity, consistent with the existing Binance record's regional-entity boundary. The 2023 licensing date is not converted into an inferred exact platform launch date."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012484",
+      "exchange_id": "hei_ex_001124",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "About Us",
+      "url": "https://www.binance.th/en/aboutus/about-us/22c0541e34e84ce19c94d79713c66f07",
+      "publisher": "Binance TH by Gulf Binance",
+      "published_at": "2023-09-04",
+      "archived_url": "https://web.archive.org/web/*/https://www.binance.th/en/aboutus/about-us/22c0541e34e84ce19c94d79713c66f07",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party profile identifies Gulf Binance Co., Ltd. as the operator of Binance TH, describes the joint-venture ownership structure, and records Thai exchange and broker licences."
+    },
+    {
+      "id": "hei_src_012485",
+      "exchange_id": "hei_ex_001124",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "List of licensed digital asset business operators — Digital Asset Exchange",
+      "url": "https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "publisher": "Securities and Exchange Commission, Thailand",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current Thailand SEC license-check page lists GULF BINANCE / Gulf Binance Company Limited as a Digital Asset Exchange and links binance.th."
+    }
+  ]
+}

--- a/records/exchanges/tdx.json
+++ b/records/exchanges/tdx.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001122",
+    "slug": "tdx",
+    "canonical_name": "TDX",
+    "aliases": [
+      "Thai Digital Assets Exchange",
+      "Thai Digital Assets Exchange Co., Ltd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Thailand",
+    "summary": "Thai centralized digital-asset exchange operated by a Stock Exchange of Thailand subsidiary, focused on trading and settlement of digital tokens.",
+    "official_url_original": "https://www.set.or.th/en/tdx/about",
+    "official_domain_original": "set.or.th",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.set.or.th/en/tdx/about",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current Stock Exchange of Thailand pages identify Thai Digital Assets Exchange Co., Ltd. as a SET subsidiary operating a Digital Asset Exchange for trading and exchanging digital assets, with current account-opening, trading, token information, and fee surfaces. The current Thailand SEC license-check page lists TDX under Digital Asset Exchange. The official history states the company was established on 2020-09-14 and licensed on 2022-03-25; HEI does not convert either date into an inferred exact exchange launch date."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012480",
+      "exchange_id": "hei_ex_001122",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "About TDX",
+      "url": "https://www.set.or.th/en/tdx/about",
+      "publisher": "The Stock Exchange of Thailand",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.set.or.th/en/tdx/about",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current SET page identifies TDX as a Digital Asset Exchange and describes active digital-token trading, settlement, and storage services."
+    },
+    {
+      "id": "hei_src_012481",
+      "exchange_id": "hei_ex_001122",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "List of licensed digital asset business operators — Digital Asset Exchange",
+      "url": "https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "publisher": "Securities and Exchange Commission, Thailand",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current Thailand SEC license-check page lists TDX / Thai Digital Assets Exchange Company Limited as a Digital Asset Exchange."
+    }
+  ]
+}

--- a/records/exchanges/waanx.json
+++ b/records/exchanges/waanx.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001121",
+    "slug": "waanx",
+    "canonical_name": "WAANX",
+    "aliases": [
+      "WaanX",
+      "Waan Exchange",
+      "Waan Exchange Co., Ltd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Thailand",
+    "summary": "Thai centralized digital-asset exchange and brokerage platform providing cryptocurrency trading services under the WAANX brand.",
+    "official_url_original": "https://www.waanx.com/",
+    "official_domain_original": "waanx.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.waanx.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party WAANX pages present an operating cryptocurrency trading platform and identify Waan Exchange Co., Ltd. as providing Digital Asset Exchange and Digital Asset Broker services. Thailand SEC's current licensed-operator page lists WAANX / Waan Exchange Company Limited under Digital Asset Exchange. The company page states that Waan Exchange was founded on 2022-01-28, but HEI does not infer that corporate foundation date as the exact exchange launch date."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012478",
+      "exchange_id": "hei_ex_001121",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "WaanX Company",
+      "url": "https://www.waanx.com/en/company",
+      "publisher": "WAANX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.waanx.com/en/company",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party company page identifies Waan Exchange Co., Ltd., describes its digital asset exchange and broker operations, and presents WAANX as an active cryptocurrency trading platform."
+    },
+    {
+      "id": "hei_src_012479",
+      "exchange_id": "hei_ex_001121",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "List of licensed digital asset business operators — Digital Asset Exchange",
+      "url": "https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "publisher": "Securities and Exchange Commission, Thailand",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current Thailand SEC license-check page lists WAANX / Waan Exchange Company Limited as a Digital Asset Exchange and links waanx.com."
+    }
+  ]
+}

--- a/records/exchanges/z-com-ex.json
+++ b/records/exchanges/z-com-ex.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001123",
+    "slug": "z-com-ex",
+    "canonical_name": "Z.com EX",
+    "aliases": [
+      "Z.COMEX",
+      "GMO-Z.com Cryptonomics (Thailand)",
+      "GMO-Z.com Cryptonomics (Thailand) Co., Ltd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Thailand",
+    "summary": "Thai centralized cryptocurrency exchange and OTC service operated by GMO-Z.com Cryptonomics (Thailand) Co., Ltd.",
+    "official_url_original": "https://ex.z.com/",
+    "official_domain_original": "ex.z.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://ex.z.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current Z.com EX support material documents cryptocurrency trading, THB and crypto deposits/withdrawals, and a completed July 2026 maintenance window. Thailand SEC's current licensed-operator page lists Z.COMEX / GMO-Z.COM CRYPTONOMICS (THAILAND) COMPANY LIMITED under Digital Asset Exchange. A 2025 first-party notice explicitly states that this Thai exchange and OTC service remained operational despite service discontinuation at another Z.com-branded group company."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012482",
+      "exchange_id": "hei_ex_001123",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "How to buy cryptocurrency on website",
+      "url": "https://support.ex.z.com/hc/en-us/articles/12497635526553-How-to-buy-cryptocurrency-on-website",
+      "publisher": "Z.com EX",
+      "published_at": "2025-07-15",
+      "archived_url": "https://web.archive.org/web/*/https://support.ex.z.com/hc/en-us/articles/12497635526553-How-to-buy-cryptocurrency-on-website",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party support documentation describes live website trading through the Z.com EX exchange interface, including cryptocurrency/THB order placement."
+    },
+    {
+      "id": "hei_src_012483",
+      "exchange_id": "hei_ex_001123",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "List of licensed digital asset business operators — Digital Asset Exchange",
+      "url": "https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "publisher": "Securities and Exchange Commission, Thailand",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://market.sec.or.th/LicenseCheck/views/DABusiness?exchange%2Fen=",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current Thailand SEC license-check page lists Z.COMEX / GMO-Z.COM Cryptonomics (Thailand) Company Limited as a Digital Asset Exchange and links ex.z.com."
+    }
+  ]
+}


### PR DESCRIPTION
## Post-D-1000 canonical growth — BX51

Resume reviewed data growth while L-2 remains in evidence-capture HOLD.

### Added

```text
WAANX       hei_ex_001121 active
TDX         hei_ex_001122 active
Z.com EX    hei_ex_001123 active
Binance TH  hei_ex_001124 active
```

Each record is backed by current first-party operating material and the current Thailand SEC Digital Asset Exchange license list.

### Dedupe handling

Orbix was screened for this batch but rejected as a new addition after direct repository path resolution found the existing reviewed Orbix/Satang record `hei_ex_001038`.

Binance TH is preserved as a distinct regional operator because Gulf Binance Co., Ltd. is a separate Thai licensed joint-venture operator and the existing global Binance record already preserves a regional-platform boundary.

### Projected reviewed state

```text
Entities: 1004
Events:   1025
Evidence: 3789
```

No new event IDs are consumed.

### Next IDs

```text
Entity:   hei_ex_001125
Event:    hei_ev_010102
Evidence: hei_src_012486
```

### Validation target

Require normal records, overlap/ID, machine/public consistency, localization output, recovery, and CI gates before merge.