### PR TITLE
Add post-D-1000 BX53 reviewed Korean VASP exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1008,
+    "entities": 1012,
     "events": 1026,
-    "evidence": 3798
+    "evidence": 3806
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX52_2026-08-09.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX53_2026-08-09.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX52, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX53, the current reviewed state is:
 
 ```text
-Entities: 1008
+Entities: 1012
 Events:   1026
-Evidence: 3798
+Evidence: 3806
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX52_2026-08-09.md
+docs/audits/HEI_POST_D1000_GROWTH_BX53_2026-08-09.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX53_2026-08-09.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX53_2026-08-09.md
@@ -1,0 +1,71 @@
+# HEI Post-D-1000 Growth — BX53
+
+Date: 2026-08-09  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX53 continues reviewed canonical growth after the D-1000 milestone and BX52.
+
+Added reviewed entities:
+
+```text
+Flybit   active / cex / South Korea
+GDAC     active / cex / South Korea
+COREDAX  active / cex / South Korea
+FOBL     active / cex / South Korea
+```
+
+Added evidence: 8  
+Added events: 0
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1012
+Events:   1026
+Evidence: 3806
+```
+
+## Evidence standard
+
+Each addition has:
+
+- a current first-party operating or operator surface;
+- current corroborating virtual-asset service provider directory evidence from DAXA, whose status page states that it is current to 2026-07-31;
+- explicit operator and service-name boundaries;
+- URL verification dated 2026-08-09;
+- no synthetic exact launch date derived from company founding, certification, or VASP-status dates.
+
+DAXA is used as a current industry status directory, not as a regulator and not as a safety, solvency, liquidity, or performance endorsement.
+
+## Identity controls
+
+Flybit is the exchange service operated by Korea Digital Asset Exchange Co., Ltd. The legal operator name is retained as an alias rather than counted as a second exchange.
+
+GDAC is the crypto trading platform operated by Peertec Co., Ltd. Peertec is not split into a separate exchange entity.
+
+COREDAX is treated as the exchange service and operator identity of COREDAX Co., Ltd.
+
+FOBL and Foblgate are one continuing reviewed entity: Foblgate Co., Ltd. is the operator and legacy/domain identity, while FOBL is the current service brand.
+
+## Lifecycle handling
+
+BX53 adds no lifecycle events. The reviewed material is sufficient for current active status and operator identity, but the batch does not convert company founding years, certification periods, VASP directory status, maintenance notices, or other operating evidence into unsupported launch or lifecycle events.
+
+## L-2 relationship
+
+This batch does not change the L-2 localization decision. Canonical growth remains allowed during HOLD. External search/usage/indexing evidence and operator QA burden remain separate L-2 requirements.
+
+## Next identifiers
+
+```text
+Entity:   hei_ex_001133
+Event:    hei_ev_010103
+Evidence: hei_src_012503
+```
+
+## Completion condition
+
+BX53 is complete only after normal record validation, reviewed-public aggregation, ID and overlap checks, country and URL-safety checks, machine/public consistency, localization output checks, recovery validation, and merge to `main` succeed.

--- a/docs/backlog/consumed/hei_unadded-bx53-four-reviewed-korea-vasp-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx53-four-reviewed-korea-vasp-records.md
@@ -1,0 +1,63 @@
+# Consumed backlog — BX53 reviewed Korean VASP exchange records
+
+Status: consumed  
+Date: 2026-08-09  
+Lane: post-D-1000 canonical growth
+
+## Added
+
+```text
+Flybit   hei_ex_001129 active
+GDAC     hei_ex_001130 active
+COREDAX  hei_ex_001131 active
+FOBL     hei_ex_001132 active
+```
+
+## Evidence allocation
+
+```text
+Flybit   hei_src_012495–012496
+GDAC     hei_src_012497–012498
+COREDAX  hei_src_012499–012500
+FOBL     hei_src_012501–012502
+```
+
+## Event allocation
+
+No new event IDs are consumed by BX53.
+
+## Review basis
+
+Flybit is supported by current first-party 2026 operating and customer-asset reporting material plus DAXA's virtual-asset service provider status page current to 2026-07-31.
+
+GDAC is supported by Peertec's current first-party operator site, which identifies GDAC as a crypto trading platform and documents current exchange/wallet ISMS certification, plus DAXA's current status directory.
+
+COREDAX is supported by current first-party exchange and company material describing the digital-asset exchange and FIU VASP reporting, plus DAXA's current status directory.
+
+FOBL is supported by its current first-party exchange surface, a first-party April 2026 exchange maintenance notice, and DAXA's current status directory.
+
+## Identity and overlap controls
+
+Direct current-main path checks found no reviewed Flybit, GDAC, COREDAX, or FOBL/Foblgate record before BX53.
+
+The legal operators are retained inside their corresponding exchange records rather than split as separate entities. FOBL and Foblgate are treated as one exchange identity.
+
+The older verified-unadded backlog is discovery input only. It is not treated as proof that a candidate remains absent or is ready to merge; direct current-main checks and current evidence control this batch.
+
+## Reviewed result
+
+```text
+Entities: 1012
+Events:   1026
+Evidence: 3806
+```
+
+Next unused identifiers after BX53:
+
+```text
+Entity:   hei_ex_001133
+Event:    hei_ev_010103
+Evidence: hei_src_012503
+```
+
+These counts remain subject to the normal reviewed-public aggregation, identity-resolution, and validation semantics at merge time.

