### PR TITLE
Add record-level machine-readable exchange bundles

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -42,4 +42,5 @@ jobs:
       - run: node --check scripts/check-machine-readable-production.mjs
       - run: npm run build
       - run: npm run machine:validate
+      - run: node scripts/validate-record-level-machine-readable.mjs
       - run: npm run public:validate

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import './scripts/build-machine-readable-layer.mjs'
+import './scripts/build-record-level-machine-readable.mjs'
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {

--- a/scripts/build-record-level-machine-readable.mjs
+++ b/scripts/build-record-level-machine-readable.mjs
@@ -1,0 +1,164 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { buildBundleEntityIdMap, loadReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
+
+const root = process.cwd()
+const publicDir = path.join(root, 'public')
+const outputDir = path.join(publicDir, 'data', 'exchanges')
+const origin = 'https://hei.badjoke-lab.com'
+
+function readJson(relativePath, fallback = []) {
+  const filePath = path.join(root, relativePath)
+  return fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, 'utf8')) : fallback
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function compareEvents(a, b) {
+  const dateOrder = String(a.event_date ?? '').localeCompare(String(b.event_date ?? ''))
+  if (dateOrder !== 0) return dateOrder
+  const sortOrder = Number(a.sort_order ?? 0) - Number(b.sort_order ?? 0)
+  if (sortOrder !== 0) return sortOrder
+  return String(a.id).localeCompare(String(b.id))
+}
+
+const versionPath = path.join(publicDir, 'version.json')
+if (!fs.existsSync(versionPath)) {
+  throw new Error('record-level build requires public/version.json from build-machine-readable-layer.mjs')
+}
+const version = JSON.parse(fs.readFileSync(versionPath, 'utf8'))
+const generatedAt = version.build?.generated_at
+if (!generatedAt) throw new Error('record-level build could not resolve generated_at')
+
+const canonicalEntities = readJson('data/entities.json')
+const canonicalEvents = readJson('data/events.json')
+const canonicalEvidence = readJson('data/evidence.json')
+const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, reviewedBundles)
+const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+const bundleEntityIdMap = buildBundleEntityIdMap(correctedCanonicalEntities, reviewedBundles)
+const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
+const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
+const canonicalExchangeId = (exchangeId) => bundleEntityIdMap.get(exchangeId) ?? exchangeId
+const entityById = new Map(entities.map((entity) => [entity.id, entity]))
+
+fs.rmSync(outputDir, { recursive: true, force: true })
+fs.mkdirSync(outputDir, { recursive: true })
+
+const eventsByEntity = new Map()
+for (const sourceEvent of events) {
+  const exchangeId = canonicalExchangeId(sourceEvent.exchange_id)
+  if (!entityById.has(exchangeId)) continue
+  const normalized = {
+    ...sourceEvent,
+    exchange_id: exchangeId,
+    exchange_slug: entityById.get(exchangeId).slug,
+    record_type: 'exchange_event',
+    canonical_page_url: `${origin}/exchange/${entityById.get(exchangeId).slug}/`,
+  }
+  const list = eventsByEntity.get(exchangeId) ?? []
+  list.push(normalized)
+  eventsByEntity.set(exchangeId, list)
+}
+
+const evidenceByEntity = new Map()
+for (const sourceEvidence of evidence) {
+  const exchangeId = canonicalExchangeId(sourceEvidence.exchange_id)
+  if (!entityById.has(exchangeId)) continue
+  const normalized = {
+    ...sourceEvidence,
+    exchange_id: exchangeId,
+    exchange_slug: entityById.get(exchangeId).slug,
+    record_type: 'exchange_evidence',
+    canonical_page_url: `${origin}/exchange/${entityById.get(exchangeId).slug}/`,
+  }
+  const list = evidenceByEntity.get(exchangeId) ?? []
+  list.push(normalized)
+  evidenceByEntity.set(exchangeId, list)
+}
+
+const indexRecords = []
+for (const entity of [...entities].sort((a, b) => a.slug.localeCompare(b.slug))) {
+  const entityEvents = [...(eventsByEntity.get(entity.id) ?? [])].sort(compareEvents)
+  const entityEvidence = [...(evidenceByEntity.get(entity.id) ?? [])].sort((a, b) => String(a.id).localeCompare(String(b.id)))
+  const evidenceIdsByEvent = new Map()
+  for (const item of entityEvidence) {
+    if (!item.event_id) continue
+    const ids = evidenceIdsByEvent.get(item.event_id) ?? []
+    ids.push(item.id)
+    evidenceIdsByEvent.set(item.event_id, ids)
+  }
+  const enrichedEvents = entityEvents.map((event) => ({
+    ...event,
+    evidence_ids: [...(evidenceIdsByEvent.get(event.id) ?? [])].sort(),
+  }))
+  const canonicalPageUrl = `${origin}/exchange/${entity.slug}/`
+  const recordJsonUrl = `${origin}/data/exchanges/${entity.slug}.json`
+  const record = {
+    schema_version: '1.0.0',
+    data_schema_version: 'hei_entity_event_evidence_v1',
+    project_id: 'historical-exchange-index',
+    record_type: 'exchange_record_bundle',
+    canonical_only: true,
+    generated_at: generatedAt,
+    canonical_origin: origin,
+    canonical_page_url: canonicalPageUrl,
+    record_json_url: recordJsonUrl,
+    entity: {
+      ...entity,
+      record_type: 'exchange_entity',
+      canonical_page_url: canonicalPageUrl,
+    },
+    relationships: {
+      predecessor_id: entity.predecessor_id ?? null,
+      successor_id: entity.successor_id ?? null,
+    },
+    verification: {
+      last_verified_at: entity.last_verified_at ?? null,
+      confidence: entity.confidence ?? null,
+    },
+    counts: {
+      events: enrichedEvents.length,
+      evidence: entityEvidence.length,
+    },
+    events: enrichedEvents,
+    evidence: entityEvidence,
+  }
+  const serialized = JSON.stringify(record)
+  for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+    if (serialized.includes(forbidden)) throw new Error(`record-level output leaked forbidden marker: ${forbidden} (${entity.slug})`)
+  }
+  writeJson(path.join(outputDir, `${entity.slug}.json`), record)
+  indexRecords.push({
+    id: entity.id,
+    slug: entity.slug,
+    canonical_name: entity.canonical_name,
+    type: entity.type,
+    status: entity.status,
+    confidence: entity.confidence ?? null,
+    last_verified_at: entity.last_verified_at ?? null,
+    event_count: enrichedEvents.length,
+    evidence_count: entityEvidence.length,
+    canonical_page_url: canonicalPageUrl,
+    record_json_url: recordJsonUrl,
+  })
+}
+
+writeJson(path.join(outputDir, 'index.json'), {
+  schema_version: '1.0.0',
+  data_schema_version: 'hei_entity_event_evidence_v1',
+  project_id: 'historical-exchange-index',
+  record_type: 'exchange_record_bundle_index',
+  canonical_only: true,
+  generated_at: generatedAt,
+  canonical_origin: origin,
+  record_count: indexRecords.length,
+  record_url_template: `${origin}/data/exchanges/{slug}.json`,
+  records: indexRecords,
+})
+
+console.log(`Built ${indexRecords.length} HEI record-level machine-readable bundles.`)

