### PR TITLE
Add post-D-1000 BX58 reviewed DEX records

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1025,
+    "entities": 1029,
     "events": 1031,
-    "evidence": 3836
+    "evidence": 3844
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX57_2026-08-10.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX58_2026-08-11.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX57, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX58, the current reviewed state is:
 
 ```text
-Entities: 1025
+Entities: 1029
 Events:   1031
-Evidence: 3836
+Evidence: 3844
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX57_2026-08-10.md
+docs/audits/HEI_POST_D1000_GROWTH_BX58_2026-08-11.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX58_2026-08-11.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX58_2026-08-11.md
@@ -1,0 +1,46 @@
+# HEI Post-D-1000 Growth — BX58
+
+Date: 2026-08-11
+Status: reviewed batch candidate
+
+## Scope
+
+BX58 adds four independently reviewed decentralized trading entities:
+
+- Arcus — `active`
+- RISEx — `active`
+- AnyHedge — `active`
+- Verus Market — `active`
+
+## Count impact
+
+```text
+Before BX58
+Entities: 1025
+Events:   1031
+Evidence: 3836
+
+After BX58
+Entities: 1029
+Events:   1031
+Evidence: 3844
+```
+
+No canonical event is added in this batch.
+
+## Review boundaries
+
+- Arcus is one venue; `Arcus Perps` is an alias/product surface, not a separate entity.
+- Extended Perps was reviewed and rejected from BX58 because `Extended` already exists canonically.
+- RISEx is normalized as the RISE Chain exchange and does not invent an exact launch date.
+- AnyHedge is recorded at protocol level as the peer-to-peer BCH derivatives venue; BCH Bull is not duplicated as a separate exchange in this batch.
+- Verus Market is the protocol-level Verus AMM/conversion venue; the Verus-Ethereum Bridge is not duplicated as an exchange entity.
+- Monitoring output is discovery-only and is not canonical evidence.
+
+## Evidence standard
+
+Each entity has a current first-party source and an independent current status/market-data source. Status is based on current trading availability or measurable current activity, not on the monitoring candidate label.
+
+## Localization
+
+L-2 remains `HOLD`. This reviewed canonical growth does not authorize broader translation or a third language.

--- a/docs/backlog/consumed/hei_unadded-bx58-four-reviewed-dex-records.md
+++ b/docs/backlog/consumed/hei_unadded-bx58-four-reviewed-dex-records.md
@@ -1,0 +1,18 @@
+# BX58 — Four reviewed DEX records
+
+Consumed: 2026-08-11
+
+Reviewed additions:
+
+- Arcus — active
+- RISEx — active
+- AnyHedge — active
+- Verus Market — active
+
+Discovery inputs came from the verified-unadded/monitoring candidate layers, but each canonical record was independently re-reviewed against current first-party and independent sources before inclusion.
+
+Rejected from this batch as a duplicate:
+
+- Extended Perps — canonical `Extended` already exists; product naming is not a new entity.
+
+Count impact: 1025 → 1029 entities; events remain 1031; evidence 3836 → 3844.

--- a/docs/backlog/consumed/hei_unadded-bx58-source-review-note.md
+++ b/docs/backlog/consumed/hei_unadded-bx58-source-review-note.md
@@ -1,0 +1,33 @@
+# BX58 source review note
+
+Date: 2026-08-11
+
+## Arcus
+
+First-party: `https://arcus.xyz/`
+
+The current site identifies Arcus as a decentralized exchange on Robinhood Chain, says Spot Beta is open to eligible users, and describes staged access to Perps Beta. DefiLlama independently reports current spot/perpetual volume, open interest, and TVL. Decision: `active`.
+
+## RISEx
+
+First-party: `https://www.rise.trade/en`
+
+The current surface presents the unified exchange and a live trading entry point. DefiLlama independently identifies RISEx as a fully on-chain perpetuals exchange on RISE Chain with current volume, open interest, and TVL. Decision: `active`.
+
+## AnyHedge
+
+First-party: `https://anyhedge.com/`
+
+The current site describes permissionless, non-custodial on-chain leverage and hedge trading on Bitcoin Cash and identifies BCH Bull as a trader-facing implementation. DefiLlama reports current derivatives activity. Decision: `active` at protocol level; BCH Bull is not duplicated here.
+
+## Verus Market
+
+First-party: `https://docs.verus.io/currencies/`
+
+Verus documentation states that basket currencies operate as AMMs and support reserve-to-reserve conversions. DefiLlama independently classifies Verus Market as an AMM DEX and reports current TVL, volume, fees, and revenue. Decision: `active`.
+
+## Duplicate rejection
+
+`Extended Perps` was not added. The current repository already contains canonical `Extended`; treating the product label as a new entity would duplicate the venue.
+
+Monitoring/candidate sources are discovery-only and are not cited as canonical evidence.