--- a/docs/backlog/consumed/hei_unadded-bx53-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx53-source-review-note.md
@@ -1,0 +1,45 @@
+# BX53 source review boundaries
+
+Date: 2026-08-09  
+Status: reviewed support note
+
+## Scope
+
+BX53 adds four South Korean centralized virtual-asset exchange records using current first-party operating material together with DAXA's current virtual-asset service provider status directory.
+
+DAXA's reviewed page states that its service-provider status is current to 2026-07-31. BX53 uses that directory as corroborating operator/service identity evidence. DAXA is not treated as a regulator or as an endorsement of safety or financial quality.
+
+## Flybit
+
+Current first-party Flybit material includes a 2026 customer virtual-asset due-diligence disclosure and continuing exchange/support surfaces. DAXA identifies Korea Digital Asset Exchange Co., Ltd. with service name Flybit and links flybit.com.
+
+BX53 treats Korea Digital Asset Exchange Co., Ltd. as Flybit's legal operator rather than a separate exchange. It does not infer an exact launch date from company or VASP history.
+
+## GDAC
+
+Peertec's current first-party corporate site identifies GDAC as its cryptocurrency trading platform and states an ISMS certification for exchange and wallet-management system operation valid through 2026-12-01. DAXA identifies Peertec Co., Ltd. with service name GDAC and links gdac.com.
+
+BX53 treats Peertec as GDAC's operator rather than a second exchange entity. Certification validity supports current operational context but is not converted into a launch or lifecycle event.
+
+## COREDAX
+
+Current first-party COREDAX company material identifies an operating digital-asset exchange and states completion of Financial Intelligence Unit virtual-asset service provider reporting. DAXA identifies COREDAX Co., Ltd. with service name COREDAX and links coredax.com.
+
+The operator's stated 2018 founding year is not converted into a synthetic exchange launch date.
+
+## FOBL
+
+The current FOBL exchange surface exposes account, trading, market, fee, disclosure, research, and support functions. A first-party notice dated 2026-04-07 documents scheduled exchange-system maintenance. DAXA identifies Foblgate Co., Ltd. with service name FOBL and links foblgate.com.
+
+BX53 treats FOBL, Foblgate, and Foblgate Co., Ltd. as one continuing exchange/operator identity and does not create separate records for the current brand and legacy/domain name.
+
+## Exclusions
+
+BX53 does not infer:
+
+- exact launch dates from incorporation, company-founding, certification, or VASP-status dates;
+- regulatory approval solely from DAXA directory presence;
+- investment recommendation or safety endorsement;
+- trading volume, liquidity, solvency, custody quality, or security quality;
+- lifecycle events from ordinary maintenance, current certification, or directory status;
+- separate exchange entities for legal operator names or service-brand variants.

