### PR TITLE
Add post-D-1000 BX54 reviewed Japan exchange records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1012,
-    "events": 1026,
-    "evidence": 3806
+    "entities": 1016,
+    "events": 1029,
+    "evidence": 3817
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX53_2026-08-09.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX54_2026-08-09.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX53, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX54, the current reviewed state is:
 
 ```text
-Entities: 1012
-Events:   1026
-Evidence: 3806
+Entities: 1016
+Events:   1029
+Evidence: 3817
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX53_2026-08-09.md
+docs/audits/HEI_POST_D1000_GROWTH_BX54_2026-08-09.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX54_2026-08-09.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX54_2026-08-09.md
@@ -1,0 +1,90 @@
+# HEI Post-D-1000 Growth — BX54
+
+Date: 2026-08-09  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX54 continues reviewed canonical growth after BX53 with four Japanese centralized crypto trading services and three meaningful lifecycle/state-change events.
+
+Added reviewed entities:
+
+```text
+BITPOINT       active / cex / Japan
+S.BLOX         active / cex / Japan
+HashKey Japan  active / cex / Japan
+BACKSEAT       limited / cex / Japan
+```
+
+Added evidence: 11  
+Added events: 3
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1016
+Events:   1029
+Evidence: 3817
+```
+
+## Evidence standard
+
+Each addition has current first-party service or operator evidence and a current identity/status corroborator where appropriate.
+
+BITPOINT uses current first-party service evidence plus first-party merger-completion notices from both sides of the 2026 legal-company merger.
+
+S.BLOX uses the current first-party trading service surface plus the current JVCEA member directory.
+
+HashKey Japan uses the current first-party service/identity site, the first-party Tokyo Hash → HashKey Japan company-name change notice, and the current JVCEA member directory.
+
+BACKSEAT uses the current first-party exchange site, a first-party 2026 external deposit/withdrawal suspension notice, and the current JVCEA member directory.
+
+JVCEA is used as a current industry/SRO membership and registration corroborator, not as a safety, solvency, liquidity, custody-quality, or investment endorsement.
+
+## Lifecycle handling
+
+### BITPOINT
+
+BITPoint Japan Co., Ltd. was absorbed into SBI VC Trade Co., Ltd. on 2026-04-01. First-party notices explicitly say that BITPOINT and VCTRADE remained separate customer-facing services after the legal-company merger. BX54 therefore adds a `merged` event with `event_status_effect: active` while keeping the BITPOINT service entity active.
+
+### HashKey Japan
+
+Tokyo Hash Co., Ltd. changed its company name to HashKey Japan Co., Ltd. effective 2026-06-01. The first-party notice says the legal entity, contracts, and services were unchanged. BX54 records a `rebranded` event and keeps one continuing active entity.
+
+### BACKSEAT
+
+BACKSEAT suspended external crypto deposits and withdrawals from 2026-02-25 with no announced restart date while crypto trading remained available. BX54 records a `withdrawal_suspended` event with `event_status_effect: limited`; the simultaneous deposit suspension is preserved in the event text because no combined deposit/withdrawal enum exists.
+
+## Scope control
+
+BX54 does not add every Japanese registered crypto-asset business. CoinTrade was explicitly reviewed and excluded because its own current FAQ states that it offers dealer-market sales only and does not provide exchange-style trading.
+
+Registration or association membership alone is not sufficient for HEI inclusion.
+
+## Date handling
+
+BX54 does not synthesize exact launch dates from:
+
+- company incorporation dates;
+- registration dates;
+- association membership;
+- month-only service-history statements.
+
+HashKey Japan's current site states that crypto-asset exchange service began in September 2021, but no exact day is encoded in `launch_date`.
+
+## L-2 relationship
+
+This batch does not change the L-2 localization decision. Canonical growth remains allowed during HOLD. Missing external search/usage/indexing evidence and operator QA burden remain separate L-2 requirements.
+
+## Next identifiers
+
+```text
+Entity:   hei_ex_001137
+Event:    hei_ev_010106
+Evidence: hei_src_012514
+```
+
+## Completion condition
+
+BX54 is complete only after normal record validation, reviewed-public aggregation, ID and overlap checks, country and URL-safety checks, machine/public consistency, localization output checks, recovery validation, count-semantics validation, and merge to `main` succeed.