--- a/records/exchanges/anyhedge.json
+++ b/records/exchanges/anyhedge.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001148",
+    "slug": "anyhedge",
+    "canonical_name": "AnyHedge",
+    "aliases": [],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Bitcoin Cash ecosystem",
+    "summary": "Permissionless, non-custodial on-chain derivatives protocol on Bitcoin Cash for leveraged long positions and fully collateralized peer-to-peer hedge or futures-style contracts.",
+    "official_url_original": "https://anyhedge.com/",
+    "official_domain_original": "anyhedge.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://anyhedge.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-11",
+    "notes": "Current first-party site describes permissionless, non-custodial leverage trading and identifies AnyHedge as the technology behind BCH Bull. Independent current derivatives metrics report non-zero perpetual volume and TVL. HEI treats the protocol-level peer-to-peer derivatives market as a DEX-like trading venue rather than creating BCH Bull as a duplicate entity in this batch."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012537",
+      "exchange_id": "hei_ex_001148",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "AnyHedge decentralized leverage trading",
+      "url": "https://anyhedge.com/",
+      "publisher": "AnyHedge",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://anyhedge.com/",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site describes leveraged long and hedge positions on Bitcoin Cash as permissionless, non-custodial, and on-chain and identifies BCH Bull as a live trader-facing implementation."
+    },
+    {
+      "id": "hei_src_012538",
+      "exchange_id": "hei_ex_001148",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "AnyHedge current derivatives metrics",
+      "url": "https://defillama.com/protocol/anyhedge",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-11",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics classify AnyHedge under derivatives and report non-zero Bitcoin Cash perpetual volume and protocol TVL, supporting active classification."
+    }
+  ]
+}

--- a/records/exchanges/arcus.json
+++ b/records/exchanges/arcus.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001146",
+    "slug": "arcus",
+    "canonical_name": "Arcus",
+    "aliases": ["Arcus Perps"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Robinhood Chain ecosystem",
+    "summary": "Self-custodial decentralized exchange on Robinhood Chain offering live spot trading in tokenized assets and a staged perpetual-futures beta across equities, crypto, commodities, and indices.",
+    "official_url_original": "https://arcus.xyz/",
+    "official_domain_original": "arcus.xyz",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://arcus.xyz/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-11",
+    "notes": "Current first-party site states that Arcus is live in beta, with spot open to eligible users and perpetuals rolling out by cohort. Independent current metrics report non-zero spot and perpetual volume and TVL. HEI records Arcus as one venue and keeps Arcus Perps as an alias rather than creating a product duplicate."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012533",
+      "exchange_id": "hei_ex_001146",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Arcus decentralized exchange and beta trading status",
+      "url": "https://arcus.xyz/",
+      "publisher": "Arcus",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://arcus.xyz/",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party site identifies Arcus as a decentralized exchange on Robinhood Chain, exposes live spot trading, and describes the staged perpetuals beta."
+    },
+    {
+      "id": "hei_src_012534",
+      "exchange_id": "hei_ex_001146",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Arcus current spot and perpetual trading metrics",
+      "url": "https://defillama.com/protocol/arcus",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-11",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics report non-zero DEX volume, perpetual volume, open interest, and TVL on Robinhood Chain, supporting active classification."
+    }
+  ]
+}