--- a/records/exchanges/coredax.json
+++ b/records/exchanges/coredax.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001131",
+    "slug": "coredax",
+    "canonical_name": "COREDAX",
+    "aliases": [
+      "Coredax",
+      "코어닥스",
+      "COREDAX Co., Ltd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "South Korea",
+    "summary": "South Korean centralized virtual-asset exchange operated by COREDAX Co., Ltd., providing account-based digital-asset trading through web and mobile exchange services.",
+    "official_url_original": "https://www.coredax.com/",
+    "official_domain_original": "coredax.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.coredax.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party site presents COREDAX as an operating digital-asset exchange with mobile trading and customer support. Its company material states that the operator completed Financial Intelligence Unit reporting as a virtual-asset service provider. DAXA's virtual-asset service provider status page, current to 2026-07-31, lists COREDAX Co., Ltd. and service name COREDAX. No exact launch date is inferred from the stated 2018 company founding year."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012499",
+      "exchange_id": "hei_ex_001131",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "COREDAX company introduction",
+      "url": "https://www.coredax.com/company/intro/ceo/index.html",
+      "publisher": "COREDAX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.coredax.com/company/intro/ceo/index.html",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party company material identifies COREDAX as a digital-asset exchange and states that the operator completed FIU virtual-asset service provider reporting."
+    },
+    {
+      "id": "hei_src_012500",
+      "exchange_id": "hei_ex_001131",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Virtual asset service provider report status",
+      "url": "https://kdaxa.org/support/vasp.php",
+      "publisher": "Digital Asset eXchange Alliance (DAXA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://kdaxa.org/support/vasp.php",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "DAXA's status page, current to 2026-07-31, lists COREDAX Co., Ltd. with service name COREDAX and links coredax.com."
+    }
+  ]
+}

--- a/records/exchanges/flybit.json
+++ b/records/exchanges/flybit.json
@@ -1,0 +1,61 @@
+{
+  "entity": {
+    "id": "hei_ex_001129",
+    "slug": "flybit",
+    "canonical_name": "Flybit",
+    "aliases": [
+      "FLYBIT",
+      "Korea Digital Asset Exchange Co., Ltd.",
+      "한국디지털거래소"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "South Korea",
+    "summary": "South Korean centralized virtual-asset exchange operated by Korea Digital Asset Exchange Co., Ltd., providing account-based crypto trading, deposits and withdrawals, and API access.",
+    "official_url_original": "https://flybit.com/",
+    "official_domain_original": "flybit.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://flybit.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party website and 2026 support material show an operating exchange with customer asset due-diligence reporting, deposits and withdrawals, trading support, and account services. DAXA's virtual-asset service provider status page, current to 2026-07-31, lists Korea Digital Asset Exchange Co., Ltd. with service name Flybit and links flybit.com. No exact launch date is inferred from company history or regulatory status."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012495",
+      "exchange_id": "hei_ex_001129",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Flybit virtual asset due-diligence report result as of 2026-03-31",
+      "url": "https://flybit.zendesk.com/hc/ko/articles/58041577116057-%EA%B0%80%EC%83%81%EC%9E%90%EC%82%B0-%EC%8B%A4%EC%82%AC-%EB%B3%B4%EA%B3%A0%EC%84%9C-%EA%B2%B0%EA%B3%BC-%EA%B3%B5%EA%B0%9C-2026-03-31",
+      "publisher": "Flybit",
+      "published_at": "2026-05-18",
+      "archived_url": "https://web.archive.org/web/*/https://flybit.zendesk.com/hc/ko/articles/58041577116057",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "First-party 2026 disclosure identifies Flybit as the exchange operated by Korea Digital Asset Exchange and reports customer virtual-asset holdings and continuing withdrawal availability as of the reviewed period."
+    },
+    {
+      "id": "hei_src_012496",
+      "exchange_id": "hei_ex_001129",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Virtual asset service provider report status",
+      "url": "https://kdaxa.org/support/vasp.php",
+      "publisher": "Digital Asset eXchange Alliance (DAXA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://kdaxa.org/support/vasp.php",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "DAXA's status page, current to 2026-07-31, lists Korea Digital Asset Exchange Co., Ltd. and service name Flybit and links flybit.com."
+    }
+  ]
+}

