### PR TITLE
Add post-D-1000 BX52 reviewed regional exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1004,
-    "events": 1025,
-    "evidence": 3789
+    "entities": 1008,
+    "events": 1026,
+    "evidence": 3798
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX51_2026-08-09.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX52_2026-08-09.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX51, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX52, the current reviewed state is:
 
 ```text
-Entities: 1004
-Events:   1025
-Evidence: 3789
+Entities: 1008
+Events:   1026
+Evidence: 3798
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX51_2026-08-09.md
+docs/audits/HEI_POST_D1000_GROWTH_BX52_2026-08-09.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX52_2026-08-09.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX52_2026-08-09.md
@@ -1,0 +1,77 @@
+# HEI Post-D-1000 Growth — BX52
+
+Date: 2026-08-09  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX52 continues reviewed canonical growth after the D-1000 milestone and BX51.
+
+Added reviewed entities:
+
+```text
+Upbit Thailand   active / cex / Thailand
+MX Global        active / cex / Malaysia
+Upbit Singapore active / cex / Singapore
+KuCoin Thailand  dead   / cex / Thailand
+```
+
+Added evidence: 9  
+Added events: 1
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1008
+Events:   1026
+Evidence: 3798
+```
+
+## Evidence standard
+
+The three active additions each have:
+
+- current first-party exchange-operation evidence;
+- current regulator evidence identifying the regional legal operator;
+- explicit operator/entity boundaries;
+- URL verification dated 2026-08-09;
+- no synthetic exact launch date derived from incorporation or licensing dates.
+
+KuCoin Thailand / ERX has:
+
+- formal Thailand SEC evidence for the January 2026 capital-related business suspension;
+- first-party evidence that no near-term resumption was scheduled;
+- first-party evidence for the 2026-04-22 customer-system closure and manual-only withdrawals thereafter;
+- first-party evidence that ERX began the process of returning its Digital Asset Exchange licence;
+- an explicit distinction between live offboarding/support access and active exchange operation.
+
+## Identity controls
+
+Upbit Thailand and Upbit Singapore are separately licensed regional legal operators and are not merged into the South Korean Upbit entity.
+
+MX Exchange is treated as the platform of MX Global Sdn Bhd rather than a second entity. The former ARXCHANGE corporate name is retained as an alias.
+
+ERX Co., Ltd. and KuCoin Thailand are one entity: ERX is the licensed/operator legal identity and KuCoin Thailand is the trade name.
+
+## Lifecycle handling
+
+KuCoin Thailand uses `status: dead` with `death_date: 2026-04-22` because normal customer exchange access ended on that date. Its website remains live for announcements and offboarding, so `official_url_status` remains `live_verified`.
+
+`death_reason: unknown` is intentionally conservative. Regulatory capital failure caused the initial suspension, while the later first-party licence-return announcement cites review of business plans and strategic direction. BX52 does not collapse those facts into one unsupported exclusive cause.
+
+## L-2 relationship
+
+This batch does not change the L-2 localization decision. Canonical growth remains allowed during HOLD. External search/usage/indexing evidence and operator QA burden remain separate L-2 requirements.
+
+## Next identifiers
+
+```text
+Entity:   hei_ex_001129
+Event:    hei_ev_010103
+Evidence: hei_src_012495
+```
+
+## Completion condition
+
+BX52 is complete only after normal record validation, reviewed-public aggregation, ID and overlap checks, machine/public consistency, localization output checks, recovery validation, and merge to `main` succeed.

