### PR TITLE
Close Stage C record-level production verification

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -40,6 +40,7 @@ jobs:
       - run: npm run monitor:smoke
       - run: npm run monitor:test-completion
       - run: node --check scripts/check-machine-readable-production.mjs
+      - run: node --check scripts/check-record-level-machine-readable-production.mjs
       - run: npm run build
       - run: npm run machine:validate
       - run: node scripts/validate-record-level-machine-readable.mjs

--- a/.github/workflows/machine-readable-production-smoke.yml
+++ b/.github/workflows/machine-readable-production-smoke.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Verify production machine-readable endpoints
         run: node scripts/check-machine-readable-production.mjs
+
+      - name: Verify production record-level endpoints
+        run: node scripts/check-record-level-machine-readable-production.mjs

--- a/scripts/build-record-level-machine-readable.mjs
+++ b/scripts/build-record-level-machine-readable.mjs
@@ -18,6 +18,12 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
 }
 
+function appendDiscoveryOnce(filePath, marker, block) {
+  const current = fs.readFileSync(filePath, 'utf8').trimEnd()
+  if (current.includes(marker)) return
+  fs.writeFileSync(filePath, `${current}\n\n${block.trim()}\n`, 'utf8')
+}
+
 function compareEvents(a, b) {
   const dateOrder = String(a.event_date ?? '').localeCompare(String(b.event_date ?? ''))
   if (dateOrder !== 0) return dateOrder
@@ -27,8 +33,14 @@ function compareEvents(a, b) {
 }
 
 const versionPath = path.join(publicDir, 'version.json')
+const manifestPath = path.join(publicDir, 'data', 'manifest.json')
+const llmsPath = path.join(publicDir, 'llms.txt')
+const aiPath = path.join(publicDir, 'ai.txt')
 if (!fs.existsSync(versionPath)) {
   throw new Error('record-level build requires public/version.json from build-machine-readable-layer.mjs')
+}
+if (!fs.existsSync(manifestPath) || !fs.existsSync(llmsPath) || !fs.existsSync(aiPath)) {
+  throw new Error('record-level build requires the base machine-readable public layer')
 }
 const version = JSON.parse(fs.readFileSync(versionPath, 'utf8'))
 const generatedAt = version.build?.generated_at
@@ -160,5 +172,29 @@ writeJson(path.join(outputDir, 'index.json'), {
   record_url_template: `${origin}/data/exchanges/{slug}.json`,
   records: indexRecords,
 })
+
+const recordLevelDiscovery = {
+  index: '/data/exchanges/index.json',
+  record_url_template: '/data/exchanges/{slug}.json',
+  record_count: indexRecords.length,
+  canonical_only: true,
+}
+version.record_level = recordLevelDiscovery
+writeJson(versionPath, version)
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+manifest.record_level = recordLevelDiscovery
+writeJson(manifestPath, manifest)
+
+appendDiscoveryOnce(llmsPath, '/data/exchanges/index.json', `## Record-level reviewed bundles
+- Index: /data/exchanges/index.json
+- Record template: /data/exchanges/{slug}.json
+- Each record bundles one reviewed exchange entity with its reviewed events, event evidence references, evidence provenance, relationships, and verification metadata.
+- Record-level files use the same reviewed canonical source of truth as the main public datasets.`)
+
+appendDiscoveryOnce(aiPath, '/data/exchanges/index.json', `Record-level reviewed bundles:
+/data/exchanges/index.json
+/data/exchanges/{slug}.json
+These files bundle one reviewed exchange entity with its reviewed events, evidence provenance, relationships, and verification metadata from the same canonical source of truth.`)
 
 console.log(`Built ${indexRecords.length} HEI record-level machine-readable bundles.`)

--- a/scripts/check-record-level-machine-readable-production.mjs
+++ b/scripts/check-record-level-machine-readable-production.mjs
@@ -1,0 +1,124 @@
+const origin = (process.env.HEI_PUBLIC_ORIGIN || 'https://hei.badjoke-lab.com').replace(/\/$/, '')
+const expectedCommit = process.env.EXPECTED_COMMIT?.trim() || null
+const maxAttempts = Number(process.env.SMOKE_MAX_ATTEMPTS || 12)
+const retryDelayMs = Number(process.env.SMOKE_RETRY_DELAY_MS || 30000)
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchJson(path, cacheKey) {
+  const separator = path.includes('?') ? '&' : '?'
+  const response = await fetch(`${origin}${path}${separator}hei_record_smoke=${encodeURIComponent(cacheKey)}`, {
+    headers: {
+      accept: 'application/json',
+      'user-agent': 'HEI record-level production smoke checker',
+      'cache-control': 'no-cache',
+    },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(20000),
+  })
+  assert(response.ok, `${path} returned HTTP ${response.status}`)
+  const contentType = (response.headers.get('content-type') || '').toLowerCase()
+  assert(contentType.includes('application/json'), `${path} returned unexpected content-type: ${contentType}`)
+  return response.json()
+}
+
+function verifyRecord(record, expected) {
+  assert(record.schema_version === '1.0.0', `${expected.slug} schema_version mismatch`)
+  assert(record.data_schema_version === 'hei_entity_event_evidence_v1', `${expected.slug} data_schema_version mismatch`)
+  assert(record.project_id === 'historical-exchange-index', `${expected.slug} project_id mismatch`)
+  assert(record.record_type === 'exchange_record_bundle', `${expected.slug} record_type mismatch`)
+  assert(record.canonical_only === true, `${expected.slug} canonical_only mismatch`)
+  assert(record.canonical_origin === origin, `${expected.slug} canonical_origin mismatch`)
+  assert(record.entity?.id === expected.id, `${expected.slug} entity id mismatch`)
+  assert(record.entity?.slug === expected.slug, `${expected.slug} entity slug mismatch`)
+  assert(record.entity?.record_type === 'exchange_entity', `${expected.slug} entity record_type mismatch`)
+  assert(record.canonical_page_url === `${origin}/exchange/${expected.slug}/`, `${expected.slug} canonical page mismatch`)
+  assert(record.record_json_url === `${origin}/data/exchanges/${expected.slug}.json`, `${expected.slug} record URL mismatch`)
+  assert(record.counts?.events === record.events?.length, `${expected.slug} event count mismatch`)
+  assert(record.counts?.evidence === record.evidence?.length, `${expected.slug} evidence count mismatch`)
+
+  const evidenceIds = new Set((record.evidence || []).map((item) => item.id))
+  assert((record.events || []).every((event) => event.exchange_id === expected.id && event.exchange_slug === expected.slug), `${expected.slug} event ownership mismatch`)
+  assert((record.evidence || []).every((item) => item.exchange_id === expected.id && item.exchange_slug === expected.slug), `${expected.slug} evidence ownership mismatch`)
+  for (const event of record.events || []) {
+    assert(Array.isArray(event.evidence_ids), `${expected.slug} event evidence_ids missing: ${event.id}`)
+    assert(event.evidence_ids.every((id) => evidenceIds.has(id)), `${expected.slug} event references unknown evidence: ${event.id}`)
+  }
+
+  const serialized = JSON.stringify(record)
+  for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+    assert(!serialized.includes(forbidden), `${expected.slug} leaked forbidden marker: ${forbidden}`)
+  }
+}
+
+async function verifyProduction() {
+  const cacheKey = expectedCommit || Date.now().toString()
+  const [version, manifest, index] = await Promise.all([
+    fetchJson('/version.json', cacheKey),
+    fetchJson('/data/manifest.json', cacheKey),
+    fetchJson('/data/exchanges/index.json', cacheKey),
+  ])
+
+  if (expectedCommit) {
+    assert(version.build?.commit === expectedCommit, `deployment is not current: expected ${expectedCommit}, received ${version.build?.commit}`)
+  }
+
+  const expectedCount = version.data?.record_counts?.primary_records
+  assert(Number.isInteger(expectedCount) && expectedCount > 0, 'version primary record count is invalid')
+  const expectedDiscovery = {
+    index: '/data/exchanges/index.json',
+    record_url_template: '/data/exchanges/{slug}.json',
+    record_count: expectedCount,
+    canonical_only: true,
+  }
+  assert(JSON.stringify(version.record_level) === JSON.stringify(expectedDiscovery), 'version record_level discovery mismatch')
+  assert(JSON.stringify(manifest.record_level) === JSON.stringify(expectedDiscovery), 'manifest record_level discovery mismatch')
+
+  assert(index.schema_version === '1.0.0', 'record index schema_version mismatch')
+  assert(index.data_schema_version === 'hei_entity_event_evidence_v1', 'record index data_schema_version mismatch')
+  assert(index.project_id === 'historical-exchange-index', 'record index project_id mismatch')
+  assert(index.record_type === 'exchange_record_bundle_index', 'record index record_type mismatch')
+  assert(index.canonical_only === true, 'record index canonical_only mismatch')
+  assert(index.canonical_origin === origin, 'record index canonical_origin mismatch')
+  assert(index.generated_at === version.build?.generated_at, 'record index generated_at mismatch')
+  assert(index.record_count === expectedCount, 'record index count mismatch')
+  assert(index.records?.length === expectedCount, 'record index records length mismatch')
+  assert(index.record_url_template === `${origin}/data/exchanges/{slug}.json`, 'record index URL template mismatch')
+
+  const representatives = [
+    { slug: 'htx', id: 'hei_ex_000019' },
+    { slug: 'btcbox', id: 'hei_ex_000602' },
+    { slug: 'bitradex', id: 'hei_ex_001150' },
+  ]
+  for (const representative of representatives) {
+    const indexItem = index.records.find((item) => item.id === representative.id)
+    assert(indexItem?.slug === representative.slug, `record index missing ${representative.slug}`)
+    const record = await fetchJson(`/data/exchanges/${representative.slug}.json`, cacheKey)
+    assert(record.generated_at === version.build?.generated_at, `${representative.slug} generated_at mismatch`)
+    verifyRecord(record, representative)
+  }
+
+  console.log(`Production record-level machine-readable layer verified at ${origin}`)
+  console.log(`commit=${version.build?.commit}, records=${expectedCount}`)
+}
+
+let lastError
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  try {
+    console.log(`Record-level production verification attempt ${attempt}/${maxAttempts}`)
+    await verifyProduction()
+    process.exit(0)
+  } catch (error) {
+    lastError = error
+    console.error(error instanceof Error ? error.message : error)
+    if (attempt < maxAttempts) await sleep(retryDelayMs)
+  }
+}
+
+throw lastError

