### PR TITLE
Support dedicated auth for HEI monitoring PR creation

### DIFF
--- a/.github/workflows/hei-monitoring-v2.yml
+++ b/.github/workflows/hei-monitoring-v2.yml
@@ -114,5 +114,16 @@ jobs:
       - name: Create monitoring pull request
         if: steps.changes.outputs.changed == 'true'
         env:
+          # A dedicated fine-grained PAT lets the resulting pull_request event
+          # start normal validation runs. PRs created with the workflow
+          # GITHUB_TOKEN intentionally enter GitHub's approval-required state.
+          GH_TOKEN: ${{ secrets.HEI_MONITORING_PR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: bash scripts/monitoring/create-report-pr.sh
+        run: |
+          if [ -n "${GH_TOKEN:-}" ]; then
+            echo "Using HEI_MONITORING_PR_TOKEN for pull-request creation."
+          else
+            echo "::warning::HEI_MONITORING_PR_TOKEN is not configured; falling back to GITHUB_TOKEN. The resulting PR workflows will require manual approval."
+            unset GH_TOKEN
+          fi
+          bash scripts/monitoring/create-report-pr.sh


### PR DESCRIPTION
## Summary

Prepare the HEI monitoring workflow to create report PRs with a dedicated repository-scoped token instead of the workflow `GITHUB_TOKEN` when available.

## Why

GitHub intentionally places `pull_request` workflow runs triggered by PRs created with `GITHUB_TOKEN` into an approval-required state. Monitoring PR #741 reproduced this with `action_required` checks and zero jobs.

## Changes

- read optional repository secret `HEI_MONITORING_PR_TOKEN` into `GH_TOKEN` for the PR-creation step
- keep `GITHUB_TOKEN` for the existing git checkout/push path and as backward-compatible fallback
- emit an explicit workflow warning when the dedicated secret is absent, documenting that fallback-created PR checks will require manual approval
- do not commit or log token values

## Remaining configuration

Issue #745 tracks the one-time external credential setup. The recommended secret is a fine-grained PAT scoped only to this repository with Contents and Pull requests write access. After it is configured, the next generated monitoring PR must be used to verify that normal PR checks start without `action_required`.

No monitoring logic or canonical data is changed.