--- a/docs/backlog/consumed/hei_unadded-bx52-four-reviewed-regional-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx52-four-reviewed-regional-exchange-records.md
@@ -1,0 +1,67 @@
+# Consumed backlog — BX52 reviewed regional exchange records
+
+Status: consumed  
+Date: 2026-08-09  
+Lane: post-D-1000 canonical growth
+
+## Added
+
+```text
+Upbit Thailand   hei_ex_001125 active
+MX Global        hei_ex_001126 active
+Upbit Singapore hei_ex_001127 active
+KuCoin Thailand  hei_ex_001128 dead
+```
+
+## Evidence allocation
+
+```text
+Upbit Thailand   hei_src_012486–012487
+MX Global        hei_src_012488–012489
+Upbit Singapore hei_src_012490–012491
+KuCoin Thailand  hei_src_012492–012494
+```
+
+## Event allocation
+
+```text
+KuCoin Thailand  hei_ev_010102 shutdown_effective 2026-04-22
+```
+
+## Review basis
+
+Upbit Thailand is supported by the current Thailand SEC Digital Asset Exchange list and current Upbit regional Exchange API documentation.
+
+MX Global is supported by current first-party exchange/rulebook surfaces and the Securities Commission Malaysia registered-DAX list updated 2026-07-20.
+
+Upbit Singapore is supported by current Upbit regional Exchange API documentation and the Monetary Authority of Singapore Financial Institutions Directory, which identifies Upbit Singapore Pte. Ltd. as a Major Payment Institution providing Digital Payment Token Service.
+
+KuCoin Thailand / ERX is added as `dead` because the reviewed sequence progressed beyond a temporary trading restriction: Thailand SEC documented the January capital-related business suspension, first-party notices stated that there was no scheduled near-term resumption, normal customer system access ended on 2026-04-22, and ERX then announced that it was in the process of returning its Digital Asset Exchange licence. Manual offboarding withdrawals and a live support surface are not treated as active exchange operation.
+
+## Identity and overlap controls
+
+Direct current-main path and name checks found no reviewed record for Upbit Thailand, MX Global, Upbit Singapore, or KuCoin Thailand / ERX before BX52.
+
+The two Upbit regional entities are not merged into the South Korean Upbit entity because they are separately licensed regional legal operators with dedicated regional service infrastructure.
+
+MX Global is not split into separate MX Global and MX Exchange entities; MX Exchange is the platform provided by MX Global Sdn Bhd and the former ARXCHANGE name is preserved as an alias.
+
+ERX and KuCoin Thailand are one reviewed entity: ERX Co., Ltd. is the legal operator and KuCoin Thailand is the trade name.
+
+## Reviewed result
+
+```text
+Entities: 1008
+Events:   1026
+Evidence: 3798
+```
+
+Next unused identifiers after BX52:
+
+```text
+Entity:   hei_ex_001129
+Event:    hei_ev_010103
+Evidence: hei_src_012495
+```
+
+These counts remain subject to the normal reviewed-public aggregation, identity-resolution, and validation semantics at merge time.