--- a/scripts/validate-record-level-machine-readable.mjs
+++ b/scripts/validate-record-level-machine-readable.mjs
@@ -16,6 +16,12 @@ function readJson(relativePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
 
+function readText(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
 function compareEvents(a, b) {
   const dateOrder = String(a.event_date ?? '').localeCompare(String(b.event_date ?? ''))
   if (dateOrder !== 0) return dateOrder
@@ -25,6 +31,9 @@ function compareEvents(a, b) {
 }
 
 const version = readJson('public/version.json')
+const manifest = readJson('public/data/manifest.json')
+const llms = readText('public/llms.txt')
+const ai = readText('public/ai.txt')
 const index = readJson('public/data/exchanges/index.json')
 const canonicalEntities = readJson('data/entities.json')
 const canonicalEvents = readJson('data/events.json')
@@ -36,7 +45,19 @@ const bundleEntityIdMap = buildBundleEntityIdMap(correctedCanonicalEntities, rev
 const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
 const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
 const canonicalExchangeId = (exchangeId) => bundleEntityIdMap.get(exchangeId) ?? exchangeId
-const entityById = new Map(entities.map((entity) => [entity.id, entity]))
+
+const expectedDiscovery = {
+  index: '/data/exchanges/index.json',
+  record_url_template: '/data/exchanges/{slug}.json',
+  record_count: entities.length,
+  canonical_only: true,
+}
+assert(stableStringify(version.record_level) === stableStringify(expectedDiscovery), 'version record_level discovery mismatch')
+assert(stableStringify(manifest.record_level) === stableStringify(expectedDiscovery), 'manifest record_level discovery mismatch')
+for (const text of [llms, ai]) {
+  assert(text.includes('/data/exchanges/index.json'), 'record-level index missing from discovery text')
+  assert(text.includes('/data/exchanges/{slug}.json'), 'record-level template missing from discovery text')
+}
 
 assert(index.schema_version === '1.0.0', 'index schema_version mismatch')
 assert(index.data_schema_version === 'hei_entity_event_evidence_v1', 'index data_schema_version mismatch')
@@ -126,4 +147,4 @@ for (const entity of entities) {
 const files = fs.readdirSync(path.join(root, 'public', 'data', 'exchanges')).filter((name) => name.endsWith('.json'))
 assert(files.length === entities.length + 1, 'record-level output contains stale or missing JSON files')
 
-console.log(`Validated ${entities.length} HEI record-level machine-readable bundles.`)
+console.log(`Validated ${entities.length} HEI record-level machine-readable bundles and discovery metadata.`)


### PR DESCRIPTION
Closes the remaining verification gap in AI-era Stage C without touching canonical records, Explorer, Compare, Stats, localization evidence, or monitoring queues.

## Changes
- expose `/data/exchanges/index.json` and `/data/exchanges/{slug}.json` through `version.record_level`, `manifest.record_level`, `llms.txt`, and `ai.txt`;
- extend the record-level validator to require that discovery metadata and keep record counts synchronized;
- add a dedicated production verifier for the record-level index plus representative HTX, BTCBOX, and BitradeX bundles;
- run that verifier from the existing post-main machine-readable production smoke workflow;
- syntax-check the new production verifier in CI.

## Safety
- reviewed canonical data remains the only source;
- no canonical entity/event/evidence changes;
- no candidate/staging/private monitoring material is published;
- no Cloudflare configuration change.

## Completion gate
This PR itself does not mark Stage C complete. Merge only after normal PR CI is green. Then require the post-merge production workflow to verify the exact merge commit and the new record-level endpoints before recording Stage C completion and advancing to Stage D.