### PR TITLE
Add reviewed CoinChief exchange record

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -6,9 +6,9 @@
   "current_item": "L2-1 — Evaluation contract, telemetry, and evidence capture",
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
-    "entities": 1031,
-    "events": 1034,
-    "evidence": 3854
+    "entities": 1032,
+    "events": 1035,
+    "evidence": 3858
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",
@@ -27,7 +27,7 @@
     "d750_completion_report": "docs/audits/HEI_D750_MILESTONE_COMPLETION_2026-07-10.md",
     "d1000_progress_report": "docs/audits/HEI_D1000_PROGRESS_BX50_2026-08-09.md",
     "d1000_completion_report": "docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md",
-    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX60_2026-08-13.md",
+    "post_d1000_growth_report": "docs/audits/HEI_POST_D1000_GROWTH_BX61_2026-08-13.md",
     "l1_activation_completion_report": "docs/audits/HEI_L1_JAPANESE_PILOT_ROUTE_ACTIVATION_COMPLETION_2026-07-10.md",
     "deployment_policy": "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
     "cloudflare_project_policy": "config/cloudflare-pages-project.json",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,18 +52,18 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX60, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. With post-D-1000 BX61, the current reviewed state is:
 
 ```text
-Entities: 1031
-Events:   1034
-Evidence: 3854
+Entities: 1032
+Events:   1035
+Evidence: 3858
 ```
 
 Current post-D-1000 growth authority:
 
 ```text
-docs/audits/HEI_POST_D1000_GROWTH_BX60_2026-08-13.md
+docs/audits/HEI_POST_D1000_GROWTH_BX61_2026-08-13.md
 ```
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX61_2026-08-13.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX61_2026-08-13.md
@@ -1,0 +1,138 @@
+# HEI Post-D-1000 Growth — BX61
+
+Date: 2026-08-13  
+Lane: canonical data growth  
+L-2 state: HOLD / evidence capture
+
+## Result
+
+BX61 adds one independently reviewed CoinChief record with a conservative active CEX classification and one non-terminal strategic-cooperation event.
+
+Added reviewed entity candidate:
+
+```text
+CoinChief  active / cex / Global
+```
+
+Added events: 1  
+Added evidence: 4
+
+Projected reviewed public state after merge:
+
+```text
+Entities: 1032
+Events:   1035
+Evidence: 3858
+```
+
+## Discovery source boundary
+
+CoinChief entered this review from the cross-site candidate intake tracked in Issue #753. The originating external service-watchlist post and supporter/referral material are discovery-only and are not used as evidence in this record.
+
+Canonical promotion is based on independently reviewed first-party, database-reference, and issuer-press-release evidence.
+
+## Evidence standard
+
+- The current first-party CoinChief site exposes Spot, USDⓈ-M Futures, Copy Trading, Earn, and Spot/P2P/Futures account and order surfaces, alongside live spot-market entries.
+- The first-party OpenAPI documentation exposes Spot, Margin and Contract/Futures trading plus account, withdrawal, order, market-data and WebSocket interfaces.
+- CoinMarketCap currently maintains a CoinChief exchange page linked to `coinchief.live` and identifies Spot, Perpetual and Futures market categories. HEI uses this only as a medium-reliability database reference and does not adopt exchange-supplied claims about founding date, licenses, reserves, security, reach, or jurisdiction without separate verification.
+- A GMTech-authored 2026-05-11 press release distributed via ACCESS Newswire and carried by Nasdaq states that GMTech intended to make a strategic investment in Coin Chief Tech INC. and had entered preliminary strategic-cooperation discussions. The same release explicitly states that no definitive agreement had been finalized.
+
+## Status handling
+
+CoinChief uses:
+
+```text
+status: active
+death_reason: null
+death_date: null
+confidence: medium
+```
+
+Current first-party surfaces and a current external exchange database support an active classification.
+
+Confidence remains `medium` because the reviewed evidence does not independently establish the operator's exact legal jurisdiction, an exact launch date, or the regulatory claims appearing in external profile copy.
+
+## Type handling
+
+CoinChief uses:
+
+```text
+type: cex
+```
+
+The reviewed first-party site presents centralized account, wallet, order, spot, P2P and futures surfaces, and the API documentation exposes authenticated account/trading endpoints. HEI therefore uses CEX rather than DEX or hybrid.
+
+## Event handling
+
+BX61 adds:
+
+```text
+2026-05-11  other  none
+```
+
+The event records GMTech's proposed strategic investment and cooperation discussions.
+
+It is deliberately **not** modeled as:
+
+```text
+acquired
+merged
+rebranded
+ownership transfer
+completed investment
+successor relationship
+```
+
+The source explicitly says the discussions were preliminary and that no definitive agreement had been finalized.
+
+## Identity and scope controls
+
+- `CoinChief` is the canonical exchange name.
+- `Coin Chief`, `Coin Chief Tech INC.`, and `C网` are retained as identity/discovery aliases.
+- Repository search on reviewed `main` found no existing CoinChief record before branch creation.
+- No launch date is taken from CoinMarketCap profile copy because it was not independently verified.
+- The operator's legal jurisdiction is not independently established. HEI uses `Global` rather than inferring a country from third-party compliance claims.
+- CoinMarketCap statements concerning U.S./Canada MSB status, reserves, security, 100+ country reach, and founding year are not promoted into HEI canonical facts by this batch.
+- The current first-party footer identifies Coin Chief Tech INC.; this does not by itself establish a jurisdiction.
+- Supporter/promotional descriptions connecting CoinChief with 9D Assets or StaX are excluded from canonical lineage/ownership claims here. Those relationships remain separate cross-site research items.
+
+## Identifier allocation
+
+```text
+Entity:   hei_ex_001152
+Event:    hei_ev_010111
+Evidence: hei_src_012551 through hei_src_012554
+```
+
+Exact repository searches after BX60 merged found these identifiers unused, and there were no open pull requests competing for the allocation.
+
+## Count impact
+
+```text
+Before BX61
+Entities: 1031
+Events:   1034
+Evidence: 3854
+
+After BX61
+Entities: 1032
+Events:   1035
+Evidence: 3858
+```
+
+## L-2 relationship
+
+This reviewed data-growth candidate does not change the L-2 localization decision. L-2 remains `HOLD / EVIDENCE CAPTURE`, and no additional language is authorized.
+
+## Deployment decision
+
+This PR changes `records/**`, so public output changes after merge. Under the Cloudflare deployment policy, a branch preview is not required for a reviewed record-only addition. GitHub validation must pass before merge.
+
+After merge, production verification must confirm the deployed `main` commit, machine/public count consistency, the CoinChief dossier, and the preliminary 2026-05-11 event.
+
+## Completion condition
+
+BX61 is complete only after record validation, duplicate/overlap checks, ID-collision checks, country/origin checks, URL-safety checks, machine/public consistency, localization output checks, recovery validation, count-semantics validation, merge to `main`, and production verification succeed.
+
+Until those gates pass, the branch and PR are review candidates rather than canonical authority.