--- a/docs/backlog/consumed/hei_unadded-bx52-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx52-source-review-note.md
@@ -1,0 +1,48 @@
+# BX52 source review boundaries
+
+Date: 2026-08-09  
+Status: reviewed support note
+
+## Scope
+
+BX52 resumes post-D-1000 canonical growth with four regulated regional centralized-exchange records. The batch uses current first-party operating or wind-down material together with current or formal financial-regulator records.
+
+## Upbit Thailand
+
+Thailand SEC's current Digital Asset Exchange list identifies UPBIT / Upbit Exchange (Thailand) Company Limited and links `th.upbit.com`. Current Upbit first-party API documentation exposes Thailand regional quotation and authenticated Exchange API endpoints.
+
+BX52 treats the Thai licensed legal operator as separate from the South Korean Upbit entity. It does not infer an exact platform launch date from the Thai company's registration or licensing history.
+
+## MX Global
+
+Current MX Global first-party material identifies MX Exchange as a digital asset exchange platform provided by MX Global Sdn Bhd, formerly ARXCHANGE Sdn. Bhd., and exposes live MYR trading and account functions. Securities Commission Malaysia's registered-DAX list updated 2026-07-20 identifies MX Global Sdn Bhd as a Registered Recognized Market Operator-Digital Asset Exchange.
+
+The MX Exchange product name is preserved inside one MX Global entity rather than counted separately. The company's stated 2018 founding year is not converted into a synthetic exact exchange launch date.
+
+## Upbit Singapore
+
+Current Upbit first-party API documentation exposes dedicated Singapore quotation and Exchange API endpoints. The Monetary Authority of Singapore Financial Institutions Directory identifies Upbit Singapore Pte. Ltd. as a Major Payment Institution providing Digital Payment Token Service and was last updated 2026-04-22.
+
+BX52 treats the Singapore licensed legal operator as separate from the South Korean Upbit entity and does not infer an exact launch date from licensing or incorporation dates.
+
+## KuCoin Thailand / ERX
+
+Thailand SEC identified ERX Co., Ltd. as the digital asset exchange operating under the KuCoin Thailand trade name and documented the 2026-01-03 business suspension after ERX failed to maintain the required ongoing capital fund.
+
+First-party notices later stated that there was no scheduled plan to resume services in the near future and that the customer system would close on 2026-04-22 at 13:00 UTC+7. From that point customers could not log in, view balances or history in the system, or perform self-service withdrawals; offboarding withdrawals moved to manual customer-service handling.
+
+On 2026-04-25 KuCoin Thailand stated that ERX was in the process of returning its Digital Asset Exchange licence following review of its business plans and strategic direction. The public support/announcement site remains reachable during wind-down.
+
+BX52 therefore uses `2026-04-22` as the operational death marker and retains `official_url_status: live_verified`. It does not equate a live wind-down website or manual withdrawal channel with an active exchange. `death_reason: unknown` is used because the reviewed record supports both a regulatory capital failure and a later strategic licence-return decision, without proving one exclusive terminal cause.
+
+## Exclusions
+
+BX52 does not infer:
+
+- exact launch dates from incorporation, registration, or licence dates;
+- investment recommendation or safety endorsement from regulatory status;
+- volume, liquidity, solvency, custody quality, or security quality;
+- corporate dissolution of ERX;
+- completion date of ERX's licence-return process beyond what the first-party notice states;
+- identity between regional Upbit legal operators and the South Korean Upbit entity;
+- a separate MX Exchange entity apart from MX Global Sdn Bhd.

