### PR TITLE
Add post-D-1000 BX56 reviewed DEX records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1017,
+    "entities": 1021,
     "events": 1031,
-    "evidence": 3820
+    "evidence": 3828
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX55_2026-08-10.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX56_2026-08-10.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX55, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX56, the current reviewed state is:
 
 ```text
-Entities: 1017
+Entities: 1021
 Events:   1031
-Evidence: 3820
+Evidence: 3828
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX55_2026-08-10.md
+docs/audits/HEI_POST_D1000_GROWTH_BX56_2026-08-10.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX56_2026-08-10.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX56_2026-08-10.md
@@ -1,0 +1,95 @@
+# HEI Post-D-1000 Growth — BX56
+
+Date: 2026-08-10  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX56 adds four reviewed active decentralized trading entities that were surfaced by monitoring but independently re-reviewed before canonical inclusion.
+
+Added reviewed entities:
+
+```text
+MUX Protocol  active / dex / Arbitrum ecosystem
+Storm Trade   active / dex / TON ecosystem
+Metal X       active / dex / XPR Network ecosystem
+Hegic         active / dex / Arbitrum ecosystem
+```
+
+Added evidence: 8  
+Added events: 0
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1021
+Events:   1031
+Evidence: 3828
+```
+
+## Evidence standard
+
+Each record uses one current first-party source plus one current independent status source.
+
+- MUX Protocol: current MUX documentation plus DefiLlama protocol / perpetual metrics.
+- Storm Trade: current Storm Trade documentation plus DefiLlama perpetual metrics.
+- Metal X: current Metal X documentation plus DefiLlama MetalX DEX metrics.
+- Hegic: current Hegic trading site plus DefiLlama options metrics.
+
+Monitoring output is candidate-discovery input only and is not cited as canonical evidence.
+
+## Status handling
+
+All four records use:
+
+```text
+status: active
+death_reason: null
+death_date: null
+```
+
+Current first-party trading surfaces are available and independent metrics report current non-zero activity. No terminal state is inferred.
+
+## Product identity handling
+
+BX56 deliberately avoids product-level duplication:
+
+- MUX perpetual trading protocols and the MUX Perpetual Aggregator remain one MUX Protocol entity.
+- Storm Trade web and Telegram interfaces remain one entity.
+- Metal X / MetalX DEX and related trading surfaces remain one Metal X entity.
+- Hegic call, put, and strategy products remain one Hegic entity.
+
+## Scope controls
+
+BX56 does not infer:
+
+- legal jurisdiction from ecosystem origin;
+- regulatory authorization;
+- exact launch dates from approximate or month-level source wording;
+- MCDEX -> MUX predecessor/successor lineage without a dedicated review;
+- separate entities for product labels that share one supported protocol identity.
+
+AnyHedge was reviewed and rejected from this batch because current first-party material describes a derivatives contract protocol that can power exchanges rather than a single exchange venue appropriate for one HEI exchange entity.
+
+The existing pending Aequinox, AjuBit, Aktionariat, and Aldrin decisions remain unchanged.
+
+## L-2 relationship
+
+This batch does not change the L-2 localization decision. Canonical growth remains allowed during HOLD. Required Search Console, GA4, indexing, language-switch, and operator-burden evidence remain separate L-2 requirements.
+
+## Next identifiers
+
+```text
+Entity:   hei_ex_001142
+Event:    hei_ev_010108
+Evidence: hei_src_012525
+```
+
+## Deployment decision
+
+This PR changes `records/**`, so production output changes after merge. Per the Cloudflare deployment policy, a branch preview is not required for a reviewed record-only addition. Normal GitHub validation must pass before merge, followed by production verification against the deployed `main` commit and machine/public counts.
+
+## Completion condition
+
+BX56 is complete only after normal record validation, overlap and ID checks, country and URL-safety checks, machine/public consistency, localization output checks, recovery validation, count-semantics validation, merge to `main`, and production verification succeed.