--- a/records/exchanges/coinchief.json
+++ b/records/exchanges/coinchief.json
@@ -1,0 +1,103 @@
+{
+  "entity": {
+    "id": "hei_ex_001152",
+    "slug": "coinchief",
+    "canonical_name": "CoinChief",
+    "aliases": ["Coin Chief", "Coin Chief Tech INC.", "C网"],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Global",
+    "summary": "Centralized digital-asset exchange offering spot, P2P, futures, copy-trading and earn surfaces, with public trading markets and first-party API documentation. In May 2026, GMTech announced preliminary discussions concerning a proposed strategic investment and broader cooperation with Coin Chief Tech INC.; no definitive agreement had been finalized at that time.",
+    "official_url_original": "https://www.coinchief.live/",
+    "official_domain_original": "coinchief.live",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.coinchief.live/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-13",
+    "notes": "The current first-party site exposes Spot, USDⓈ-M Futures, Copy Trading, Earn, and Spot/P2P/Futures account and order surfaces, and identifies Coin Chief Tech INC. in its footer. First-party OpenAPI documentation separately exposes spot, margin, contract/futures, account, withdrawal and market-data interfaces. CoinMarketCap currently lists CoinChief as an exchange linked to coinchief.live, but HEI does not independently adopt CoinMarketCap profile claims about founding date, licensing, reserves, security, or jurisdiction. The reviewed sources do not independently establish the operator's legal jurisdiction or an exact launch date, so HEI uses Global and leaves launch_date null. The 2026 GMTech announcement is recorded as preliminary investment/cooperation discussion only and is not treated as an acquisition, merger, completed investment, ownership transfer, or successor relationship. Promotional claims connecting CoinChief to 9D Assets / StaX remain outside this record unless separately verified."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010111",
+      "exchange_id": "hei_ex_001152",
+      "event_type": "other",
+      "event_date": "2026-05-11",
+      "title": "GMTech announced proposed strategic investment and cooperation discussions",
+      "description": "GMTech Inc. announced that it intended to make a strategic investment in Coin Chief Tech INC. and had entered preliminary discussions regarding global strategic cooperation. The announcement stated that no definitive agreement had been finalized.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "none",
+      "source_count": 1,
+      "sort_order": 1,
+      "counterparty_name": "GMTech Inc.",
+      "notes": "This is a preliminary-discussion event. HEI does not classify CoinChief as acquired or merged and does not infer that the proposed investment was completed."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012551",
+      "exchange_id": "hei_ex_001152",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "CoinChief public service site",
+      "url": "https://www.coinchief.live/",
+      "publisher": "CoinChief",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.coinchief.live/",
+      "accessed_at": "2026-08-13",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party site shows Spot, USDⓈ-M Futures, Copy Trading, Earn, Spot/P2P/Futures accounts and orders, and public BTC/USDT, LTC/USDT, BCH/USDT and TRX/USDT market surfaces. Footer identifies Coin Chief Tech INC. Used for current service/status evidence only; promotional security claims are not independently adopted by HEI."
+    },
+    {
+      "id": "hei_src_012552",
+      "exchange_id": "hei_ex_001152",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "CoinChief OpenAPI documentation",
+      "url": "https://www.coinchief.live/openapi/open-api-en.html",
+      "publisher": "CoinChief",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.coinchief.live/openapi/open-api-en.html",
+      "accessed_at": "2026-08-13",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party API documentation exposes Spot, Margin and Contract/Futures trading, account, withdrawal, order, market-data and WebSocket interfaces. Used to corroborate the exchange-service shape."
+    },
+    {
+      "id": "hei_src_012553",
+      "exchange_id": "hei_ex_001152",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "CoinChief trade volume and market listings",
+      "url": "https://coinmarketcap.com/exchanges/coinchief/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/coinchief/",
+      "accessed_at": "2026-08-13",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current database reference links CoinChief to coinchief.live and lists Spot, Perpetual and Futures market categories. HEI does not independently adopt the page's exchange-supplied claims concerning founding year, licenses, reserves, safety, reach, or jurisdiction."
+    },
+    {
+      "id": "hei_src_012554",
+      "exchange_id": "hei_ex_001152",
+      "event_id": "hei_ev_010111",
+      "source_type": "official_statement",
+      "title": "GMTech Inc. Announces Proposed Strategic Cooperation with Coin Chief Tech INC.",
+      "url": "https://www.nasdaq.com/press-release/gmtech-inc-announces-proposed-strategic-cooperation-coin-chief-tech-inc-2026-05-11",
+      "publisher": "GMTech Inc.",
+      "published_at": "2026-05-11",
+      "archived_url": "https://web.archive.org/web/*/https://www.nasdaq.com/press-release/gmtech-inc-announces-proposed-strategic-cooperation-coin-chief-tech-inc-2026-05-11",
+      "accessed_at": "2026-08-13",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "GMTech-authored press release distributed via ACCESS Newswire and carried by Nasdaq. It states that GMTech intended to make a strategic investment in Coin Chief Tech INC. and had entered cooperation discussions, while explicitly stating that no definitive agreement had been finalized. Primary evidence for the preliminary 2026-05-11 event only."
+    }
+  ]
+}