--- a/docs/backlog/consumed/hei_unadded-bx54-four-reviewed-japan-exchange-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx54-four-reviewed-japan-exchange-records.md
@@ -1,0 +1,71 @@
+# Consumed backlog — BX54 reviewed Japan exchange records
+
+Status: consumed  
+Date: 2026-08-09  
+Lane: post-D-1000 canonical growth
+
+## Added
+
+```text
+BITPOINT       hei_ex_001133 active
+S.BLOX         hei_ex_001134 active
+HashKey Japan  hei_ex_001135 active
+BACKSEAT       hei_ex_001136 limited
+```
+
+## Event allocation
+
+```text
+BITPOINT       hei_ev_010103 operator merger / service remains active
+HashKey Japan  hei_ev_010104 rebrand
+BACKSEAT       hei_ev_010105 external deposit/withdrawal suspension
+```
+
+S.BLOX consumes no new event ID in this batch.
+
+## Evidence allocation
+
+```text
+BITPOINT       hei_src_012503–012505
+S.BLOX         hei_src_012506–012507
+HashKey Japan  hei_src_012508–012510
+BACKSEAT       hei_src_012511–012513
+```
+
+## Review basis
+
+BITPOINT is supported by its current first-party trading site plus first-party merger-completion notices from both BITPOINT and SBI VC Trade. The former legal operator merged into SBI VC Trade on 2026-04-01, while the BITPOINT and VCTRADE customer-facing services remained distinct and available. The legal-company merger is therefore recorded as an event with `event_status_effect: active`, not as service death.
+
+S.BLOX is supported by its current first-party crypto trading site and the current JVCEA member directory, which lists S.BLOX Inc. under Kanto Finance Bureau crypto-asset exchange registration No. 00016.
+
+HashKey Japan is supported by its current first-party site, the first-party company-name change notice, and the current JVCEA member directory. The June 1, 2026 Tokyo Hash → HashKey Japan change was a company-name change only; the first-party notice states that legal identity, contracts, and services were unchanged.
+
+BACKSEAT is supported by its current first-party exchange site, a 2026 first-party suspension notice, and the current JVCEA member directory. The exchange remains usable for crypto trading, but external crypto deposits/withdrawals and staking are suspended and the dealer-market service is unavailable; `limited` is therefore the conservative current status.
+
+## Identity and scope controls
+
+Direct current-main path checks found no reviewed BITPOINT, S.BLOX, HashKey Japan/Tokyo Hash, or BACKSEAT exchange record before BX54.
+
+The batch does not treat every Japanese registered crypto-asset business as an HEI exchange. CoinTrade was reviewed and excluded from this batch because its own FAQ states that it currently provides only dealer-market sales rather than exchange-style trading. Registration alone is not sufficient for HEI inclusion.
+
+HashKey Japan and Tokyo Hash are treated as one continuing entity rather than predecessor/successor entities because the first-party rebrand notice explicitly preserves the legal entity and services.
+
+BITPOINT is treated as a continuing service identity after the operator-company merger because its current first-party site and merger notice explicitly preserve the BITPOINT service brand.
+
+## Reviewed result
+
+```text
+Entities: 1016
+Events:   1029
+Evidence: 3817
+```
+
+Next unused identifiers after BX54:
+
+```text
+Entity:   hei_ex_001137
+Event:    hei_ev_010106
+Evidence: hei_src_012514
+```
+
+These counts remain subject to normal reviewed-public aggregation, identity-resolution, and validation semantics at merge time.