--- a/docs/backlog/consumed/hei_unadded-bx56-four-reviewed-dex-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx56-four-reviewed-dex-records.md
@@ -1,0 +1,51 @@
+# BX56 consumed candidate set — four reviewed DEX records
+
+Date: 2026-08-10  
+Status: consumed
+
+## Added reviewed entities
+
+```text
+MUX Protocol  -> hei_ex_001138
+Storm Trade   -> hei_ex_001139
+Metal X       -> hei_ex_001140
+Hegic         -> hei_ex_001141
+```
+
+## Candidate origin
+
+These names were surfaced by HEI's automated candidate monitoring / external exchange and protocol discovery layer. Monitoring output was used only to identify names for review; it is not canonical evidence.
+
+Each candidate was independently re-reviewed against current first-party and independent public sources before record creation.
+
+## Pre-add overlap checks
+
+For all four entities, current-main repository search and direct canonical-path checks found no existing reviewed record bundle under the selected canonical identity.
+
+Important product-level overlap decisions:
+
+- MUX Protocol, MUX perpetual trading protocols, and the MUX Perpetual Aggregator are represented as one protocol-level exchange entity.
+- Storm Trade web and Telegram trading interfaces are represented as one entity.
+- Metal X / MetalX DEX / related trading surfaces are represented as one protocol-level exchange entity rather than separate records for product labels such as MetalX Swap and MetalX Dex.
+- Hegic's current options products and one-click strategy surfaces remain one Hegic entity.
+
+## Evidence threshold
+
+Each added entity has:
+
+```text
+one current first-party source
+one current independent database / protocol-metrics source
+```
+
+Current activity is supported by non-zero trading or protocol metrics where applicable.
+
+## Excluded candidates
+
+The existing pending rows for Aequinox, AjuBit, Aktionariat, and Aldrin remain pending. BX56 does not weaken their prior evidence or scope decisions merely to increase batch size.
+
+AnyHedge was also reviewed during BX56 research and not added: current first-party material describes a Bitcoin Cash derivatives contract protocol that can power exchanges, rather than a single exchange venue that should be modeled as an HEI exchange entity.
+
+## Result
+
+BX56 consumes only the four candidates that satisfy current HEI reviewed-public thresholds. Monitoring output itself remains non-canonical and no automated status assignment is promoted directly into reviewed data.

