### PR TITLE
Add post-D-1000 BX57 reviewed DEX records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1021,
+    "entities": 1025,
     "events": 1031,
-    "evidence": 3828
+    "evidence": 3836
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX56_2026-08-10.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX57_2026-08-10.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX56, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX57, the current reviewed state is:
 
 ```text
-Entities: 1021
+Entities: 1025
 Events:   1031
-Evidence: 3828
+Evidence: 3836
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX56_2026-08-10.md
+docs/audits/HEI_POST_D1000_GROWTH_BX57_2026-08-10.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX57_2026-08-10.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX57_2026-08-10.md
@@ -1,0 +1,102 @@
+# HEI Post-D-1000 Growth — BX57
+
+Date: 2026-08-10  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX57 adds four independently reviewed decentralized trading entities surfaced through monitoring and re-reviewed before canonical inclusion.
+
+Added reviewed entities:
+
+```text
+Perpl         active  / dex / Monad ecosystem
+Deri Protocol active  / dex / Multi-chain EVM ecosystem
+AwakenSwap    active  / dex / aelf ecosystem
+WX Network    limited / dex / Waves ecosystem
+```
+
+Added evidence: 8  
+Added events: 0
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1025
+Events:   1031
+Evidence: 3836
+```
+
+## Evidence standard
+
+Each record uses current first-party exchange/trading evidence plus an independent current status source.
+
+- Perpl: first-party exchange site plus DefiLlama current perpetual metrics.
+- Deri Protocol: first-party trading site plus DefiLlama current protocol metrics.
+- AwakenSwap: first-party DEX site plus DefiLlama current AMM metrics.
+- WX Network: first-party DEX protocol documentation plus CoinGecko current exchange listing.
+
+Monitoring output remains candidate-discovery input only.
+
+## Status handling
+
+Perpl, Deri Protocol, and AwakenSwap use:
+
+```text
+status: active
+death_reason: null
+death_date: null
+```
+
+WX Network uses:
+
+```text
+status: limited
+death_reason: null
+death_date: null
+```
+
+Current WX first-party materials still expose exchange functionality, but current independent market observations are weak and inconsistent enough that `active` would overstate present use.
+
+## Identity handling
+
+BX57 deliberately avoids identity inflation:
+
+- Deri Protocol versions remain one entity.
+- AwakenSwap and Awaken Finance naming remain one exchange identity.
+- Waves DEX, Waves.Exchange, Waves Exchange, and WX Network are normalized under the current WX Network entity for this batch.
+- Historical name transitions are not converted into precise events without dedicated lineage review.
+
+Deri Protocol is distinct from the existing Derive exchange record.
+
+## Scope controls
+
+BX57 does not infer:
+
+- exact launch dates from incomplete current source wording;
+- legal jurisdiction from ecosystem origin;
+- regulatory authorization;
+- separate entities for Deri versions;
+- exact WX Network rebrand dates;
+- strong active-use status from site availability alone.
+
+## L-2 relationship
+
+This batch does not change the L-2 localization decision. Canonical growth remains allowed during HOLD. Required Search Console, GA4, indexing, language-switch, and operator-burden evidence remain separate L-2 requirements.
+
+## Next identifiers
+
+```text
+Entity:   hei_ex_001146
+Event:    hei_ev_010108
+Evidence: hei_src_012533
+```
+
+## Deployment decision
+
+This PR changes `records/**`, so production output changes after merge. Per the Cloudflare deployment policy, a branch preview is not required for a reviewed record-only addition. Normal GitHub validation must pass before merge, followed by production verification against the deployed `main` commit and machine/public counts.
+
+## Completion condition
+
+BX57 is complete only after normal record validation, overlap and ID checks, country and URL-safety checks, machine/public consistency, localization output checks, recovery validation, count-semantics validation, merge to `main`, and production verification succeed.