--- a/records/exchanges/kucoin-thailand.json
+++ b/records/exchanges/kucoin-thailand.json
@@ -1,0 +1,93 @@
+{
+  "entity": {
+    "id": "hei_ex_001128",
+    "slug": "kucoin-thailand",
+    "canonical_name": "KuCoin Thailand",
+    "aliases": [
+      "ERX",
+      "ERX Co., Ltd.",
+      "ERX Company Limited",
+      "KuCoin TH"
+    ],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": "2026-04-22",
+    "country_or_origin": "Thailand",
+    "summary": "Thailand digital-asset exchange operated by ERX Co., Ltd. under the KuCoin Thailand trade name. Trading and deposits were suspended in January 2026 after a regulatory capital deficiency, the customer system closed on April 22, and the operator subsequently announced that it was returning its Digital Asset Exchange licence.",
+    "official_url_original": "https://www.kucoin.th/",
+    "official_domain_original": "kucoin.th",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.kucoin.th/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Thailand SEC identified ERX Co., Ltd. as the digital asset exchange operating under the KuCoin Thailand trade name and documented the 2026-01-03 suspension after ERX failed to maintain required ongoing capital. First-party notices later stated that there was no scheduled near-term resumption, closed customer login and self-service withdrawals from 2026-04-22 13:00 UTC+7, and on 2026-04-25 announced a process to return the Digital Asset Exchange licence following review of business plans and strategic direction. HEI uses 2026-04-22 as the operational death marker because normal customer exchange access ended then; manual offboarding withdrawals and a live support website do not constitute an active exchange. `unknown` is used for death_reason because the reviewed record includes both regulatory-capital failure and a later strategic licence-return decision rather than one exclusive terminal cause."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010102",
+      "exchange_id": "hei_ex_001128",
+      "event_type": "shutdown_effective",
+      "event_date": "2026-04-22",
+      "title": "KuCoin Thailand closed its customer system during wind-down",
+      "description": "KuCoin Thailand ended normal customer system access at 13:00 UTC+7 on April 22, 2026 after trading and deposits had already been suspended. Customers could no longer log in, view balances or transaction history in the platform, or perform self-service withdrawals; remaining withdrawals moved to manual customer-service processing.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "dead",
+      "source_count": 3,
+      "sort_order": 1,
+      "is_major_event": true,
+      "notes": "The April 22 marker represents operational exchange shutdown, not corporate dissolution. A first-party April 25 notice subsequently stated that ERX was in the process of returning its Digital Asset Exchange licence."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012492",
+      "exchange_id": "hei_ex_001128",
+      "event_id": "hei_ev_010102",
+      "source_type": "regulatory_notice",
+      "title": "SEC conducts inspection of ERX after temporary suspension of operations",
+      "url": "https://www.sec.or.th/EN/Pages/News_Detail.aspx?SECID=12421",
+      "publisher": "Securities and Exchange Commission, Thailand",
+      "published_at": "2026-01-07",
+      "archived_url": "https://web.archive.org/web/*/https://www.sec.or.th/EN/Pages/News_Detail.aspx?SECID=12421",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Regulator notice identifies ERX as the exchange operating under the KuCoin Thailand trade name and records the January 3 business suspension caused by failure to maintain the required ongoing capital fund."
+    },
+    {
+      "id": "hei_src_012493",
+      "exchange_id": "hei_ex_001128",
+      "event_id": "hei_ev_010102",
+      "source_type": "official_statement",
+      "title": "Important Announcement: Asset Withdrawal, Temporary System Suspension, and Custody Fee Policy",
+      "url": "https://www.kucoin.th/en/announcement/20254-35",
+      "publisher": "KuCoin Thailand",
+      "published_at": "2026-04-16",
+      "archived_url": "https://web.archive.org/web/*/https://www.kucoin.th/en/announcement/20254-35",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice states that there was no scheduled plan to resume in the near future and that customer login and self-service account functions would end on 2026-04-22 at 13:00 UTC+7, with later withdrawals handled manually."
+    },
+    {
+      "id": "hei_src_012494",
+      "exchange_id": "hei_ex_001128",
+      "event_id": "hei_ev_010102",
+      "source_type": "official_statement",
+      "title": "Return of Digital Asset Exchange License",
+      "url": "https://www.kucoin.th/en/announcement/20509-35",
+      "publisher": "KuCoin Thailand",
+      "published_at": "2026-04-25",
+      "archived_url": "https://web.archive.org/web/*/https://www.kucoin.th/en/announcement/20509-35",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice states that ERX was in the process of returning its Digital Asset Exchange licence to the Ministry of Finance following review of its business plans and strategic direction, while manual withdrawals remained available."
+    }
+  ]
+}

