### PR TITLE
Add AI-era registry specification and execution schedule

### DIFF
--- a/docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md
+++ b/docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md
@@ -1,0 +1,36 @@
+# HEI AI-era Execution Schedule
+
+Status: roadmap addendum
+
+This schedule does not replace active HEI work. It inserts AI-era resilience work into the existing roadmap without stopping record growth or monitoring.
+
+## Work order
+### A. Preserve ongoing operations
+Continue reviewed record growth, evidence maintenance, monitoring, localization, and current approved roadmap work.
+
+### B. Provenance and lifecycle audit
+Audit representative active/dead records for missing post-event follow-up, last-verified metadata, archive/evidence visibility, claims/recovery/distribution events, and successor relationships. Produce a bounded backlog; do not mass-change canonical data automatically.
+
+### C. Record-level machine-readable surface
+Define and ship deterministic per-record JSON derived from canonical entity/event/evidence data. Validate parity with the human page and existing manifest/version rules.
+
+### D. Explorer/Search strengthening
+Add useful deterministic filters supported by canonical data, including time, origin, event/status/death dimensions and evidence/verification dimensions where safe. Preserve URL/query contracts.
+
+### E. Compare completion/extension
+Use the existing Compare specification as authority; add only evidence-backed historical/lifecycle fields and keep missing values explicit.
+
+### F. Stats completion
+Use the existing Stats specification/hand-off as authority. Emphasize snapshot, trend, coverage and data quality; no price/TVL/ranking drift.
+
+### G. Lifecycle follow-up pass
+Prioritize important records where the historical story currently stops at the headline event. Add reviewed follow-up events/evidence through claims, recovery, distribution, successor or final state when supported.
+
+### H. Natural-language evaluation only after B-G
+Evaluate natural-language-to-structured-filter translation only after deterministic search is strong. No free-form AI answer is canonical.
+
+## Gate for every stage
+Spec/update -> implementation PR -> CI green -> merge -> production/read-only verification where applicable -> roadmap/status synchronization. A later stage must not be declared complete from code alone.
+
+## Mandatory continuation rule
+Every future HEI work thread must read the current authoritative roadmap plus `HEI_AI_ERA_REGISTRY_SPEC.md` and this schedule before choosing the next task.

--- a/docs/HEI_AI_ERA_REGISTRY_SPEC.md
+++ b/docs/HEI_AI_ERA_REGISTRY_SPEC.md
@@ -1,0 +1,25 @@
+# HEI AI-era Registry Specification
+
+Status: planned / mandatory reference for future product work
+
+## Purpose
+HEI must remain useful when generic AI can summarize well-known exchange histories. HEI therefore optimizes for verifiable historical records, provenance, structured retrieval, comparison, and lifecycle follow-up rather than prose volume.
+
+## Required product direction
+1. Preserve the canonical entity -> event -> evidence model and reviewed-only publication boundary.
+2. Follow incidents beyond the initial headline: shutdown, insolvency, bankruptcy, claims, recoveries, distributions, acquisitions, relaunches, successors, and final state when evidence exists.
+3. Make provenance prominent: evidence type, claim scope, confidence, archive links, last verification, and unresolved uncertainty.
+4. Provide record-level machine-readable output bundling one entity with its reviewed events, evidence references, relationships, and verification metadata. Do not create a separate AI-only source of truth.
+5. Strengthen structured Explorer filters before considering natural-language search. Natural-language search, if added, must compile into deterministic structured filters and must not invent results.
+6. Maintain and extend Compare using canonical fields and evidence-backed derived values.
+7. Implement Stats as registry analysis and coverage/quality reporting, not a market ranking dashboard.
+8. Keep correction/review workflows human-accountable. Automated discovery may stage candidates but must not directly mutate canonical records.
+
+## Non-goals
+AI summary buttons, prompt libraries, public chat, and LLM-generated canonical facts are not priority work. API infrastructure is not required where static deterministic JSON is sufficient.
+
+## Completion gate
+This specification is satisfied only when record-level structured output, strengthened discovery/filtering, Compare, Stats, provenance visibility, and lifecycle follow-up are represented in production or explicitly tracked by the execution roadmap.
+
+## Mandatory reference rule
+All future HEI feature, data-growth, monitoring, Explorer, Compare, Stats, and machine-readable work must check this document together with the current authoritative HEI roadmap/specs. Existing stricter safety or evidence rules take precedence.


### PR DESCRIPTION
Adds an authoritative AI-era resilience specification and roadmap addendum for HEI. It preserves the existing entity/event/evidence model and current roadmap while making provenance, lifecycle follow-up, record-level machine-readable output, deterministic Explorer/Search, Compare, and Stats explicit future requirements. Future HEI work is required to consult these documents alongside the existing authoritative specs.