--- a/docs/backlog/consumed/hei_unadded-bx54-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx54-source-review-note.md
@@ -1,0 +1,56 @@
+# BX54 source review boundaries
+
+Date: 2026-08-09  
+Status: reviewed support note
+
+## Scope
+
+BX54 reviews four Japanese centralized crypto trading services using current first-party service or operator material plus the current Japan Virtual and Crypto assets Exchange Association (JVCEA) member directory where appropriate.
+
+JVCEA membership and Japanese registration are corroborating identity/status evidence. They are not treated as investment recommendation, safety endorsement, solvency proof, liquidity proof, or proof that every registered business fits HEI exchange scope.
+
+## BITPOINT
+
+The current BITPOINT first-party site exposes account opening, spot trading, exchange tools, asset transfers, staking, and current 2026 notices. First-party notices from BITPOINT and SBI VC Trade confirm that BITPoint Japan Co., Ltd. was absorbed into SBI VC Trade Co., Ltd. on 2026-04-01.
+
+The same notices explicitly state that BITPOINT and VCTRADE continued as distinct service brands after the legal-company merger, with later service integration to be announced separately. BX54 therefore records the corporate merger as an event while keeping the BITPOINT entity `active`.
+
+BX54 does not convert the former operating company's 2016 incorporation date into an exact BITPOINT service launch date.
+
+## S.BLOX
+
+The current S.BLOX first-party site identifies S.BLOX Inc., displays Japanese crypto-asset exchange registration, and presents the current trading service. Current 2026 support notices describe crypto buying/selling availability around scheduled maintenance.
+
+JVCEA's current member directory lists S.BLOX Inc. as a crypto-asset exchange business member with Kanto Finance Bureau registration No. 00016.
+
+BX54 does not infer a launch date from registration, corporate history, or ownership history.
+
+## HashKey Japan
+
+The current first-party site identifies HashKey Japan as the former Tokyo Hash and states that crypto-asset exchange service has been provided since September 2021. The company-name change notice states that Tokyo Hash Co., Ltd. became HashKey Japan Co., Ltd. effective 2026-06-01 and explicitly says that legal identity, contracts, and provided services were unchanged.
+
+BX54 therefore keeps one continuing entity, preserves Tokyo Hash as an alias, and records a `rebranded` event with an active status effect. It does not create separate predecessor/successor entities.
+
+The month-only September 2021 service-start statement is not converted into a synthetic exact launch date.
+
+## BACKSEAT
+
+The current BACKSEAT first-party site exposes account opening, order-book exchange, OTC trading, and current 2026 notices. First-party 2026 notices state that external crypto deposits and withdrawals are suspended from 2026-02-25 with no announced restart date, while crypto trading remains available. Staking is also stopped, and a later operating notice states that dealer-market buy/sell is unavailable while exchange trading continues.
+
+BX54 therefore uses `limited`, not `active`, because material customer functions are unavailable, and not `dead`, because exchange trading remains available.
+
+The suspension event uses the available `withdrawal_suspended` enum while explicitly preserving the simultaneous deposit suspension in the event title, description, and notes.
+
+## Explicit exclusion reviewed during BX54
+
+CoinTrade was reviewed but not added. Its current first-party FAQ states that it presently offers only dealer-market sales and does not provide exchange-style trading. BX54 does not treat Japanese crypto-asset registration alone as sufficient to override HEI's exchange-scope boundary.
+
+## General exclusions
+
+BX54 does not infer:
+
+- safety, solvency, liquidity, custody quality, or investment merit from registration or association membership;
+- exact launch dates from incorporation, registration, or month-only service history;
+- service death from a legal-operator merger when the customer-facing exchange service continues;
+- separate entities for a pure legal-name rebrand with unchanged contracts and services;
+- `dead` status from partial service suspensions when exchange trading remains available.

