### PR TITLE
Add conservative BitradeX limited record

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -8,7 +8,7 @@
   "reviewed_counts": {
     "entities": 1030,
     "events": 1032,
-    "evidence": 3847
+    "evidence": 3849
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",

--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1029,
-    "events": 1031,
-    "evidence": 3844
+    "entities": 1030,
+    "events": 1032,
+    "evidence": 3847
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX58_2026-08-11.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX59_2026-08-11.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -57,7 +57,7 @@ Reviewed canonical growth continues after D-1000. With post-D-1000 BX59, the cur
 ```text
 Entities: 1030
 Events:   1032
-Evidence: 3847
+Evidence: 3849
 ```
 
 Current post-D-1000 growth authority:

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX58, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX59, the current reviewed state is:
 
 ```text
-Entities: 1029
-Events:   1031
-Evidence: 3844
+Entities: 1030
+Events:   1032
+Evidence: 3847
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX58_2026-08-11.md
+docs/audits/HEI_POST_D1000_GROWTH_BX59_2026-08-11.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX59_2026-08-11.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX59_2026-08-11.md
@@ -11,26 +11,28 @@ BX59 adds one independently reviewed centralized exchange record for BitradeX wi
 Added reviewed entity candidate:
 
 ```text
-BitradeX  limited / cex / origin unresolved
+BitradeX  limited / cex / United Kingdom
 ```
 
 Added event: 1  
-Added evidence: 3
+Added evidence: 5
 
 Projected reviewed public state after merge:
 
 ```text
 Entities: 1030
 Events:   1032
-Evidence: 3847
+Evidence: 3849
 ```
 
 ## Evidence standard
 
-The record separates current entity/status evidence from the August incident signal.
+The record separates current entity/status evidence, corporate-origin evidence, and the August incident signal.
 
 - BitradeX first-party public website establishes current exchange identity and a live official domain.
 - CoinMarketCap provides an independent current market listing with spot and derivatives data and links to the same official domain.
+- BitradeX's registration page identifies BITRADEX FINTECH LIMITED, company number 16322746, as its legal company entity in England and Wales.
+- UK Companies House independently confirms BITRADEX FINTECH LIMITED, company number 16322746, as an active private limited company incorporated on 2025-03-18.
 - A 2026-08-11 Japanese community post is retained as low-reliability event evidence because it summarizes an alleged BitradeX announcement about staged return/release of existing user assets while explicitly warning that detailed rules were not yet available.
 
 HEI has not yet captured the underlying first-party August notice or detailed release rules.
@@ -77,7 +79,8 @@ Those claims require the primary August notice or stronger independent evidence 
 - `BitradeX` is the canonical entity name.
 - `Bitrade X` is retained only as a search/identity alias.
 - No exact launch date is invented from the year-only secondary description.
-- No country/origin is inferred from promotional corporate claims without dedicated jurisdiction review.
+- `United Kingdom` is used as the current verified corporate origin because BitradeX links the platform to BITRADEX FINTECH LIMITED and Companies House independently confirms that UK entity. This does not backdate the UK company identity to BitradeX's earlier claimed platform history.
+- Regulatory-authorization claims on BitradeX's registration page are not promoted without authority-specific verification.
 - Current public trading surfaces are not treated as proof that all customer assets are freely withdrawable.
 
 ## Identifier allocation
@@ -85,7 +88,7 @@ Those claims require the primary August notice or stronger independent evidence 
 ```text
 Entity:   hei_ex_001150
 Event:    hei_ev_010108
-Evidence: hei_src_012541 through hei_src_012543
+Evidence: hei_src_012541 through hei_src_012545
 ```
 
 Exact repository search before branch creation found these identifiers unused on the reviewed main state.
@@ -101,7 +104,7 @@ Evidence: 3844
 After BX59
 Entities: 1030
 Events:   1032
-Evidence: 3847
+Evidence: 3849
 ```
 
 ## L-2 relationship

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX59_2026-08-11.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX59_2026-08-11.md
@@ -1,0 +1,119 @@
+# HEI Post-D-1000 Growth — BX59
+
+Date: 2026-08-11  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX59 adds one independently reviewed centralized exchange record for BitradeX with a deliberately conservative status and event boundary.
+
+Added reviewed entity candidate:
+
+```text
+BitradeX  limited / cex / origin unresolved
+```
+
+Added event: 1  
+Added evidence: 3
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1030
+Events:   1032
+Evidence: 3847
+```
+
+## Evidence standard
+
+The record separates current entity/status evidence from the August incident signal.
+
+- BitradeX first-party public website establishes current exchange identity and a live official domain.
+- CoinMarketCap provides an independent current market listing with spot and derivatives data and links to the same official domain.
+- A 2026-08-11 Japanese community post is retained as low-reliability event evidence because it summarizes an alleged BitradeX announcement about staged return/release of existing user assets while explicitly warning that detailed rules were not yet available.
+
+HEI has not yet captured the underlying first-party August notice or detailed release rules.
+
+## Status handling
+
+BitradeX uses:
+
+```text
+status: limited
+death_reason: null
+death_date: null
+confidence: medium
+```
+
+The public site and independent market listing remain live, so `inactive` or `dead` would overstate the available evidence. The August public signal is material enough that `active` would also overstate normal availability. `limited` is therefore the conservative interim classification.
+
+## Event handling
+
+BX59 adds:
+
+```text
+event_type: other
+event_status_effect: limited
+impact_level: high
+```
+
+The event is titled `Asset-release restrictions reported during platform changes` and is intentionally framed as a reported restriction, not a confirmed technical or financial root cause.
+
+BX59 does **not** assert:
+
+- a hot-wallet hack;
+- insolvency;
+- bankruptcy;
+- scam/rug classification;
+- terminal shutdown;
+- that recruiting new users is a confirmed condition for faster asset release;
+- that any particular daily release rate is confirmed.
+
+Those claims require the primary August notice or stronger independent evidence before canonical promotion.
+
+## Identity and scope controls
+
+- `BitradeX` is the canonical entity name.
+- `Bitrade X` is retained only as a search/identity alias.
+- No exact launch date is invented from the year-only secondary description.
+- No country/origin is inferred from promotional corporate claims without dedicated jurisdiction review.
+- Current public trading surfaces are not treated as proof that all customer assets are freely withdrawable.
+
+## Identifier allocation
+
+```text
+Entity:   hei_ex_001150
+Event:    hei_ev_010108
+Evidence: hei_src_012541 through hei_src_012543
+```
+
+Exact repository search before branch creation found these identifiers unused on the reviewed main state.
+
+## Count impact
+
+```text
+Before BX59
+Entities: 1029
+Events:   1031
+Evidence: 3844
+
+After BX59
+Entities: 1030
+Events:   1032
+Evidence: 3847
+```
+
+## L-2 relationship
+
+This reviewed data-growth candidate does not change the L-2 localization decision. L-2 remains `HOLD / EVIDENCE CAPTURE`, and no additional language is authorized.
+
+## Deployment decision
+
+This PR changes `records/**`, so public output changes after merge. Under the Cloudflare deployment policy, a branch preview is not required for a reviewed record-only addition. GitHub validation must pass before merge. After merge, production verification must confirm the deployed `main` commit and machine/public count consistency.
+
+## Completion condition
+
+BX59 is complete only after record validation, overlap/duplicate checks, ID-collision checks, country/origin checks, URL-safety checks, machine/public consistency, localization output checks, recovery validation, count-semantics validation, merge to `main`, and production verification succeed.
+
+If the underlying BitradeX August notice or detailed release rules become available before merge, the event and evidence should be strengthened in this PR rather than converting an unverified interpretation into a stronger canonical claim.

--- a/records/exchanges/bitradex.json
+++ b/records/exchanges/bitradex.json
@@ -9,7 +9,7 @@
     "death_reason": null,
     "launch_date": null,
     "death_date": null,
-    "country_or_origin": null,
+    "country_or_origin": "United Kingdom",
     "summary": "Centralized cryptocurrency exchange and AI-oriented digital asset platform whose public site and current market listings remain live while August 2026 public reports describe material restrictions on access to existing user assets.",
     "official_url_original": "https://www.bitradex.ai/",
     "official_domain_original": "bitradex.ai",
@@ -19,7 +19,7 @@
     "successor_id": null,
     "confidence": "medium",
     "last_verified_at": "2026-08-11",
-    "notes": "The current first-party site remains publicly available and CoinMarketCap continues to expose BitradeX spot and derivatives market pages. Public Japanese reports on 2026-08-11 described staged release or return of existing user assets during ongoing platform changes, but HEI has not yet captured the underlying first-party August notice or the detailed release rules. HEI therefore uses `limited` conservatively and does not infer a terminal shutdown, insolvency, hack, scam/rug classification, or referral-conditioned asset release from the available reviewed evidence."
+    "notes": "The current first-party site remains publicly available and CoinMarketCap continues to expose BitradeX spot and derivatives market pages. BitradeX identifies BITRADEX FINTECH LIMITED as its legal operator, and the UK Companies House register confirms company 16322746 as an active private limited company incorporated in England and Wales on 2025-03-18; HEI therefore uses United Kingdom as the verified current corporate origin without backdating that company identity to the platform's earlier claimed history. Public Japanese reports on 2026-08-11 described staged release or return of existing user assets during ongoing platform changes, but HEI has not yet captured the underlying first-party August notice or the detailed release rules. HEI therefore uses `limited` conservatively and does not infer a terminal shutdown, insolvency, hack, scam/rug classification, or referral-conditioned asset release from the available reviewed evidence."
   },
   "events": [
     {
@@ -82,6 +82,36 @@
       "reliability": "low",
       "claim_scope": "event",
       "notes": "Japanese community post characterizes a BitradeX announcement as saying existing principal could not be returned immediately and would be released gradually. The post itself states that detailed rules were not yet available and avoids a definitive conclusion. HEI uses it only as a monitoring-quality event signal, not as proof of hack, insolvency, scam, or referral-linked release mechanics."
+    },
+    {
+      "id": "hei_src_012544",
+      "exchange_id": "hei_ex_001150",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Registration Information & Licenses",
+      "url": "https://help.bitradex.ai/hc/en-001/articles/15432623431055-Registration-Information-Licenses",
+      "publisher": "BitradeX",
+      "published_at": "2026-03-13",
+      "archived_url": "https://web.archive.org/web/*/https://help.bitradex.ai/hc/en-001/articles/15432623431055-Registration-Information-Licenses",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party registration page identifies BITRADEX FINTECH LIMITED, company number 16322746, as the legal company entity and states its registration jurisdiction is England and Wales. This evidence supports the operator linkage only; regulatory-authorization claims on the page require separate authority-specific verification."
+    },
+    {
+      "id": "hei_src_012545",
+      "exchange_id": "hei_ex_001150",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "BITRADEX FINTECH LIMITED company overview",
+      "url": "https://find-and-update.company-information.service.gov.uk/company/16322746",
+      "publisher": "UK Companies House",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://find-and-update.company-information.service.gov.uk/company/16322746",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Official UK company register confirms BITRADEX FINTECH LIMITED, company number 16322746, as an active private limited company incorporated on 2025-03-18 with a registered office in England. This establishes the current corporate record but does not independently establish BitradeX platform activity before incorporation."
     }
   ]
 }