--- a/scripts/validate-record-level-machine-readable.mjs
+++ b/scripts/validate-record-level-machine-readable.mjs
@@ -1,0 +1,129 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { buildBundleEntityIdMap, loadReviewedBundles, mergeRecords, stableStringify } from './lib/reviewed-bundle-aggregation.mjs'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
+
+const root = process.cwd()
+const origin = 'https://hei.badjoke-lab.com'
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`record-level machine-readable validation failed: ${message}`)
+}
+
+function readJson(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function compareEvents(a, b) {
+  const dateOrder = String(a.event_date ?? '').localeCompare(String(b.event_date ?? ''))
+  if (dateOrder !== 0) return dateOrder
+  const sortOrder = Number(a.sort_order ?? 0) - Number(b.sort_order ?? 0)
+  if (sortOrder !== 0) return sortOrder
+  return String(a.id).localeCompare(String(b.id))
+}
+
+const version = readJson('public/version.json')
+const index = readJson('public/data/exchanges/index.json')
+const canonicalEntities = readJson('data/entities.json')
+const canonicalEvents = readJson('data/events.json')
+const canonicalEvidence = readJson('data/evidence.json')
+const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, reviewedBundles)
+const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+const bundleEntityIdMap = buildBundleEntityIdMap(correctedCanonicalEntities, reviewedBundles)
+const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
+const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
+const canonicalExchangeId = (exchangeId) => bundleEntityIdMap.get(exchangeId) ?? exchangeId
+const entityById = new Map(entities.map((entity) => [entity.id, entity]))
+
+assert(index.schema_version === '1.0.0', 'index schema_version mismatch')
+assert(index.data_schema_version === 'hei_entity_event_evidence_v1', 'index data_schema_version mismatch')
+assert(index.project_id === 'historical-exchange-index', 'index project_id mismatch')
+assert(index.record_type === 'exchange_record_bundle_index', 'index record_type mismatch')
+assert(index.canonical_only === true, 'index canonical_only must be true')
+assert(index.generated_at === version.build?.generated_at, 'index generated_at must match version')
+assert(index.canonical_origin === origin, 'index canonical_origin mismatch')
+assert(index.record_count === entities.length, 'index record_count mismatch')
+assert(index.records.length === entities.length, 'index records length mismatch')
+assert(index.record_url_template === `${origin}/data/exchanges/{slug}.json`, 'index record_url_template mismatch')
+
+const indexById = new Map(index.records.map((item) => [item.id, item]))
+assert(indexById.size === entities.length, 'index IDs are not unique')
+
+for (const entity of entities) {
+  const relativePath = `public/data/exchanges/${entity.slug}.json`
+  const record = readJson(relativePath)
+  const expectedEvents = events
+    .filter((event) => canonicalExchangeId(event.exchange_id) === entity.id)
+    .sort(compareEvents)
+  const expectedEvidence = evidence
+    .filter((item) => canonicalExchangeId(item.exchange_id) === entity.id)
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+  const expectedEvidenceIdsByEvent = new Map()
+  for (const item of expectedEvidence) {
+    if (!item.event_id) continue
+    const ids = expectedEvidenceIdsByEvent.get(item.event_id) ?? []
+    ids.push(item.id)
+    expectedEvidenceIdsByEvent.set(item.event_id, ids)
+  }
+
+  assert(record.schema_version === '1.0.0', `${entity.slug} schema_version mismatch`)
+  assert(record.data_schema_version === 'hei_entity_event_evidence_v1', `${entity.slug} data_schema_version mismatch`)
+  assert(record.project_id === 'historical-exchange-index', `${entity.slug} project_id mismatch`)
+  assert(record.record_type === 'exchange_record_bundle', `${entity.slug} record_type mismatch`)
+  assert(record.canonical_only === true, `${entity.slug} canonical_only must be true`)
+  assert(record.generated_at === version.build?.generated_at, `${entity.slug} generated_at mismatch`)
+  assert(record.canonical_origin === origin, `${entity.slug} canonical_origin mismatch`)
+  assert(record.canonical_page_url === `${origin}/exchange/${entity.slug}/`, `${entity.slug} canonical page URL mismatch`)
+  assert(record.record_json_url === `${origin}/data/exchanges/${entity.slug}.json`, `${entity.slug} record JSON URL mismatch`)
+  assert(record.entity?.id === entity.id, `${entity.slug} entity ID mismatch`)
+  assert(record.entity?.slug === entity.slug, `${entity.slug} entity slug mismatch`)
+  assert(record.entity?.record_type === 'exchange_entity', `${entity.slug} entity record_type mismatch`)
+  assert(record.relationships?.predecessor_id === (entity.predecessor_id ?? null), `${entity.slug} predecessor mismatch`)
+  assert(record.relationships?.successor_id === (entity.successor_id ?? null), `${entity.slug} successor mismatch`)
+  assert(record.verification?.last_verified_at === (entity.last_verified_at ?? null), `${entity.slug} last_verified_at mismatch`)
+  assert(record.verification?.confidence === (entity.confidence ?? null), `${entity.slug} confidence mismatch`)
+  assert(record.counts?.events === expectedEvents.length, `${entity.slug} event count mismatch`)
+  assert(record.counts?.evidence === expectedEvidence.length, `${entity.slug} evidence count mismatch`)
+  assert(record.events.length === expectedEvents.length, `${entity.slug} events length mismatch`)
+  assert(record.evidence.length === expectedEvidence.length, `${entity.slug} evidence length mismatch`)
+
+  for (let i = 0; i < expectedEvents.length; i += 1) {
+    const actual = record.events[i]
+    const expected = expectedEvents[i]
+    assert(actual.id === expected.id, `${entity.slug} event order/ID mismatch at ${i}`)
+    assert(actual.exchange_id === entity.id, `${entity.slug} event canonical exchange ID mismatch: ${actual.id}`)
+    assert(actual.exchange_slug === entity.slug, `${entity.slug} event slug mismatch: ${actual.id}`)
+    assert(actual.record_type === 'exchange_event', `${entity.slug} event record_type mismatch: ${actual.id}`)
+    const expectedIds = [...(expectedEvidenceIdsByEvent.get(expected.id) ?? [])].sort()
+    assert(stableStringify(actual.evidence_ids) === stableStringify(expectedIds), `${entity.slug} evidence_ids mismatch: ${actual.id}`)
+  }
+
+  for (let i = 0; i < expectedEvidence.length; i += 1) {
+    const actual = record.evidence[i]
+    const expected = expectedEvidence[i]
+    assert(actual.id === expected.id, `${entity.slug} evidence order/ID mismatch at ${i}`)
+    assert(actual.exchange_id === entity.id, `${entity.slug} evidence canonical exchange ID mismatch: ${actual.id}`)
+    assert(actual.exchange_slug === entity.slug, `${entity.slug} evidence slug mismatch: ${actual.id}`)
+    assert(actual.record_type === 'exchange_evidence', `${entity.slug} evidence record_type mismatch: ${actual.id}`)
+  }
+
+  const indexItem = indexById.get(entity.id)
+  assert(indexItem, `${entity.slug} missing from index`)
+  assert(indexItem.slug === entity.slug, `${entity.slug} index slug mismatch`)
+  assert(indexItem.event_count === expectedEvents.length, `${entity.slug} index event_count mismatch`)
+  assert(indexItem.evidence_count === expectedEvidence.length, `${entity.slug} index evidence_count mismatch`)
+  assert(indexItem.record_json_url === record.record_json_url, `${entity.slug} index record URL mismatch`)
+
+  const serialized = JSON.stringify(record)
+  for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+    assert(!serialized.includes(forbidden), `${entity.slug} contains forbidden marker: ${forbidden}`)
+  }
+}
+
+const files = fs.readdirSync(path.join(root, 'public', 'data', 'exchanges')).filter((name) => name.endsWith('.json'))
+assert(files.length === entities.length + 1, 'record-level output contains stale or missing JSON files')
+
+console.log(`Validated ${entities.length} HEI record-level machine-readable bundles.`)