--- a/records/exchanges/backseat-exchange.json
+++ b/records/exchanges/backseat-exchange.json
@@ -1,0 +1,91 @@
+{
+  "entity": {
+    "id": "hei_ex_001136",
+    "slug": "backseat-exchange",
+    "canonical_name": "BACKSEAT",
+    "aliases": [
+      "BACKSEAT Exchange",
+      "BACKSEAT Exchange Inc.",
+      "BACKSEAT暗号資産交換業株式会社"
+    ],
+    "type": "cex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Japan",
+    "summary": "Japan-based centralized crypto exchange providing order-book and OTC trading. Exchange trading remains available, while external crypto deposits and withdrawals, dealer-market trading, and staking have been suspended as of 2026.",
+    "official_url_original": "https://www.backseat-exchange.com/",
+    "official_domain_original": "backseat-exchange.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.backseat-exchange.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party website continues to expose the crypto exchange, account-opening, OTC, and current July 2026 notices. First-party 2026 operating notices state that order-book exchange trading remains available while external crypto deposits and withdrawals are suspended from 2026-02-25, staking remains stopped, and the dealer-market buy/sell service is also unavailable. HEI therefore uses status limited rather than active or dead. JVCEA's current member directory lists BACKSEAT Crypto Asset Exchange Co., Ltd. with Kanto Finance Bureau registration No. 00026."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010105",
+      "exchange_id": "hei_ex_001136",
+      "event_type": "withdrawal_suspended",
+      "event_date": "2026-02-25",
+      "title": "External crypto deposits and withdrawals suspended",
+      "description": "BACKSEAT suspended external crypto deposits and withdrawals from February 25, 2026 with no announced restart date. Crypto trading remained available, while staking had already been stopped.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "limited",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "The first-party notice covers both external deposits and withdrawals. HEI uses withdrawal_suspended as the closest available event enum and preserves the deposit suspension in the title, description, and notes."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012511",
+      "exchange_id": "hei_ex_001136",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "BACKSEAT official exchange website",
+      "url": "https://www.backseat-exchange.com/",
+      "publisher": "BACKSEAT",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.backseat-exchange.com/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes account opening, crypto exchange and OTC service surfaces, current July 2026 notices, and the operator's Japanese registration."
+    },
+    {
+      "id": "hei_src_012512",
+      "exchange_id": "hei_ex_001136",
+      "event_id": "hei_ev_010105",
+      "source_type": "official_statement",
+      "title": "External deposits, withdrawals and staking service suspension notice",
+      "url": "https://www.backseat-exchange.com/2026news/info2026020301",
+      "publisher": "BACKSEAT",
+      "published_at": "2026-02-03",
+      "archived_url": "https://web.archive.org/web/*/https://www.backseat-exchange.com/2026news/info2026020301",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice sets the February 25, 2026 external deposit/withdrawal suspension and states that crypto trading would remain available."
+    },
+    {
+      "id": "hei_src_012513",
+      "exchange_id": "hei_ex_001136",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "JVCEA member directory",
+      "url": "https://jvcea.or.jp/member/",
+      "publisher": "Japan Virtual and Crypto assets Exchange Association (JVCEA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://jvcea.or.jp/member/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current JVCEA member directory lists BACKSEAT Crypto Asset Exchange Co., Ltd. as a crypto-asset exchange business member with Kanto Finance Bureau registration No. 00026."
+    }
+  ]
+}

--- a/records/exchanges/bitpoint.json
+++ b/records/exchanges/bitpoint.json
@@ -1,0 +1,91 @@
+{
+  "entity": {
+    "id": "hei_ex_001133",
+    "slug": "bitpoint",
+    "canonical_name": "BITPOINT",
+    "aliases": [
+      "BITPOINT PRO",
+      "Bitpoint Japan",
+      "株式会社ビットポイントジャパン"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Japan",
+    "summary": "Japanese centralized crypto trading service that continues as a distinct BITPOINT brand under SBI VC Trade after the former operating company, BITPoint Japan, was absorbed into SBI VC Trade in April 2026.",
+    "official_url_original": "https://www.bitpoint.co.jp/",
+    "official_domain_original": "bitpoint.co.jp",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bitpoint.co.jp/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "The current first-party BITPOINT site exposes account opening, spot trading, exchange tools, asset transfers, staking, and current July 2026 notices. The former operator, BITPoint Japan Co., Ltd., was absorbed into SBI VC Trade Co., Ltd. on 2026-04-01, but both BITPOINT and VCTRADE remained distinct customer-facing services after the legal-company merger. HEI therefore records an active service identity plus a merger event rather than treating the brand as dead or merged out. No exact launch date is inferred from the former operating company's 2016 establishment date."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010103",
+      "exchange_id": "hei_ex_001133",
+      "event_type": "merged",
+      "event_date": "2026-04-01",
+      "title": "BITPOINT operating company merged into SBI VC Trade",
+      "description": "BITPoint Japan Co., Ltd. was absorbed into SBI VC Trade Co., Ltd. on April 1, 2026. The BITPOINT service brand continued separately after the corporate merger and remained available to customers.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "This is a legal-operator merger, not a service shutdown. First-party notices from both BITPOINT and SBI VC Trade state that BITPOINT and VCTRADE remained separate services after the merger, with future service integration planned separately."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012503",
+      "exchange_id": "hei_ex_001133",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "BITPOINT official crypto trading service website",
+      "url": "https://www.bitpoint.co.jp/",
+      "publisher": "BITPOINT",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bitpoint.co.jp/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site exposes active account opening, spot trading, exchange tools, asset transfers, staking, and recent July 2026 operating notices."
+    },
+    {
+      "id": "hei_src_012504",
+      "exchange_id": "hei_ex_001133",
+      "event_id": "hei_ev_010103",
+      "source_type": "official_statement",
+      "title": "Completion of merger between BITPoint Japan and SBI VC Trade",
+      "url": "https://www.bitpoint.co.jp/news/info/info-2026040101/",
+      "publisher": "BITPOINT",
+      "published_at": "2026-04-01",
+      "archived_url": "https://web.archive.org/web/*/https://www.bitpoint.co.jp/news/info/info-2026040101/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice confirms the April 1 legal-company merger and explicitly states that BITPOINT and VCTRADE would continue as distinct service brands for the time being."
+    },
+    {
+      "id": "hei_src_012505",
+      "exchange_id": "hei_ex_001133",
+      "event_id": "hei_ev_010103",
+      "source_type": "official_statement",
+      "title": "SBI VC Trade and BITPoint Japan merger completion notice",
+      "url": "https://www.sbivc.co.jp/newsview/umhk6419ku",
+      "publisher": "SBI VC Trade",
+      "published_at": "2026-04-01",
+      "archived_url": "https://web.archive.org/web/*/https://www.sbivc.co.jp/newsview/umhk6419ku",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Corroborating first-party notice from the surviving legal operator confirms the merger and continued exchange/trading service business."
+    }
+  ]
+}