--- a/docs/backlog/consumed/hei_unadded-bx57-four-reviewed-dex-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx57-four-reviewed-dex-records.md
@@ -1,0 +1,57 @@
+# BX57 consumed candidate set — four reviewed DEX records
+
+Date: 2026-08-10  
+Status: consumed
+
+## Added reviewed entities
+
+```text
+Perpl         -> hei_ex_001142
+Deri Protocol -> hei_ex_001143
+AwakenSwap    -> hei_ex_001144
+WX Network    -> hei_ex_001145
+```
+
+## Candidate origin
+
+The four names were surfaced from HEI candidate monitoring / external discovery and then independently re-reviewed. Monitoring output itself is not canonical evidence.
+
+## Pre-add overlap checks
+
+Direct current-main path and repository checks found no reviewed bundle for:
+
+```text
+records/exchanges/perpl.json
+records/exchanges/deri-protocol.json
+records/exchanges/awaken-swap.json
+records/exchanges/wx-network.json
+records/exchanges/waves-exchange.json
+```
+
+Related-identity controls:
+
+- Deri Protocol is distinct from the existing Derive record.
+- Current Deri versions are represented as one protocol-level entity; BX57 does not create separate Deri V4 lineage records.
+- AwakenSwap / Awaken Finance naming is normalized to one exchange entity.
+- Waves DEX, Waves.Exchange, Waves Exchange, and WX Network naming is normalized to one current WX Network entity in this batch. A separate lineage/rebrand event is not asserted without dedicated historical review.
+
+## Evidence threshold
+
+Each entity has current first-party exchange/trading evidence plus an independent current status source.
+
+```text
+Perpl         first-party exchange + DefiLlama current perp metrics
+Deri Protocol first-party exchange + DefiLlama current protocol metrics
+AwakenSwap    first-party exchange + DefiLlama current protocol metrics
+WX Network    first-party exchange docs + CoinGecko current exchange listing
+```
+
+## Status boundary
+
+Perpl, Deri Protocol, and AwakenSwap are `active` because current first-party trading surfaces and independent current activity evidence are both present.
+
+WX Network is `limited`, not `active`: first-party trading functionality remains published and independent exchange data still tracks the venue, but observed current market liquidity and volume are very small or inconsistent. BX57 preserves this uncertainty rather than treating mere site availability as strong active-use evidence.
+
+## Result
+
+BX57 consumes only these four reviewed candidates. No automated monitoring status or generic list entry is promoted directly into canonical data.

--- a/docs/backlog/consumed/hei_unadded-bx57-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx57-source-review-note.md
@@ -1,0 +1,115 @@
+# BX57 source review note — Perpl, Deri Protocol, AwakenSwap, WX Network
+
+Date: 2026-08-10
+
+## Perpl
+
+### First-party
+
+`https://perpl.xyz/`
+
+The current site identifies Perpl as a fully on-chain perpetual futures exchange on Monad using a CLOB-based design and links to live trading.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/perpl`
+
+Current independent metrics report non-zero perpetual volume, open interest, fees, revenue, and TVL on Monad.
+
+Canonical use:
+
+```text
+perpetual DEX identity
+active status
+Monad ecosystem origin
+```
+
+No exact launch date, legal entity, or jurisdiction is asserted.
+
+## Deri Protocol
+
+### First-party
+
+`https://deri.io/`
+
+The current first-party site exposes Deri trading entry points and lists futures, options, powers, and gamma products. Current Deri documentation describes the protocol as an on-chain decentralized derivatives exchange spanning multiple networks.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/deri`
+
+Current independent metrics report non-zero Deri TVL across Linea, BSC, Arbitrum, ZKsync Era, and other EVM networks.
+
+Canonical use:
+
+```text
+decentralized derivatives exchange identity
+active status
+multi-chain EVM ecosystem origin
+```
+
+BX57 does not encode Deri version history as separate entities or transition events.
+
+## AwakenSwap
+
+### First-party
+
+`https://awaken.finance/`
+
+The current site presents AwakenSwap as an all-in-one DEX on aelf with spot trading, token swaps, smart routing, liquidity tools, and limit orders. Its documentation describes a non-custodial AMM exchange.
+
+### Independent status corroboration
+
+`https://defillama.com/protocol/awaken-swap`
+
+Current independent metrics report non-zero aelf TVL and classify Awaken Swap as an AMM DEX.
+
+Canonical use:
+
+```text
+AMM DEX identity
+active status
+aelf ecosystem origin
+```
+
+No exact launch date, legal entity, or jurisdiction is asserted.
+
+## WX Network
+
+### First-party
+
+`https://docs.waves.exchange/en/waves-exchange/waves-exchange-protocol`
+
+Current WX Network documentation describes a decentralized exchange with a matcher-based order book and blockchain-validated exchange transactions. Current user documentation still exposes spot trading, swaps, liquidity pools, and exchange APIs.
+
+### Independent status corroboration
+
+`https://www.coingecko.com/en/exchanges/wx-network`
+
+CoinGecko continues to identify Waves.Exchange as relaunched under WX Network and tracks the venue as a decentralized exchange. Current observations show very small or inconsistent market volume and liquidity.
+
+Canonical use:
+
+```text
+DEX identity
+limited status
+Waves ecosystem origin
+Waves DEX / Waves.Exchange / WX Network alias continuity
+```
+
+BX57 does not convert naming continuity into exact rebrand events or predecessor/successor records without a dedicated historical lineage review.
+
+## Excluded inferences
+
+BX57 does not infer or assert:
+
+- exact launch dates where current source wording is insufficient;
+- legal jurisdiction from blockchain ecosystem origin;
+- regulatory authorization;
+- separate Deri version entities;
+- strong active-use status for WX Network merely because the interface and documentation remain available;
+- exact Waves DEX -> Waves.Exchange -> WX Network transition dates without dedicated event review.
+
+## Review conclusion
+
+Perpl, Deri Protocol, and AwakenSwap satisfy HEI's current reviewed-public threshold for `active`. WX Network satisfies the threshold for a reviewed entity but is conservatively classified `limited` because current trading availability is stronger than current market-activity evidence.

