### PR TITLE
Harden HEI monitoring candidate and URL checks

### DIFF
--- a/scripts/monitoring/core/news-extract.mjs
+++ b/scripts/monitoring/core/news-extract.mjs
@@ -34,6 +34,9 @@ const KNOWN_BAD_NAMES = new Set([
   'users',
   'hackers',
   'regulators',
+  'popular',
+  'top crypto',
+  'russia',
 ]);
 
 function cleanCandidateName(value) {
@@ -46,6 +49,23 @@ function cleanCandidateName(value) {
     words.shift();
   }
   return words.join(' ').replace(/\b(exchange|dex|protocol|platform)$/i, '').trim();
+}
+
+function isMetadataSelfReference(name, item) {
+  const normalized = normalizeText(name);
+  if (!normalized) return true;
+
+  const sourceName = normalizeText(item?.source_name);
+  if (sourceName && normalized === sourceName) return true;
+
+  const authorityNames = [
+    item?.regulatory_authority,
+    item?.regulatory_authority_short_name,
+  ]
+    .map((value) => normalizeText(value))
+    .filter(Boolean);
+
+  return authorityNames.includes(normalized);
 }
 
 function domainFromUrl(value) {
@@ -87,7 +107,11 @@ export function extractCandidateNameFromNews(item) {
     const match = text.match(pattern);
     if (match?.[1]) {
       const name = cleanCandidateName(match[1]);
-      if (name && !KNOWN_BAD_NAMES.has(normalizeText(name))) return name;
+      if (
+        name
+        && !KNOWN_BAD_NAMES.has(normalizeText(name))
+        && !isMetadataSelfReference(name, item)
+      ) return name;
     }
   }
 

--- a/scripts/monitoring/monitors/active-status-watch.mjs
+++ b/scripts/monitoring/monitors/active-status-watch.mjs
@@ -4,6 +4,7 @@ import { checkHttpUrl } from '../adapters/http-check.mjs';
 
 const ENABLE_DOMAIN_CHECKS = process.env.HEI_MONITORING_ENABLE_DOMAIN_CHECKS === '1';
 const DEFAULT_LIMIT = 50;
+const RETRYABLE_CHECK_STATUSES = new Set(['dns_failure', 'tls_failure', 'server_error', 'timeout']);
 
 function getCheckLimit() {
   const parsed = Number.parseInt(process.env.HEI_MONITORING_DOMAIN_CHECK_LIMIT || String(DEFAULT_LIMIT), 10);
@@ -27,6 +28,30 @@ function isAccessControlNoise(check) {
 
 function isHealthyRedirect(check) {
   return check.status === 'redirected' && check.http_status === 200 && check.final_url;
+}
+
+export function shouldRetryOfficialSiteCheck(check) {
+  return Boolean(check && RETRYABLE_CHECK_STATUSES.has(check.status));
+}
+
+async function checkOfficialSite(url) {
+  const initialCheck = await checkHttpUrl(url);
+  if (!shouldRetryOfficialSiteCheck(initialCheck)) {
+    return {
+      check: initialCheck,
+      initial_check: null,
+      retry_attempted: false,
+      recovered_after_retry: false,
+    };
+  }
+
+  const retryCheck = await checkHttpUrl(url);
+  return {
+    check: retryCheck,
+    initial_check: initialCheck,
+    retry_attempted: true,
+    recovered_after_retry: retryCheck.status === 'ok' || isHealthyRedirect(retryCheck) || isAccessControlNoise(retryCheck),
+  };
 }
 
 function shouldCreateFinding(entity, check) {
@@ -103,7 +128,9 @@ export async function runActiveStatusWatch(context, { startedAt } = {}) {
 
   for (const entity of selected) {
     const url = entityUrl(entity);
-    const check = await checkHttpUrl(url);
+    const checkResult = await checkOfficialSite(url);
+    const check = checkResult.check;
+    const findingCreated = shouldCreateFinding(entity, check);
     checks.push({
       entity_id: entity.id,
       slug: entity.slug,
@@ -111,17 +138,20 @@ export async function runActiveStatusWatch(context, { startedAt } = {}) {
       status: entity.status,
       official_url: url,
       check,
-      finding_created: shouldCreateFinding(entity, check),
+      initial_check: checkResult.initial_check,
+      retry_attempted: checkResult.retry_attempted,
+      recovered_after_retry: checkResult.recovered_after_retry,
+      finding_created: findingCreated,
     });
 
-    if (shouldCreateFinding(entity, check)) {
+    if (findingCreated) {
       const severity = severityForCheck(entity, check);
       findings.push(createFinding({
         monitor,
         severity,
         category: `official_site_${check.status}`,
         title: `Official site check ${check.status}: ${entity.canonical_name}`,
-        summary: `${entity.id} ${url} -> ${check.status}${check.http_status ? ` HTTP ${check.http_status}` : ''}${check.error ? ` error=${check.error}` : ''}`,
+        summary: `${entity.id} ${url} -> ${check.status}${check.http_status ? ` HTTP ${check.http_status}` : ''}${check.error ? ` error=${check.error}` : ''}; retry_attempted=${checkResult.retry_attempted}`,
         affected_entity: {
           matched_existing_entity: true,
           id: entity.id,
@@ -149,6 +179,8 @@ export async function runActiveStatusWatch(context, { startedAt } = {}) {
         active_side_entities_with_urls: targets.length,
         checked: selected.length,
         findings: findings.length,
+        retries_attempted: checks.filter((item) => item.retry_attempted).length,
+        recovered_after_retry: checks.filter((item) => item.recovered_after_retry).length,
         access_control_noise: checks.filter((item) => isAccessControlNoise(item.check)).length,
         healthy_redirects: checks.filter((item) => isHealthyRedirect(item.check)).length,
         inactive_dns_noise: checks.filter((item) => item.status === 'inactive' && item.check.status === 'dns_failure').length,

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -55,6 +55,44 @@ function runMonitoringOutputRegressions() {
   });
   assert(extractedName === 'Oxium', `news extraction must identify Oxium instead of a headline fragment: ${extractedName}`);
 
+  const topCrypto = extractCandidateNameFromNews({
+    title: 'Another Top Crypto Exchange Shuts Down. What Does This Mean For the Future of the Crypto Market?',
+    snippet: 'A generic headline should not manufacture an exchange named Top Crypto.',
+    source_name: 'The Motley Fool',
+  });
+  assert(topCrypto === null, `news extraction must reject generic Top Crypto candidate: ${topCrypto}`);
+
+  const popular = extractCandidateNameFromNews({
+    title: 'Popular exchange shuts down after 8 years, here is everything you need to know',
+    snippet: 'Popular is an adjective, not an exchange identity.',
+    source_name: 'TheStreet',
+  });
+  assert(popular === null, `news extraction must reject generic Popular candidate: ${popular}`);
+
+  const russia = extractCandidateNameFromNews({
+    title: 'Russia Exchange Shuts Down After Regulatory Action',
+    snippet: 'A geographic label must not become a canonical exchange candidate.',
+    source_name: 'Example News',
+  });
+  assert(russia === null, `news extraction must reject geographic Russia candidate: ${russia}`);
+
+  const sourceSelfReference = extractCandidateNameFromNews({
+    title: 'CoinDesk Exchange Suspends Withdrawals Following Incident',
+    snippet: 'The publisher name must not become the monitored exchange identity.',
+    source_name: 'CoinDesk',
+  });
+  assert(sourceSelfReference === null, `news extraction must reject publisher self-reference candidate: ${sourceSelfReference}`);
+
+  const authoritySelfReference = extractCandidateNameFromNews({
+    title: 'FCA Warning on Crypto Exchange Registration',
+    snippet: 'The regulator name must not become the monitored exchange identity.',
+    source_name: 'Financial Conduct Authority',
+    source_category: 'regulatory_source',
+    regulatory_authority: 'Financial Conduct Authority',
+    regulatory_authority_short_name: 'FCA',
+  });
+  assert(authoritySelfReference === null, `news extraction must reject regulatory authority self-reference candidate: ${authoritySelfReference}`);
+
   const summary = buildSummaryMarkdown({
     runId: '20260630-smoke',
     mode: 'smoke',

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -4,6 +4,7 @@ import { loadCanonicalData } from './core/load-canonical-data.mjs';
 import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
 import { buildSummaryMarkdown } from './core/summary-writer.mjs';
 import { extractCandidateNameFromNews } from './core/news-extract.mjs';
+import { shouldRetryOfficialSiteCheck } from './monitors/active-status-watch.mjs';
 import { normalizeSitemapUrl } from './adapters/sitemap-check.mjs';
 import { runReviewedBundleAggregationRegression } from '../test-reviewed-bundle-aggregation.mjs';
 import { buildRegistryMetrics, parseReviewMonth } from '../review/monthly-registry-core.mjs';
@@ -92,6 +93,13 @@ function runMonitoringOutputRegressions() {
     regulatory_authority_short_name: 'FCA',
   });
   assert(authoritySelfReference === null, `news extraction must reject regulatory authority self-reference candidate: ${authoritySelfReference}`);
+
+  assert(shouldRetryOfficialSiteCheck({ status: 'dns_failure' }), 'DNS failures must be retried before creating an active-status finding');
+  assert(shouldRetryOfficialSiteCheck({ status: 'tls_failure' }), 'TLS failures must be retried before creating an active-status finding');
+  assert(shouldRetryOfficialSiteCheck({ status: 'server_error' }), 'server errors must be retried before creating an active-status finding');
+  assert(shouldRetryOfficialSiteCheck({ status: 'timeout' }), 'timeouts must be retried before creating an active-status finding');
+  assert(!shouldRetryOfficialSiteCheck({ status: 'ok' }), 'healthy responses must not be retried');
+  assert(!shouldRetryOfficialSiteCheck({ status: 'redirected', http_status: 200 }), 'healthy redirects must not be retried');
 
   const summary = buildSummaryMarkdown({
     runId: '20260630-smoke',


### PR DESCRIPTION
## Summary

Harden the 2026-08-10 monitoring paths that produced false candidate identities and transient official-site alerts.

## Root causes

1. `extractCandidateNameFromNews()` accepted capitalized headline fragments, publisher names, geography labels, and regulatory authority names as exchange candidates.
2. The active-status monitor created findings from a single DNS/TLS/server/timeout result without a confirmation retry.

## Changes

- reject `Popular`, `Top Crypto`, and `Russia` as non-entity headline fragments
- reject candidate names that exactly match the news publisher
- reject candidate names that exactly match the configured regulatory authority or short name
- retry DNS, TLS, server-error, and timeout official-site results once before creating a finding
- record retry/recovery metadata in monitoring output
- add smoke regressions for all false-positive patterns and retry-policy statuses while preserving the positive Oxium extraction case

## Safety

Canonical entity/event/evidence data is unchanged. Persistent official-site failures still produce the existing severity/action after confirmation retry.