--- a/records/exchanges/hashkey-japan.json
+++ b/records/exchanges/hashkey-japan.json
@@ -1,0 +1,91 @@
+{
+  "entity": {
+    "id": "hei_ex_001135",
+    "slug": "hashkey-japan",
+    "canonical_name": "HashKey Japan",
+    "aliases": [
+      "Tokyo Hash",
+      "東京ハッシュ株式会社",
+      "HashKey Japan株式会社"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Japan",
+    "summary": "Japan-based registered centralized crypto-asset exchange service operator, formerly Tokyo Hash, that changed its company name to HashKey Japan in June 2026 while keeping the same contracts and services.",
+    "official_url_original": "https://www.tokyohash.co.jp/",
+    "official_domain_original": "tokyohash.co.jp",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.tokyohash.co.jp/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "The current first-party site identifies HashKey Japan as the former Tokyo Hash, states that it began providing crypto-asset exchange services in September 2021, and lists Kanto Finance Bureau registration No. 00027. The June 1, 2026 company-name change did not alter the legal entity, contracts, or provided services. HEI therefore keeps one continuing entity and records a rebrand event. No exact launch date is encoded from the month-only service-start statement."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010104",
+      "exchange_id": "hei_ex_001135",
+      "event_type": "rebranded",
+      "event_date": "2026-06-01",
+      "title": "Tokyo Hash changed company name to HashKey Japan",
+      "description": "Tokyo Hash Co., Ltd. changed its company name to HashKey Japan Co., Ltd. on June 1, 2026 as part of group branding and management alignment, without changing the legal entity, contracts, or provided services.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "First-party notice explicitly says this was a company-name change only and that the contract counterparty and services remained unchanged."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012508",
+      "exchange_id": "hei_ex_001135",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "HashKey Japan official website",
+      "url": "https://www.tokyohash.co.jp/",
+      "publisher": "HashKey Japan",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.tokyohash.co.jp/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site identifies the current HashKey Japan identity, states that crypto-asset exchange service has been provided since September 2021, and lists the Japanese registration number."
+    },
+    {
+      "id": "hei_src_012509",
+      "exchange_id": "hei_ex_001135",
+      "event_id": "hei_ev_010104",
+      "source_type": "official_statement",
+      "title": "Company name change notice",
+      "url": "https://www.tokyohash.co.jp/news20260608/",
+      "publisher": "HashKey Japan",
+      "published_at": "2026-06-15",
+      "archived_url": "https://web.archive.org/web/*/https://www.tokyohash.co.jp/news20260608/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice states that Tokyo Hash Co., Ltd. became HashKey Japan Co., Ltd. effective June 1, 2026 and that the legal entity, contracts, and services were unchanged."
+    },
+    {
+      "id": "hei_src_012510",
+      "exchange_id": "hei_ex_001135",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "JVCEA member directory",
+      "url": "https://jvcea.or.jp/member/",
+      "publisher": "Japan Virtual and Crypto assets Exchange Association (JVCEA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://jvcea.or.jp/member/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current JVCEA member directory lists HashKey Japan Co., Ltd. as a crypto-asset exchange business member with Kanto Finance Bureau registration No. 00027."
+    }
+  ]
+}