### PR DESCRIPTION
Implements HEI AI-era Stage C as a bounded product change without touching canonical records, record-growth queues, localization evidence, Explorer, Compare, or Stats.

## Public output

The normal production build now generates:

- `/data/exchanges/index.json`
- `/data/exchanges/{slug}.json` for every reviewed canonical exchange

Each per-record bundle is derived from the same reviewed entity/event/evidence aggregation used by the existing machine-readable layer. No AI-only database or alternative source of truth is introduced.

Per-record output includes:
- canonical entity and current status
- ordered reviewed events
- event-level `evidence_ids`
- reviewed evidence with source type, publisher, reliability, claim scope, archive URL and access date when canonical
- canonical predecessor/successor IDs when present
- `last_verified_at` and entity confidence
- canonical human page URL and stable record JSON URL

## Safety

- canonical reviewed state only
- reviewed bundle corrections and canonical ID normalization are reused
- internal monitoring, staging paths, candidate fields and private research markers are rejected
- output directory is rebuilt from scratch so stale per-record files cannot survive entity changes

## Validation

Adds an independent record-level validator to CI. It recomputes reviewed entities/events/evidence, checks every generated slug file and index row, verifies event/evidence ownership and deterministic ordering, checks event-to-evidence references, validates canonical relationships/verification metadata, rejects forbidden internal markers, and fails if stale/missing JSON files exist.

## Non-interference

This branch was created only after Stage B PR #762 merged and the open-PR queue returned to zero. It changes only the new record-level generator/validator, `next.config.ts` generation wiring, and the existing CI workflow. Canonical data and the L-2 HOLD/evidence-capture lane are unchanged.

## Completion boundary

Do not mark Stage C complete from code alone. Full PR CI must pass, then production must be verified against the merged main commit and representative record endpoints before the execution schedule is advanced to Stage D.