### PR DESCRIPTION
## Roadmap / lane

Post-D-1000 reviewed canonical data growth while L-2 remains `HOLD / EVIDENCE CAPTURE`.

Refs #753.

## Change

Adds a reviewed CoinChief bundle:

- entity: `CoinChief` — `active / cex / Global`
- event: 2026-05-11 preliminary proposed strategic investment / cooperation discussions with GMTech (`other`, effect `none`)
- evidence: 4 sources

The originating external service-watchlist post and supporter/referral material are discovery-only and are **not** evidence in this record.

## Evidence boundary

Reviewed evidence establishes:

- current first-party Spot, USDⓈ-M Futures, Copy Trading, Earn, Spot/P2P/Futures account and order surfaces at `coinchief.live`;
- first-party OpenAPI documentation for Spot, Margin, Contract/Futures, account, withdrawal, order and market-data interfaces;
- current CoinMarketCap exchange listing linked to `coinchief.live`, used as medium-reliability database corroboration only;
- a GMTech-authored 2026-05-11 press release distributed via ACCESS Newswire and carried by Nasdaq, stating that GMTech intended to make a strategic investment in Coin Chief Tech INC. and entered preliminary strategic-cooperation discussions, while explicitly stating that no definitive agreement had been finalized.

No launch date is inferred. No U.S./Canada license claim, reserve claim, safety claim, exact jurisdiction claim, or 2019 founding claim from external exchange-profile copy is promoted into canonical HEI facts.