--- a/records/exchanges/mx-global.json
+++ b/records/exchanges/mx-global.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001126",
+    "slug": "mx-global",
+    "canonical_name": "MX Global",
+    "aliases": [
+      "MX Exchange",
+      "MX Global Sdn Bhd",
+      "ARXCHANGE Sdn. Bhd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Malaysia",
+    "summary": "Malaysian centralized digital-asset exchange operated by MX Global Sdn Bhd, providing MYR-denominated trading and custody-related exchange functions.",
+    "official_url_original": "https://mxglobal.com.my/",
+    "official_domain_original": "mxglobal.com.my",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://mxglobal.com.my/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party material identifies MX Exchange as a digital asset exchange platform provided by MX Global Sdn Bhd, formerly ARXCHANGE Sdn. Bhd., and exposes current MYR trading, deposits, withdrawals, and app access. The Securities Commission Malaysia's registered-DAX list updated 2026-07-20 lists MX Global Sdn Bhd as a Registered Recognized Market Operator-Digital Asset Exchange. The company states that it was founded in 2018, but HEI does not convert that company-founding year into a synthetic exact exchange launch date."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012488",
+      "exchange_id": "hei_ex_001126",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "MX Exchange Trading Rulebook",
+      "url": "https://mxglobal.com.my/en/product",
+      "publisher": "MX Global",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://mxglobal.com.my/en/product",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party rulebook identifies MX Exchange as the digital asset exchange platform provided by MX Global Sdn Bhd and describes client registration, trading, settlement, deposits, and withdrawals."
+    },
+    {
+      "id": "hei_src_012489",
+      "exchange_id": "hei_ex_001126",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "List of Registered Digital Asset Exchanges",
+      "url": "https://www.sc.com.my/regulation/guidelines/recognizedmarkets/list-of-registered-digital-asset-exchanges",
+      "publisher": "Securities Commission Malaysia",
+      "published_at": "2026-07-20",
+      "archived_url": "https://web.archive.org/web/*/https://www.sc.com.my/regulation/guidelines/recognizedmarkets/list-of-registered-digital-asset-exchanges",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "The current SC list identifies MX Global Sdn Bhd as a registered Malaysian Recognized Market Operator-Digital Asset Exchange."
+    }
+  ]
+}

--- a/records/exchanges/upbit-singapore.json
+++ b/records/exchanges/upbit-singapore.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001127",
+    "slug": "upbit-singapore",
+    "canonical_name": "Upbit Singapore",
+    "aliases": [
+      "UPBIT SINGAPORE",
+      "UPBIT SINGAPORE PTE. LTD.",
+      "Upbit SG"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Singapore",
+    "summary": "Singapore centralized digital-asset exchange service operated by Upbit Singapore Pte. Ltd., a Major Payment Institution licensed for Digital Payment Token Service.",
+    "official_url_original": "https://sg.upbit.com/",
+    "official_domain_original": "sg.upbit.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://sg.upbit.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "The Monetary Authority of Singapore's current Financial Institutions Directory identifies Upbit Singapore Pte. Ltd. as a Major Payment Institution licensed for Digital Payment Token Service. Current Upbit first-party API documentation exposes Singapore quotation and authenticated Exchange API endpoints, including sg-api.upbit.com. HEI keeps this licensed Singapore legal operator separate from the South Korean Upbit entity rather than merging distinct regional operators. No exact launch date is inferred from licensing or incorporation dates."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012490",
+      "exchange_id": "hei_ex_001127",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Upbit API Overview",
+      "url": "https://global-docs.upbit.com/sg/reference/api-overview",
+      "publisher": "Upbit",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://global-docs.upbit.com/sg/reference/api-overview",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party documentation lists the Singapore REST and WebSocket endpoints and describes quotation plus authenticated exchange operations including orders, deposits, withdrawals, and account assets."
+    },
+    {
+      "id": "hei_src_012491",
+      "exchange_id": "hei_ex_001127",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "UPBIT SINGAPORE PTE. LTD. — Financial Institutions Directory",
+      "url": "https://eservices.mas.gov.sg/fid/institution/detail/420457-UPBIT-SINGAPORE-PTE-LTD",
+      "publisher": "Monetary Authority of Singapore",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://eservices.mas.gov.sg/fid/institution/detail/420457-UPBIT-SINGAPORE-PTE-LTD",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current MAS directory identifies Upbit Singapore Pte. Ltd. as a Major Payment Institution providing Digital Payment Token Service; the directory was last updated 2026-04-22."
+    }
+  ]
+}