--- a/records/exchanges/risex.json
+++ b/records/exchanges/risex.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001147",
+    "slug": "risex",
+    "canonical_name": "RISEx",
+    "aliases": ["RISE Exchange"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "RISE ecosystem",
+    "summary": "Fully on-chain perpetual futures exchange on RISE Chain with self-custodial trading, collateralized positions, and a composable order-book trading surface.",
+    "official_url_original": "https://www.rise.trade/en",
+    "official_domain_original": "rise.trade",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.rise.trade/en",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-11",
+    "notes": "Current first-party trading surface identifies RISEx as the unified exchange and exposes a live trading entry point. Independent current metrics identify RISEx as a fully on-chain perpetuals exchange on RISE Chain with substantial non-zero perpetual volume, open interest, and TVL."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012535",
+      "exchange_id": "hei_ex_001147",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "RISEx unified exchange trading surface",
+      "url": "https://www.rise.trade/en",
+      "publisher": "RISEx",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.rise.trade/en",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party surface presents RISEx as the unified exchange and exposes a live Trade now entry point."
+    },
+    {
+      "id": "hei_src_012536",
+      "exchange_id": "hei_ex_001147",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "RISEx current perpetual trading metrics",
+      "url": "https://defillama.com/protocol/risex",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-11",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics identify RISEx as a fully on-chain perpetuals exchange on RISE Chain and report substantial non-zero perpetual volume, open interest, and TVL."
+    }
+  ]
+}

--- a/records/exchanges/verus-market.json
+++ b/records/exchanges/verus-market.json
@@ -1,0 +1,57 @@
+{
+  "entity": {
+    "id": "hei_ex_001149",
+    "slug": "verus-market",
+    "canonical_name": "Verus Market",
+    "aliases": ["Verus DeFi"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Verus ecosystem",
+    "summary": "Protocol-level decentralized exchange on Verus using reserve-backed basket currencies as automated market makers for on-chain and cross-chain asset conversions.",
+    "official_url_original": "https://docs.verus.io/currencies/",
+    "official_domain_original": "docs.verus.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://docs.verus.io/currencies/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-11",
+    "notes": "Current first-party documentation describes Verus basket currencies as AMMs that support reserve-to-reserve conversions and the current Verus site identifies protocol-level DeFi conversion activity. Independent current metrics classify Verus Market as an AMM DEX with non-zero volume, fees, revenue, and TVL. The Verus-Ethereum Bridge is not modeled as a separate exchange entity here."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012539",
+      "exchange_id": "hei_ex_001149",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Verus basket currencies and AMM conversions",
+      "url": "https://docs.verus.io/currencies/",
+      "publisher": "Verus",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.verus.io/currencies/",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation states that Verus basket currencies function as AMMs with reserves and permit reserve-to-reserve conversions, establishing the protocol-level decentralized exchange mechanism."
+    },
+    {
+      "id": "hei_src_012540",
+      "exchange_id": "hei_ex_001149",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Verus Market current DEX metrics",
+      "url": "https://defillama.com/protocol/verus-market",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-11",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Independent current metrics classify Verus Market as an AMM DEX on Verus and report non-zero DEX volume, fees, revenue, and TVL, supporting active classification."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds post-D-1000 BX58 with four independently reviewed decentralized trading entities:

- Arcus — active
- RISEx — active
- AnyHedge — active
- Verus Market — active

Each record uses current first-party evidence plus an independent current status/market-data source. Monitoring output is discovery-only and is not canonical evidence.

## Data impact

- Entities: 1025 -> 1029
- Events: 1031 -> 1031
- Evidence: 3836 -> 3844

## Scope controls

- Extended Perps was explicitly rejected as a duplicate because canonical Extended already exists
- Arcus / Arcus Perps remain one venue
- AnyHedge is modeled at protocol level; BCH Bull is not duplicated
- Verus Market is the protocol-level AMM/conversion venue; the Verus-Ethereum Bridge is not duplicated as an exchange
- no synthetic events or invented launch dates
- L-2 remains HOLD; Language Selection remains blocked

## Validation required

Normal HEI Records, overlap/ID, country, URL-safety, machine/public, localization, recovery, count-semantics, and CI gates must pass before merge. After merge, production must verify against the deployed main commit and counts.