--- a/records/exchanges/awaken-swap.json
+++ b/records/exchanges/awaken-swap.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001144",
+    "slug": "awaken-swap",
+    "canonical_name": "AwakenSwap",
+    "aliases": ["Awaken Swap", "Awaken Finance"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "aelf ecosystem",
+    "summary": "Non-custodial AMM decentralized exchange on aelf supporting token swaps, liquidity pools, routing, spot trading tools, and limit-order functionality.",
+    "official_url_original": "https://awaken.finance/",
+    "official_domain_original": "awaken.finance",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://awaken.finance/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party site and documentation identify AwakenSwap as an all-in-one DEX on aelf with non-custodial AMM swaps, liquidity tools, spot-trading infrastructure, and limit orders. Independent current protocol metrics report non-zero aelf TVL. An exact launch date, legal entity, or jurisdiction is not asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012529",
+      "exchange_id": "hei_ex_001144",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "AwakenSwap current DEX platform",
+      "url": "https://awaken.finance/",
+      "publisher": "AwakenSwap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://awaken.finance/",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site presents AwakenSwap as an aelf DEX with spot trading, instant swaps, routing, liquidity provision, and limit-order tools."
+    },
+    {
+      "id": "hei_src_012530",
+      "exchange_id": "hei_ex_001144",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Awaken Swap current protocol metrics",
+      "url": "https://defillama.com/protocol/awaken-swap",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero aelf TVL for Awaken Swap and classify it as an AMM DEX, supporting the active classification."
+    }
+  ]
+}

--- a/records/exchanges/deri-protocol.json
+++ b/records/exchanges/deri-protocol.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001143",
+    "slug": "deri-protocol",
+    "canonical_name": "Deri Protocol",
+    "aliases": ["Deri", "Deri V4"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Multi-chain EVM ecosystem",
+    "summary": "Decentralized on-chain derivatives exchange supporting perpetual futures, everlasting options, power perpetuals, and gamma-swap products across multiple EVM networks.",
+    "official_url_original": "https://deri.io/",
+    "official_domain_original": "deri.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://deri.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party site and documentation present Deri Protocol as an on-chain decentralized derivatives exchange with live futures, options, powers, and gamma products. Independent current protocol metrics report non-zero TVL across several EVM networks. BX57 treats current Deri versions as one protocol-level entity and does not infer version-transition events without a separate lineage review."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012527",
+      "exchange_id": "hei_ex_001143",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Deri Protocol current derivatives trading platform",
+      "url": "https://deri.io/",
+      "publisher": "Deri Protocol",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://deri.io/",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site identifies Deri Protocol, exposes current trading entry points, and lists futures, options, powers, and gamma derivative products."
+    },
+    {
+      "id": "hei_src_012528",
+      "exchange_id": "hei_ex_001143",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Deri current protocol metrics",
+      "url": "https://defillama.com/protocol/deri",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero Deri TVL across Linea, BSC, Arbitrum, ZKsync Era and other supported networks, supporting the active classification."
+    }
+  ]
+}