--- a/records/exchanges/upbit-thailand.json
+++ b/records/exchanges/upbit-thailand.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001125",
+    "slug": "upbit-thailand",
+    "canonical_name": "Upbit Thailand",
+    "aliases": [
+      "UPBIT",
+      "UPBIT EXCHANGE (THAILAND)",
+      "Upbit Exchange (Thailand) Company Limited"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Thailand",
+    "summary": "Thailand-licensed centralized digital-asset exchange operated by Upbit Exchange (Thailand) Company Limited with a dedicated Thai service and regional exchange API.",
+    "official_url_original": "https://th.upbit.com/",
+    "official_domain_original": "th.upbit.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://th.upbit.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Thailand SEC's current Digital Asset Exchange list identifies UPBIT / Upbit Exchange (Thailand) Company Limited and the dedicated th.upbit.com service. Current Upbit first-party API documentation exposes Thailand quotation and authenticated Exchange API endpoints, including th-api.upbit.com. HEI keeps this licensed Thai legal operator separate from the South Korean Upbit entity rather than merging distinct regional operators. No exact launch date is inferred from company-registration or licensing dates."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012486",
+      "exchange_id": "hei_ex_001125",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Upbit REST API Usage and Error Guide",
+      "url": "https://global-docs.upbit.com/reference/rest-api-guide",
+      "publisher": "Upbit",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://global-docs.upbit.com/reference/rest-api-guide",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party documentation lists the Thailand REST endpoint th-api.upbit.com and documents quotation and authenticated exchange operations by region."
+    },
+    {
+      "id": "hei_src_012487",
+      "exchange_id": "hei_ex_001125",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "Digital Asset Exchange licensed operators",
+      "url": "https://market.sec.or.th/LicenseCheck/views/DABusiness/en",
+      "publisher": "Securities and Exchange Commission, Thailand",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://market.sec.or.th/LicenseCheck/views/DABusiness/en",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current regulator list identifies UPBIT / Upbit Exchange (Thailand) Company Limited as a Digital Asset Exchange and links th.upbit.com."
+    }
+  ]
+}

--- a/records/exchanges/upbit-thailand.json
+++ b/records/exchanges/upbit-thailand.json
@@ -4,7 +4,7 @@
     "slug": "upbit-thailand",
     "canonical_name": "Upbit Thailand",
     "aliases": [
-      "UPBIT",
+      "UPBIT Thailand",
       "UPBIT EXCHANGE (THAILAND)",
       "Upbit Exchange (Thailand) Company Limited"
     ],


### PR DESCRIPTION
## Post-D-1000 canonical growth — BX52

Continue reviewed canonical growth while L-2 remains in evidence-capture HOLD.

### Added

```text
Upbit Thailand   hei_ex_001125 active
MX Global        hei_ex_001126 active
Upbit Singapore hei_ex_001127 active
KuCoin Thailand  hei_ex_001128 dead
```

### Lifecycle addition

KuCoin Thailand / ERX is recorded as dead with an operational shutdown marker on 2026-04-22. Thailand SEC documented the January capital-related suspension; first-party notices later documented no scheduled near-term resumption, customer-system closure, manual-only withdrawals, and the process to return the Digital Asset Exchange licence. The live support/announcement site is retained as `live_verified` rather than treated as active exchange operation.

### Evidence

- Upbit Thailand: current Upbit regional Exchange API + Thailand SEC licensed exchange list
- MX Global: current first-party MX Exchange rulebook + Securities Commission Malaysia registered-DAX list
- Upbit Singapore: current Upbit regional Exchange API + MAS Financial Institutions Directory
- KuCoin Thailand: Thailand SEC suspension notice + two first-party wind-down/licence-return notices

### Projected reviewed state

```text
Entities: 1008
Events:   1026
Evidence: 3798
```

### Next IDs

```text
Entity:   hei_ex_001129
Event:    hei_ev_010103
Evidence: hei_src_012495
```

### Validation target

Require records, enum, ID/overlap, country, URL safety, machine/public consistency, localization, recovery, baseline, and CI gates before merge.