--- a/records/exchanges/fobl.json
+++ b/records/exchanges/fobl.json
@@ -1,0 +1,62 @@
+{
+  "entity": {
+    "id": "hei_ex_001132",
+    "slug": "fobl",
+    "canonical_name": "FOBL",
+    "aliases": [
+      "Foblgate",
+      "FOBLGATE",
+      "포블",
+      "Foblgate Co., Ltd."
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "South Korea",
+    "summary": "South Korean centralized virtual-asset exchange operated by Foblgate Co., Ltd. under the FOBL brand, providing account registration, crypto trading, market access, and customer support.",
+    "official_url_original": "https://www.foblgate.com/",
+    "official_domain_original": "foblgate.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.foblgate.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party exchange surface exposes registration, login, trading, support, fees, disclosures, and research functions. A first-party April 2026 maintenance notice confirms continuing exchange operations. DAXA's virtual-asset service provider status page, current to 2026-07-31, lists Foblgate Co., Ltd. with service name FOBL. No exact launch date is inferred from corporate or regulatory history."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012501",
+      "exchange_id": "hei_ex_001132",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "FOBL exchange maintenance notice",
+      "url": "https://www.foblgate.com/press-release/300",
+      "publisher": "FOBL",
+      "published_at": "2026-04-07",
+      "archived_url": "https://web.archive.org/web/*/https://www.foblgate.com/press-release/300",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "First-party 2026 maintenance notice identifies FOBL as a South Korean virtual-asset exchange and documents ongoing exchange-system operation."
+    },
+    {
+      "id": "hei_src_012502",
+      "exchange_id": "hei_ex_001132",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Virtual asset service provider report status",
+      "url": "https://kdaxa.org/support/vasp.php",
+      "publisher": "Digital Asset eXchange Alliance (DAXA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://kdaxa.org/support/vasp.php",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "DAXA's status page, current to 2026-07-31, lists Foblgate Co., Ltd. with service name FOBL and links foblgate.com."
+    }
+  ]
+}

--- a/records/exchanges/gdac.json
+++ b/records/exchanges/gdac.json
@@ -1,0 +1,60 @@
+{
+  "entity": {
+    "id": "hei_ex_001130",
+    "slug": "gdac",
+    "canonical_name": "GDAC",
+    "aliases": [
+      "지닥",
+      "Peertec GDAC"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "South Korea",
+    "summary": "South Korean centralized virtual-asset exchange operated by Peertec Co., Ltd., providing crypto trading and related digital-asset services under the GDAC brand.",
+    "official_url_original": "https://www.gdac.com/",
+    "official_domain_original": "gdac.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.gdac.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Peertec's current first-party corporate site presents GDAC as its cryptocurrency trading platform and states an ISMS certification for exchange and wallet-management system operation valid through 2026-12-01. DAXA's virtual-asset service provider status page, current to 2026-07-31, lists Peertec Co., Ltd. with service name GDAC and links gdac.com. No exact launch date is inferred from the operator's founding date or regulatory status."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012497",
+      "exchange_id": "hei_ex_001130",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Peertec products and solutions — GDAC",
+      "url": "https://peertec.com/",
+      "publisher": "Peertec",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://peertec.com/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party operator site identifies GDAC as a crypto trading platform and states ISMS certification for exchange and wallet-management system operation with validity through 2026-12-01."
+    },
+    {
+      "id": "hei_src_012498",
+      "exchange_id": "hei_ex_001130",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Virtual asset service provider report status",
+      "url": "https://kdaxa.org/support/vasp.php",
+      "publisher": "Digital Asset eXchange Alliance (DAXA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://kdaxa.org/support/vasp.php",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "DAXA's status page, current to 2026-07-31, lists Peertec Co., Ltd. and service name GDAC and links gdac.com."
+    }
+  ]
+}


### PR DESCRIPTION
## Post-D-1000 canonical growth — BX53

Continue reviewed canonical growth while L-2 remains in evidence-capture HOLD.

### Added

```text
Flybit   hei_ex_001129 active
GDAC     hei_ex_001130 active
COREDAX  hei_ex_001131 active
FOBL     hei_ex_001132 active
```

### Evidence

Each record uses current first-party operating or operator material plus DAXA's virtual-asset service provider status directory, whose reviewed page states that its status is current to 2026-07-31.

DAXA is used as a corroborating industry status directory, not as a regulator or as a safety/performance endorsement.

No exact launch date or lifecycle event is inferred from company founding, certification, maintenance, or VASP-status dates.

### Projected reviewed state

```text
Entities: 1012
Events:   1026
Evidence: 3806
```

### Next IDs

```text
Entity:   hei_ex_001133
Event:    hei_ev_010103
Evidence: hei_src_012503
```

### Validation target

Require records, duplicate identity, enum, country, URL safety, machine/public consistency, localization, recovery, baseline, count semantics, and CI gates before merge.