--- a/records/exchanges/perpl.json
+++ b/records/exchanges/perpl.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001142",
+    "slug": "perpl",
+    "canonical_name": "Perpl",
+    "aliases": ["Perpl Exchange"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Monad ecosystem",
+    "summary": "Fully on-chain perpetual futures exchange on Monad using a central-limit-order-book trading model with on-chain execution and collateral.",
+    "official_url_original": "https://perpl.xyz/",
+    "official_domain_original": "perpl.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://perpl.xyz/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party site identifies Perpl as a fully on-chain CLOB-based perpetual futures DEX on Monad. Independent current protocol metrics report non-zero perpetual volume, open interest, fees, revenue, and TVL. An exact launch date, legal entity, or jurisdiction is not asserted."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012525",
+      "exchange_id": "hei_ex_001142",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Perpl on-chain perpetual futures exchange",
+      "url": "https://perpl.xyz/",
+      "publisher": "Perpl",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://perpl.xyz/",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site describes Perpl as a fully on-chain CLOB-based perpetual futures DEX on Monad and links to the live trading application."
+    },
+    {
+      "id": "hei_src_012526",
+      "exchange_id": "hei_ex_001142",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Perpl current perpetual trading metrics",
+      "url": "https://defillama.com/protocol/perpl",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero Monad perpetual volume, open interest, fees, revenue, and TVL, supporting the active classification."
+    }
+  ]
+}

--- a/records/exchanges/wx-network.json
+++ b/records/exchanges/wx-network.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001145",
+    "slug": "wx-network",
+    "canonical_name": "WX Network",
+    "aliases": ["Waves.Exchange", "Waves Exchange", "Waves DEX"],
+    "type": "dex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Waves ecosystem",
+    "summary": "Decentralized spot exchange and wallet platform on Waves using a matcher-based order book with blockchain-validated settlement, alongside swap and liquidity-pool tools.",
+    "official_url_original": "https://wx.network/",
+    "official_domain_original": "wx.network",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://wx.network/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-10",
+    "notes": "Current first-party WX Network documentation still describes a decentralized exchange, spot trading, matcher APIs, swaps, and Waves-based custody. Independent current exchange data still lists WX Network / Waves.Exchange and recently updated spot pairs, but reported liquidity and volume are very small and inconsistent across observations. BX57 therefore uses limited rather than active. Historical Waves DEX -> Waves.Exchange -> WX Network naming is preserved as aliases here without asserting separate lineage records or exact rebrand dates."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012531",
+      "exchange_id": "hei_ex_001145",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "WX Network decentralized exchange protocol",
+      "url": "https://docs.waves.exchange/en/waves-exchange/waves-exchange-protocol",
+      "publisher": "WX Network",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.waves.exchange/en/waves-exchange/waves-exchange-protocol",
+      "accessed_at": "2026-08-10",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation describes WX Network as a decentralized exchange with matcher-based order execution and blockchain validation, while current user documentation continues to expose spot trading and swap functionality."
+    },
+    {
+      "id": "hei_src_012532",
+      "exchange_id": "hei_ex_001145",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "WX Network current exchange markets",
+      "url": "https://www.coingecko.com/en/exchanges/wx-network",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-10",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent exchange listing identifies Waves.Exchange as relaunched under WX Network and continues to expose exchange-market observations, but current market depth and volume are very low or variable; this supports a limited rather than fully active classification."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds post-D-1000 BX57 with four independently reviewed decentralized trading entities:

- Perpl — active
- Deri Protocol — active
- AwakenSwap — active
- WX Network — limited

Each record uses current first-party exchange/trading evidence plus an independent current status source. Monitoring output is used only for candidate discovery and is not canonical evidence.

## Data impact

- Entities: 1021 -> 1025
- Events: 1031 -> 1031
- Evidence: 3828 -> 3836

## Scope controls

- Deri Protocol is distinct from the existing Derive record
- Deri versions remain one protocol-level entity; no synthetic version-transition events
- AwakenSwap / Awaken Finance are normalized to one exchange entity
- Waves DEX / Waves.Exchange / WX Network are normalized under WX Network without inventing exact rebrand dates
- WX Network is deliberately `limited` because current first-party trading functionality remains available while independent market activity is very small or inconsistent
- L-2 remains HOLD; Language Selection remains blocked

## Validation required

Normal HEI Records, overlap/ID, country, URL-safety, machine/public, localization, recovery, count-semantics, and CI gates must pass before merge. After merge, production must verify against the deployed main commit and counts.