--- a/records/exchanges/s-blox.json
+++ b/records/exchanges/s-blox.json
@@ -1,0 +1,59 @@
+{
+  "entity": {
+    "id": "hei_ex_001134",
+    "slug": "s-blox",
+    "canonical_name": "S.BLOX",
+    "aliases": [
+      "S.BLOX株式会社"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Japan",
+    "summary": "Japan-based centralized crypto-asset trading service operated by S.BLOX Inc., providing account-based crypto buying and selling and related customer asset services.",
+    "official_url_original": "https://www.sblox.jp/",
+    "official_domain_original": "sblox.jp",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.sblox.jp/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-09",
+    "notes": "Current first-party site identifies S.BLOX Inc. as a Japanese registered crypto-asset exchange service provider and presents an active crypto trading service. Current 2026 support notices describe normal crypto buy/sell operations outside scheduled maintenance. JVCEA's current member directory lists S.BLOX Inc. with Kanto Finance Bureau registration No. 00016. No exact launch date is inferred from registration or corporate-history dates."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012506",
+      "exchange_id": "hei_ex_001134",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "S.BLOX crypto trading service website",
+      "url": "https://www.sblox.jp/",
+      "publisher": "S.BLOX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.sblox.jp/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site identifies S.BLOX Inc., displays its Japanese crypto-asset exchange registration, and provides the active customer-facing trading service surface."
+    },
+    {
+      "id": "hei_src_012507",
+      "exchange_id": "hei_ex_001134",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "JVCEA member directory",
+      "url": "https://jvcea.or.jp/member/",
+      "publisher": "Japan Virtual and Crypto assets Exchange Association (JVCEA)",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://jvcea.or.jp/member/",
+      "accessed_at": "2026-08-09",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current JVCEA member directory lists S.BLOX Inc. as a crypto-asset exchange business member with Kanto Finance Bureau registration No. 00016."
+    }
+  ]
+}


### PR DESCRIPTION
## Post-D-1000 canonical growth — BX54

Continue reviewed canonical growth while L-2 remains in evidence-capture HOLD.

### Added

```text
BITPOINT       hei_ex_001133 active
S.BLOX         hei_ex_001134 active
HashKey Japan  hei_ex_001135 active
BACKSEAT       hei_ex_001136 limited
```

### Lifecycle handling

- BITPOINT: records the 2026-04-01 legal-operator merger into SBI VC Trade while preserving the BITPOINT service as `active`; first-party notices state BITPOINT and VCTRADE continued as distinct services after the corporate merger.
- HashKey Japan: records the 2026-06-01 Tokyo Hash → HashKey Japan company-name change as `rebranded`; first-party material states legal identity, contracts, and services were unchanged.
- BACKSEAT: records the 2026-02-25 external crypto deposit/withdrawal suspension and uses `limited` because exchange trading remains available while material customer functions are suspended.
- S.BLOX: current active exchange record with no synthetic lifecycle event.

### Scope boundary

CoinTrade was reviewed and excluded from this batch because its current first-party FAQ states that it provides dealer-market sales only rather than exchange-style trading. Japanese registration alone is not sufficient for HEI exchange inclusion.

### Projected reviewed state

```text
Entities: 1016
Events:   1029
Evidence: 3817
```

### Next IDs

```text
Entity:   hei_ex_001137
Event:    hei_ev_010106
Evidence: hei_src_012514
```

### Validation target

Require records and duplicate-identity validation, country/origin, URL safety, active-CEX quality, machine/public consistency, localization, recovery, baseline, count semantics, and CI gates before merge.