### PR TITLE
Prioritize Aug 12 intake in active-status monitoring

### DIFF
--- a/scripts/monitoring/monitors/active-status-watch.mjs
+++ b/scripts/monitoring/monitors/active-status-watch.mjs
@@ -4,11 +4,18 @@ import { checkHttpUrl } from '../adapters/http-check.mjs';
 
 const ENABLE_DOMAIN_CHECKS = process.env.HEI_MONITORING_ENABLE_DOMAIN_CHECKS === '1';
 const DEFAULT_LIMIT = 50;
+const DEFAULT_PRIORITY_SLUGS = ['coinchief', 'cryptopanda', 'izaka-ya', 'msx'];
 const RETRYABLE_CHECK_STATUSES = new Set(['dns_failure', 'tls_failure', 'server_error', 'timeout']);
 
 function getCheckLimit() {
   const parsed = Number.parseInt(process.env.HEI_MONITORING_DOMAIN_CHECK_LIMIT || String(DEFAULT_LIMIT), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMIT;
+}
+
+function getPrioritySlugs() {
+  const raw = process.env.HEI_MONITORING_PRIORITY_DOMAIN_SLUGS;
+  if (!raw) return [...DEFAULT_PRIORITY_SLUGS];
+  return [...new Set(raw.split(',').map((value) => value.trim()).filter(Boolean))];
 }
 
 function entityUrl(entity) {
@@ -20,6 +27,28 @@ function activeSideEntities(entities = []) {
     .filter((entity) => ACTIVE_SIDE_STATUSES.includes(entity.status))
     .filter((entity) => entityUrl(entity))
     .sort((a, b) => String(a.slug || '').localeCompare(String(b.slug || '')));
+}
+
+export function prioritizeActiveStatusTargets(targets = [], prioritySlugs = []) {
+  const bySlug = new Map(targets.map((entity) => [String(entity.slug || ''), entity]));
+  const ordered = [];
+  const seen = new Set();
+
+  for (const slug of prioritySlugs) {
+    const entity = bySlug.get(slug);
+    if (!entity || seen.has(slug)) continue;
+    ordered.push(entity);
+    seen.add(slug);
+  }
+
+  for (const entity of targets) {
+    const slug = String(entity.slug || '');
+    if (seen.has(slug)) continue;
+    ordered.push(entity);
+    seen.add(slug);
+  }
+
+  return ordered;
 }
 
 function isAccessControlNoise(check) {
@@ -92,6 +121,7 @@ export async function runActiveStatusWatch(context, { startedAt } = {}) {
   const errors = [];
   const entities = context?.canonicalData?.entities || [];
   const targets = activeSideEntities(entities);
+  const prioritySlugs = getPrioritySlugs();
 
   if (!ENABLE_DOMAIN_CHECKS) {
     findings.push(createFinding({
@@ -117,13 +147,17 @@ export async function runActiveStatusWatch(context, { startedAt } = {}) {
           enabled: false,
           active_side_entities_with_urls: targets.length,
           checked: 0,
+          priority_slugs: prioritySlugs,
+          priority_selected: 0,
         },
       },
     });
   }
 
   const limit = getCheckLimit();
-  const selected = targets.slice(0, limit);
+  const prioritizedTargets = prioritizeActiveStatusTargets(targets, prioritySlugs);
+  const selected = prioritizedTargets.slice(0, limit);
+  const selectedSlugs = new Set(selected.map((entity) => String(entity.slug || '')));
   const checks = [];
 
   for (const entity of selected) {
@@ -179,6 +213,8 @@ export async function runActiveStatusWatch(context, { startedAt } = {}) {
         active_side_entities_with_urls: targets.length,
         checked: selected.length,
         findings: findings.length,
+        priority_slugs: prioritySlugs,
+        priority_selected: prioritySlugs.filter((slug) => selectedSlugs.has(slug)).length,
         retries_attempted: checks.filter((item) => item.retry_attempted).length,
         recovered_after_retry: checks.filter((item) => item.recovered_after_retry).length,
         access_control_noise: checks.filter((item) => isAccessControlNoise(item.check)).length,

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -4,7 +4,7 @@ import { loadCanonicalData } from './core/load-canonical-data.mjs';
 import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
 import { buildSummaryMarkdown } from './core/summary-writer.mjs';
 import { extractCandidateNameFromNews } from './core/news-extract.mjs';
-import { shouldRetryOfficialSiteCheck } from './monitors/active-status-watch.mjs';
+import { prioritizeActiveStatusTargets, shouldRetryOfficialSiteCheck } from './monitors/active-status-watch.mjs';
 import { normalizeSitemapUrl } from './adapters/sitemap-check.mjs';
 import { runReviewedBundleAggregationRegression } from '../test-reviewed-bundle-aggregation.mjs';
 import { buildRegistryMetrics, parseReviewMonth } from '../review/monthly-registry-core.mjs';
@@ -100,6 +100,21 @@ function runMonitoringOutputRegressions() {
   assert(shouldRetryOfficialSiteCheck({ status: 'timeout' }), 'timeouts must be retried before creating an active-status finding');
   assert(!shouldRetryOfficialSiteCheck({ status: 'ok' }), 'healthy responses must not be retried');
   assert(!shouldRetryOfficialSiteCheck({ status: 'redirected', http_status: 200 }), 'healthy redirects must not be retried');
+
+  const prioritizedTargets = prioritizeActiveStatusTargets(
+    [
+      { slug: 'alpha' },
+      { slug: 'coinchief' },
+      { slug: 'izaka-ya' },
+      { slug: 'msx' },
+      { slug: 'zeta' },
+    ],
+    ['msx', 'coinchief', 'missing', 'msx'],
+  );
+  assert(
+    prioritizedTargets.map((entity) => entity.slug).join(',') === 'msx,coinchief,alpha,izaka-ya,zeta',
+    `active-status priority ordering must be stable and deduplicated: ${prioritizedTargets.map((entity) => entity.slug).join(',')}`,
+  );
 
   const summary = buildSummaryMarkdown({
     runId: '20260630-smoke',


### PR DESCRIPTION
## Scope

Close the monitoring gap for the reviewed Aug 12 cross-site HEI intake.

## Problem

Scheduled HEI monitoring enables official-domain checks but caps them at 25 entities. `active-status-watch` sorts all active-side entities by slug and previously used `targets.slice(0, limit)`, so newly added reviewed entities were not guaranteed to be checked merely because they were canonical.

## Change

- add priority ordering to `active-status-watch` before the existing limit is applied;
- default priority slugs to the four reviewed Aug 12 additions: `coinchief`, `cryptopanda`, `izaka-ya`, `msx`;
- allow an optional `HEI_MONITORING_PRIORITY_DOMAIN_SLUGS` comma-separated override;
- expose `priority_slugs` and `priority_selected` in the monitor summary;
- add smoke regression coverage for stable priority ordering and deduplication.

The overall domain-check limit is unchanged. Priority items consume positions inside the existing cap rather than adding unbounded network calls.

## Safety

No canonical entity/event/evidence data is changed. Monitoring remains read-only with respect to canonical data and retains the existing retry/noise rules.

## Cross-site boundary

SOG #559 and CYA #203 were separately synchronized for the unresolved 9D/StaX line. This PR covers only HEI active-status monitoring for the four already reviewed/canonical HEI entities.