--- a/docs/backlog/consumed/hei_unadded-bx56-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx56-source-review-note.md
@@ -1,0 +1,118 @@
+# BX56 source review note — MUX Protocol, Storm Trade, Metal X, Hegic
+
+Date: 2026-08-10
+
+## MUX Protocol
+
+### First-party
+
+`https://docs.mux.network/`
+
+The current documentation describes MUX as a protocol suite containing decentralized perpetual trading protocols and the MUX Perpetual Aggregator. It documents routed liquidity, leveraged trading, and multi-chain deployments.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/mux-protocol`
+
+Current independent metrics report non-zero TVL, perpetual volume, perpetual-aggregator volume, fees, and active addresses.
+
+Canonical use:
+
+```text
+exchange / derivatives identity
+active status
+Arbitrum-led multi-chain ecosystem context
+one protocol-level entity across MUX trading products
+```
+
+BX56 does not infer an exact launch date or encode the historical MCDEX -> MUX transition without a dedicated lineage review.
+
+## Storm Trade
+
+### First-party
+
+`https://docs.storm.tg/introduction/readme`
+
+Current documentation identifies Storm Trade as a decentralized derivatives trading platform on TON with leveraged markets and web and Telegram trading interfaces.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/storm-trade`
+
+Current metrics report non-zero TON TVL, perpetual volume, open interest, fees, and revenue.
+
+Canonical use:
+
+```text
+decentralized derivatives exchange identity
+active status
+TON ecosystem origin
+single entity across web and Telegram interfaces
+```
+
+No exact public launch date or legal jurisdiction is asserted.
+
+## Metal X
+
+### First-party
+
+`https://docs.metalx.com/`
+
+Current Metal X documentation describes a DEX on XPR Network using on-chain order books, multiple order types, and non-custodial wallet control.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/metalx-dex`
+
+Current metrics report non-zero XPR Network DEX volume and TVL. CoinGecko also exposes current Metal X exchange markets, but BX56 keeps the canonical record to two reviewed evidence rows rather than duplicating status evidence.
+
+Canonical use:
+
+```text
+DEX identity
+active status
+XPR Network ecosystem origin
+Metal X / MetalX product identity normalization
+```
+
+BX56 does not split MetalX Dex and MetalX Swap into separate HEI exchange entities.
+
+## Hegic
+
+### First-party
+
+`https://www.hegic.co/`
+
+The current site describes Hegic as a peer-to-pool on-chain options trading protocol on Arbitrum, with BTC and ETH call / put options and one-click strategies.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/hegic`
+
+Current metrics report non-zero options premium and notional volume, TVL, fees, and revenue.
+
+Canonical use:
+
+```text
+on-chain options exchange identity
+active status
+Arbitrum ecosystem origin
+current options products
+```
+
+The first-party site says Hegic has served options traders since February 2020. BX56 does not convert that month-level statement into an exact `launch_date`.
+
+## Excluded inferences
+
+BX56 does not infer or assert:
+
+- legal jurisdiction from blockchain ecosystem origin;
+- regulatory authorization;
+- exact launch dates from month/year statements;
+- product-level entities where one protocol-level exchange identity is better supported;
+- historical predecessor/successor lineage that has not been separately reviewed;
+- activity solely from monitoring output.
+
+## Review conclusion
+
+All four candidates satisfy the current reviewed-public threshold for active DEX / on-chain exchange entities. Each classification is grounded in a current first-party trading description and an independent current activity source.

--- a/records/exchanges/hegic.json
+++ b/records/exchanges/hegic.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001141",
+    "slug": "hegic",
+    "canonical_name": "Hegic",
+    "aliases": ["Hegic Options"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Arbitrum ecosystem",
+    "summary": "On-chain peer-to-pool options trading protocol on Arbitrum offering BTC and ETH call and put options and one-click options strategies.",
+    "official_url_original": "https://www.hegic.co/",
+    "official_domain_original": "hegic.co",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.hegic.co/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party trading surfaces identify Hegic as an on-chain peer-to-pool options trading protocol on Arbitrum with live BTC and ETH options and strategy products. Independent current protocol metrics report non-zero options notional and premium volume, TVL, fees, and revenue. The first-party site states service to options traders since February 2020, but BX56 does not convert that month-level statement into an exact launch date."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012523",
+      "exchange_id": "hei_ex_001141",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Hegic on-chain options trading protocol",
+      "url": "https://www.hegic.co/",
+      "publisher": "Hegic",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.hegic.co/",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site describes Hegic as a peer-to-pool on-chain options trading protocol on Arbitrum and exposes current BTC and ETH call, put, and strategy trading surfaces."
+    },
+    {
+      "id": "hei_src_012524",
+      "exchange_id": "hei_ex_001141",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Hegic current options trading and protocol metrics",
+      "url": "https://defillama.com/protocol/hegic",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero options notional and premium volume, TVL, fees, and revenue, supporting the active classification."
+    }
+  ]
+}

--- a/records/exchanges/metal-x.json
+++ b/records/exchanges/metal-x.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001140",
+    "slug": "metal-x",
+    "canonical_name": "Metal X",
+    "aliases": ["MetalX", "MetalX DEX"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "XPR Network ecosystem",
+    "summary": "Decentralized cryptocurrency exchange on XPR Network using on-chain order books and non-custodial wallet-based trading, alongside AMM swap functionality in the broader Metal X product suite.",
+    "official_url_original": "https://metalx.com/",
+    "official_domain_original": "metalx.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://metalx.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party documentation identifies Metal X as a decentralized exchange on XPR Network with on-chain order books, multiple order types, and user-controlled wallets. Independent exchange and protocol metrics report current markets and non-zero DEX volume. HEI treats the order-book DEX and related MetalX DEX trading surfaces as one protocol-level exchange entity rather than splitting product labels. An exact launch day, legal entity, or jurisdiction is not asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012521",
+      "exchange_id": "hei_ex_001140",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "What is Metal X?",
+      "url": "https://docs.metalx.com/",
+      "publisher": "Metal X",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.metalx.com/",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation describes Metal X as a DEX using on-chain order books, non-custodial wallet control, multiple order types, and XPR Network infrastructure."
+    },
+    {
+      "id": "hei_src_012522",
+      "exchange_id": "hei_ex_001140",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "MetalX DEX current volume and liquidity metrics",
+      "url": "https://defillama.com/protocol/metalx-dex",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero XPR Network DEX volume and TVL for MetalX DEX, supporting the active classification."
+    }
+  ]
+}

--- a/records/exchanges/mux-protocol.json
+++ b/records/exchanges/mux-protocol.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001138",
+    "slug": "mux-protocol",
+    "canonical_name": "MUX Protocol",
+    "aliases": ["MUX", "MUX Perpetual Aggregator"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Arbitrum ecosystem",
+    "summary": "Multi-chain decentralized perpetual trading protocol and aggregator offering leveraged markets, pooled liquidity, and routed execution across several EVM networks.",
+    "official_url_original": "https://mux.network/",
+    "official_domain_original": "mux.network",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://mux.network/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party documentation presents MUX as a protocol suite containing decentralized perpetual trading protocols and a perpetual aggregator. Independent current protocol metrics report non-zero perpetual and aggregator volume, TVL, fees, and active addresses. HEI models the MUX trading protocols and aggregator as one protocol-level exchange entity rather than separate product entities. An exact launch date, legal entity, jurisdiction, or MCDEX lineage transition is not asserted here."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012517",
+      "exchange_id": "hei_ex_001138",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "MUX Protocol overview",
+      "url": "https://docs.mux.network/",
+      "publisher": "MUX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.mux.network/",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation describes the MUX protocol suite, including decentralized perpetual trading protocols and the MUX Perpetual Aggregator, with multi-chain trading and routed liquidity."
+    },
+    {
+      "id": "hei_src_012518",
+      "exchange_id": "hei_ex_001138",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "MUX Protocol current protocol and perpetual trading metrics",
+      "url": "https://defillama.com/protocol/mux-protocol",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero TVL, 24-hour and 30-day perpetual volume, perpetual aggregator volume, fees, and active addresses across the MUX protocol suite."
+    }
+  ]
+}

--- a/records/exchanges/storm-trade.json
+++ b/records/exchanges/storm-trade.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001139",
+    "slug": "storm-trade",
+    "canonical_name": "Storm Trade",
+    "aliases": ["Storm", "StormTrade"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "TON ecosystem",
+    "summary": "Decentralized derivatives exchange on TON offering leveraged futures trading through web and Telegram interfaces with on-chain smart-contract execution.",
+    "official_url_original": "https://storm.tg/",
+    "official_domain_original": "storm.tg",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://storm.tg/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party documentation identifies Storm Trade as a decentralized futures and derivatives exchange built on TON, available through web and Telegram interfaces. Independent current protocol metrics report non-zero perpetual volume, open interest, TVL, fees, and revenue. An exact public launch date, legal entity, or jurisdiction is not asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012519",
+      "exchange_id": "hei_ex_001139",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "About Storm Trade",
+      "url": "https://docs.storm.tg/introduction/readme",
+      "publisher": "Storm Trade",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.storm.tg/introduction/readme",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation describes Storm Trade as a decentralized derivatives trading platform on TON with leveraged markets and web and Telegram trading interfaces."
+    },
+    {
+      "id": "hei_src_012520",
+      "exchange_id": "hei_ex_001139",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Storm Trade current protocol and perpetual trading metrics",
+      "url": "https://defillama.com/protocol/storm-trade",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero TON TVL, perpetual volume, open interest, fees, and revenue, supporting the active classification."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds post-D-1000 BX56 with four independently reviewed active decentralized trading entities:

- MUX Protocol
- Storm Trade
- Metal X
- Hegic

Each record uses current first-party identity evidence and independent current activity metrics. Monitoring output is used only for candidate discovery and is not promoted as canonical evidence.

## Data impact

- Entities: 1017 -> 1021
- Events: 1031 -> 1031
- Evidence: 3820 -> 3828

## Scope controls

- no product-level duplication for MUX, Storm Trade, Metal X, or Hegic
- no unsupported exact launch dates or legal jurisdictions
- AnyHedge remains excluded because current sources describe a derivatives contract protocol that can power exchanges rather than one exchange venue
- existing pending Aequinox, AjuBit, Aktionariat, and Aldrin decisions remain unchanged
- L-2 remains HOLD; Language Selection remains blocked

## Validation required

Normal HEI Records, overlap/ID, country, URL-safety, machine/public, localization, recovery, count-semantics, and CI gates must pass before merge. After merge, production must verify against the deployed main commit and counts.