--- a/records/exchanges/bitradex.json
+++ b/records/exchanges/bitradex.json
@@ -1,0 +1,87 @@
+{
+  "entity": {
+    "id": "hei_ex_001150",
+    "slug": "bitradex",
+    "canonical_name": "BitradeX",
+    "aliases": ["Bitrade X"],
+    "type": "cex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": null,
+    "summary": "Centralized cryptocurrency exchange and AI-oriented digital asset platform whose public site and current market listings remain live while August 2026 public reports describe material restrictions on access to existing user assets.",
+    "official_url_original": "https://www.bitradex.ai/",
+    "official_domain_original": "bitradex.ai",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.bitradex.ai/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-11",
+    "notes": "The current first-party site remains publicly available and CoinMarketCap continues to expose BitradeX spot and derivatives market pages. Public Japanese reports on 2026-08-11 described staged release or return of existing user assets during ongoing platform changes, but HEI has not yet captured the underlying first-party August notice or the detailed release rules. HEI therefore uses `limited` conservatively and does not infer a terminal shutdown, insolvency, hack, scam/rug classification, or referral-conditioned asset release from the available reviewed evidence."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010108",
+      "exchange_id": "hei_ex_001150",
+      "event_type": "other",
+      "event_date": "2026-08-11",
+      "title": "Asset-release restrictions reported during platform changes",
+      "description": "A Japanese community report summarizing a BitradeX announcement said existing user assets could not be returned in full immediately and would be released in stages, while detailed release rules were still pending.",
+      "confidence": "medium",
+      "impact_level": "high",
+      "event_status_effect": "limited",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "This event records the public report and resulting status signal only. The underlying first-party August announcement has not yet been captured by HEI, so this record does not assert a hack, insolvency, scam/rug, or a requirement to recruit new users in order to accelerate release. Re-review when the primary release rules are available."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012541",
+      "exchange_id": "hei_ex_001150",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "BitradeX official website",
+      "url": "https://www.bitradex.ai/",
+      "publisher": "BitradeX",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bitradex.ai/",
+      "accessed_at": "2026-08-11",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party public website establishes the BitradeX exchange identity and remains accessible at review time."
+    },
+    {
+      "id": "hei_src_012542",
+      "exchange_id": "hei_ex_001150",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "BitradeX exchange market listing",
+      "url": "https://coinmarketcap.com/exchanges/bitradex/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-11",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current independent market listing exposes BitradeX spot and derivatives market data and links to bitradex.ai, supporting that the exchange surface is not being treated as terminally shut down."
+    },
+    {
+      "id": "hei_src_012543",
+      "exchange_id": "hei_ex_001150",
+      "event_id": "hei_ev_010108",
+      "source_type": "community_reference",
+      "title": "BitradeX asset-release interpretation and pending-rule warning",
+      "url": "https://x.com/yd59ktn/status/2087036254114484450",
+      "publisher": "ワイドルフLingo",
+      "published_at": "2026-08-11",
+      "archived_url": null,
+      "accessed_at": "2026-08-11",
+      "reliability": "low",
+      "claim_scope": "event",
+      "notes": "Japanese community post characterizes a BitradeX announcement as saying existing principal could not be returned immediately and would be released gradually. The post itself states that detailed rules were not yet available and avoids a definitive conclusion. HEI uses it only as a monitoring-quality event signal, not as proof of hack, insolvency, scam, or referral-linked release mechanics."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Adds BitradeX as a reviewed post-D-1000 growth candidate with a deliberately conservative `limited` classification and one August 2026 event recording a **reported** asset-release restriction.

The event is not promoted to hack, insolvency, scam/rug, bankruptcy, or terminal shutdown because the underlying first-party August notice and detailed release rules have not yet been captured by HEI.

## Roadmap / specification

- Roadmap lane: post-D-1000 reviewed data and quality growth during L-2 HOLD
- `docs/HEI_V1_EXECUTION_ROADMAP.md` — canonical growth remains allowed in parallel
- `docs/HEI_DATA_GROWTH_MILESTONES_SPEC.md` — preserve identity, evidence, status, URL-safety, and reviewed-public boundaries
- `docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md` — record-only reviewed additions do not require branch preview

## Canonical count impact after merge

```text
Before
Entities: 1029
Events:   1031
Evidence: 3844

After
Entities: 1030
Events:   1032
Evidence: 3849
```

Allocated IDs:

```text
Entity:   hei_ex_001150
Event:    hei_ev_010108
Evidence: hei_src_012541..hei_src_012545
```

## Evidence boundary

- first-party BitradeX website: current entity identity / live official domain
- CoinMarketCap: independent current exchange-market listing
- BitradeX registration page: links the platform to `BITRADEX FINTECH LIMITED`, company 16322746, in England and Wales
- UK Companies House: independently confirms company 16322746 as an active UK private limited company incorporated 2025-03-18
- supplied 2026-08-11 X post: `community_reference`, low reliability, used only for the reported August event signal

`country_or_origin` is therefore `United Kingdom` as the verified current corporate origin. This does not backdate the UK company identity to the platform's earlier claimed history.

The community post explicitly says detailed rules were not yet available. This PR therefore does **not** claim that recruiting new users is a confirmed requirement for accelerated release.

## Deployment impact

- `records/**` changes public output after merge
- Cloudflare branch preview: **not required** under the current deployment policy for reviewed record-only additions
- L-2 remains `HOLD / EVIDENCE CAPTURE`

## Validation performed before opening / during review

- current `main` read directly from GitHub: `120011b86ccf41cd00a2974305b700c8886b28f6`
- no open PR existed at branch start
- repository/code search found no existing BitradeX record or PR
- exact repository searches confirmed `hei_ex_001150` and evidence IDs through `hei_src_012545` unused
- `hei_ev_010108` confirmed as the next event identifier from the current reviewed growth sequence
- strict country/origin gate inspected before merge; initial null origin was replaced with independently verified UK corporate evidence
- branch started 0 commits behind current main

GitHub CI must pass before merge. In particular the normal record validation, overlap/ID checks, country/origin and URL-safety checks, machine/public consistency, localization, recovery, and count-semantics checks remain merge gates.

## Production verification plan

After merge:

1. confirm deployed `/version.json` matches the merged `main` commit;
2. confirm `/data/manifest.json` reports 1030 entities / 1032 events / 3849 evidence;
3. confirm public entity/event/evidence lengths and HTML counts match the machine-readable layer;
4. verify the BitradeX dossier renders as `limited` and does not imply dead/scam/insolvency/hack;
5. verify sitemap/locale output and URL-safety behavior remain valid.

## Follow-up evidence rule

If the underlying BitradeX August announcement or the detailed release rules are captured, strengthen the event with first-party evidence and revise only claims directly supported by that source.