## Status / type

```text
type: cex
status: active
country_or_origin: Global
confidence: medium
```

`Global` is used because the reviewed evidence does not independently establish the operator's legal jurisdiction. The first-party footer identifying Coin Chief Tech INC. does not by itself establish jurisdiction.

## Event boundary

The GMTech item is modeled only as a preliminary discussion event:

```text
2026-05-11  other  none
```

This PR does **not** classify CoinChief as acquired, merged, rebranded, a completed investment target, or a successor/predecessor entity.

## Duplicate / identity controls

After CryptoPanda BX60 merged, repository searches found no existing CoinChief record and no open PRs competing for allocation.

## Identifier allocation

- entity: `hei_ex_001152`
- event: `hei_ev_010111`
- evidence: `hei_src_012551`–`hei_src_012554`

All were checked unused against the post-BX60 `main` state.

## Canonical count impact

Before:

- entities: 1031
- events: 1034
- evidence: 3854

Projected after merge:

- entities: 1032
- events: 1035
- evidence: 3858

The recovery checkpoint and L-2 growth note are advanced to BX61, while L-2 remains HOLD.

## 9D / StaX boundary

Promotional descriptions connecting CoinChief, 9D Assets and StaX are intentionally not used to establish ownership, lineage, reserves, or canonical relationships here. Those remain separate SOG/CYA research items.

## Deployment / validation

`records/**` changes reviewed public output after merge. Per current Cloudflare policy, no branch preview is required for this record-only addition; production remains main-only.

Required GitHub validation must pass before merge, including records, duplicate/overlap, IDs, country/origin, URL safety, machine/public consistency, localization, recovery and count semantics.

## Production verification plan

After merge:

1. confirm deployed `main` commit;
2. verify `/version.json` and `/data/manifest.json`;
3. verify reviewed counts `1032 / 1035 / 3858`;
4. verify `/exchange/coinchief/` and localized fallback route;
5. verify the 2026-05-11 event is shown as a non-terminal preliminary event;
6. verify evidence and URL-safety behavior.

## Audit authority

`docs/audits/HEI_POST_D1000_GROWTH_BX61_2026-08-13.md`
