### PR TITLE
Strengthen Explorer with reviewed provenance filters

### DIFF
--- a/config/explorer-query-contract.json
+++ b/config/explorer-query-contract.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "status": "fixed_for_explorer_v1_implementation",
+  "version": 2,
+  "status": "extended_for_ai_era_stage_d",
   "route": "/explore/",
   "view_parameter": {
     "key": "view",
@@ -13,7 +13,8 @@
     "different_keys": "and",
     "repeated_parameter_encoding": true,
     "deduplicate_repeated_values": true,
-    "repeated_single_value_parameter": "first_valid_value"
+    "repeated_single_value_parameter": "first_valid_value",
+    "evidence_filter_scope": "all active evidence filters must match the same reviewed evidence item"
   },
   "invalid_input": {
     "unknown_parameter": "ignore",
@@ -63,6 +64,11 @@
         {"key": "official_url_status", "kind": "enum", "cardinality": "multi", "values": ["live_verified", "live_unverified", "redirected", "repurposed", "dead_domain", "unsafe", "unknown"]},
         {"key": "archive_available", "kind": "boolean", "cardinality": "single", "values": ["true", "false"]},
         {"key": "confidence", "kind": "enum", "cardinality": "multi", "values": ["high", "medium", "low"]},
+        {"key": "verified_from", "kind": "date", "cardinality": "single"},
+        {"key": "verified_to", "kind": "date", "cardinality": "single"},
+        {"key": "evidence_source_type", "kind": "enum", "cardinality": "multi", "values": ["official_statement", "official_blog", "official_social", "archive_capture", "news_article", "court_document", "regulatory_notice", "database_reference", "community_reference", "other"]},
+        {"key": "evidence_reliability", "kind": "enum", "cardinality": "multi", "values": ["high", "medium", "low"]},
+        {"key": "evidence_archive_available", "kind": "boolean", "cardinality": "single", "values": ["true", "false"]},
         {"key": "country_or_origin", "kind": "reviewed_value", "cardinality": "multi", "matching": "case_insensitive_to_reviewed_canonical_value"},
         {"key": "sort", "kind": "enum", "cardinality": "single", "values": ["name_asc", "name_desc", "launch_oldest", "launch_newest", "death_oldest", "death_newest", "last_verified_newest"]}
       ],
@@ -88,6 +94,9 @@
         {"key": "confidence", "kind": "enum", "cardinality": "multi", "values": ["high", "medium", "low"]},
         {"key": "entity_type", "kind": "enum", "cardinality": "multi", "values": ["cex", "dex", "hybrid"]},
         {"key": "entity_status", "kind": "enum", "cardinality": "multi", "values": ["active", "limited", "inactive", "dead", "merged", "acquired", "rebranded", "unknown"]},
+        {"key": "evidence_source_type", "kind": "enum", "cardinality": "multi", "values": ["official_statement", "official_blog", "official_social", "archive_capture", "news_article", "court_document", "regulatory_notice", "database_reference", "community_reference", "other"]},
+        {"key": "evidence_reliability", "kind": "enum", "cardinality": "multi", "values": ["high", "medium", "low"]},
+        {"key": "evidence_archive_available", "kind": "boolean", "cardinality": "single", "values": ["true", "false"]},
         {"key": "sort", "kind": "enum", "cardinality": "single", "values": ["date_newest", "date_oldest", "entity_name_asc"]}
       ],
       "sort_semantics": {
@@ -108,6 +117,7 @@
     "unknown_future_keys_on_old_parser": "ignore",
     "parameter_rename_after_v1": "requires_spec_change_and_migration_plan",
     "enum_value_change_after_v1": "requires_schema_and_query_contract_review",
-    "serialization_order_change_after_v1": "requires_compatibility_review"
+    "serialization_order_change_after_v1": "requires_compatibility_review",
+    "stage_d_additive_keys": "backward_compatible_old_urls_unchanged"
   }
 }

--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -7,8 +7,8 @@
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
     "entities": 1034,
-    "events": 1037,
-    "evidence": 3867
+    "events": 1039,
+    "evidence": 3871
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",

--- a/docs/HEI_AI_ERA_EXPLORER_STRENGTHENING_SPEC.md
+++ b/docs/HEI_AI_ERA_EXPLORER_STRENGTHENING_SPEC.md
@@ -1,0 +1,157 @@
+# HEI AI-era Explorer/Search Strengthening Specification
+
+Status: implementation specification  
+Stage: AI-era Stage D  
+Route: `/explore/`
+
+Authority:
+
+- `docs/HEI_V1_EXECUTION_ROADMAP.md`
+- `docs/HEI_AI_ERA_REGISTRY_SPEC.md`
+- `docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md`
+- `docs/HEI_EXPLORER_QUERY_CONTRACT.md`
+- `config/explorer-query-contract.json`
+
+## 1. Purpose
+
+Stage D strengthens deterministic discovery before any natural-language filter translation is considered. The existing Entity and Event Explorer already covers identity, lifecycle, status, origin, event, impact, confidence, URL and archive dimensions. Stage D adds reviewed provenance and verification dimensions without replacing the existing query contract or creating an Evidence Explorer.
+
+The implementation remains a reviewed-registry research surface. It is not a risk score, recommendation engine, semantic search service, or LLM-generated answer layer.
+
+## 2. Compatibility boundary
+
+The route and all existing v1 query keys remain unchanged. Existing shared URLs must continue to parse and serialize identically.
+
+Stage D is additive only. New keys are ignored by old parsers under the existing unknown-key compatibility rule.
+
+The fixed route remains:
+
+```text
+/explore/
+```
+
+The existing crawl policy remains:
+
+```text
+base route indexable: yes
+query variants in sitemap: no
+query canonical: /explore/
+generated filter landing pages: no
+```
+
+## 3. Entity Explorer additions
+
+New entity query keys:
+
+```text
+verified_from
+verified_to
+evidence_source_type
+evidence_reliability
+evidence_archive_available
+```
+
+### 3.1 Last verification range
+
+`verified_from` and `verified_to` use the same date normalization and inclusive range semantics as existing lifecycle dates, but operate only on canonical `entity.last_verified_at`.
+
+A record with no valid `last_verified_at` does not match an active verification-date range.
+
+### 3.2 Evidence provenance
+
+`evidence_source_type` uses reviewed canonical evidence `source_type` values.
+
+`evidence_reliability` uses reviewed canonical evidence `reliability` values:
+
+```text
+high
+medium
+low
+```
+
+`evidence_archive_available` uses reviewed canonical `evidence.archived_url`:
+
+```text
+true  -> qualifying evidence item has an archive URL
+false -> qualifying evidence item has no archive URL
+```
+
+When more than one evidence filter is active, all evidence constraints must be satisfied by the same reviewed evidence item. This avoids a result where source type is satisfied by one source and reliability/archive state by an unrelated source.
+
+## 4. Event Explorer additions
+
+New event query keys:
+
+```text
+evidence_source_type
+evidence_reliability
+evidence_archive_available
+```
+
+Event evidence filters operate only on reviewed evidence whose `event_id` directly matches the reviewed event. Entity-level evidence without an event link does not satisfy an Event Explorer provenance filter.
+
+All active evidence constraints must match the same directly linked evidence item.
+
+## 5. Source type domain
+
+Stage D exposes the existing reviewed evidence source-type domain without inventing new classifications:
+
+```text
+official_statement
+official_blog
+official_social
+archive_capture
+news_article
+court_document
+regulatory_notice
+database_reference
+community_reference
+other
+```
+
+## 6. UI requirements
+
+Entity Explorer must expose compact controls for:
+
+- last-verified date range;
+- evidence source type;
+- evidence reliability;
+- evidence archive state.
+
+Event Explorer must expose compact controls for:
+
+- directly linked evidence source type;
+- directly linked evidence reliability;
+- directly linked evidence archive state.
+
+Existing desktop/mobile density, native details/summary filter groups, keyboard behavior, shareable URL state, and clear-all behavior remain required.
+
+## 7. Safety
+
+Stage D must not:
+
+- expose raw evidence monitoring output;
+- expose staging candidates;
+- expose private notes;
+- infer source quality beyond reviewed `reliability`;
+- create a synthetic provenance score;
+- generate arbitrary SEO pages from query combinations;
+- change canonical entity/event/evidence facts.
+
+## 8. Validation
+
+Completion requires:
+
+- query contract validator passes;
+- query round-trip tests cover new keys;
+- old canonical URL serialization remains unchanged;
+- Entity and Event filters consume reviewed evidence only;
+- evidence constraints use same-item matching;
+- English and Japanese Explorer routes load the same reviewed evidence set while keeping canonical query keys locale-independent;
+- final Explorer audit confirms accessibility, crawl policy and provenance wiring;
+- full repository CI passes;
+- production/read-only verification confirms the deployed Stage D commit before completion is recorded.
+
+## 9. Handoff
+
+After Stage D is production-verified, AI-era Stage E may extend Compare with deterministic provenance/lifecycle fields. Natural-language query translation remains deferred until Stages B through G are complete and a separate evaluation justifies it.

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,19 +52,21 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. With post-D-1000 BX62, the current reviewed state is:
+Reviewed canonical growth continues after D-1000. BX62 established 1034 reviewed entities; subsequent reviewed lifecycle/regulatory additions did not add entities but advanced event/evidence coverage. The current reviewed state under build aggregation semantics is:
 
 ```text
 Entities: 1034
-Events:   1037
-Evidence: 3867
+Events:   1039
+Evidence: 3871
 ```
 
-Current post-D-1000 growth authority:
+Post-D-1000 entity-growth authority remains:
 
 ```text
 docs/audits/HEI_POST_D1000_GROWTH_BX62_2026-08-13.md
 ```
+
+Later reviewed lifecycle additions are represented by their merged exchange record bundles and normal reviewed aggregation; they do not alter the D-1000 or BX62 entity milestone authority.
 
 The localization decision remains HOLD until real evaluation evidence is complete. D-1000 completion and later canonical growth do not expand translation breadth and do not authorize a third language.
 

--- a/scripts/audit-explorer-final.mjs
+++ b/scripts/audit-explorer-final.mjs
@@ -45,6 +45,9 @@ assert(exploreHtml.includes('aria-label="Search reviewed entities"'), 'Entity se
 assert(exploreHtml.includes('type="checkbox"'), 'Entity filter checkboxes are missing from generated Explorer output')
 assert(exploreHtml.includes('<label'), 'Explorer filter controls lack label elements')
 assert(exploreHtml.includes('<summary>'), 'Explorer filter groups are not native keyboard-operable details/summary controls')
+assert(exploreHtml.includes('Evidence source type'), 'Entity provenance source-type controls missing from generated Explorer')
+assert(exploreHtml.includes('Evidence reliability'), 'Entity provenance reliability controls missing from generated Explorer')
+assert(exploreHtml.includes('Last verified'), 'Entity last-verified controls missing from generated Explorer')
 
 const canonicalMatches = [...exploreHtml.matchAll(/<link\b[^>]*rel=["']canonical["'][^>]*href=["']([^"']+)["']/gi)]
 assert(canonicalMatches.length === 1, `Explorer canonical count is ${canonicalMatches.length}`)
@@ -90,6 +93,9 @@ for (const [label, html] of sourcePages) {
 
 const entitySource = read('src/components/explorer/entity-explorer-client.tsx')
 const eventSource = read('src/components/explorer/event-explorer-panel.tsx')
+const entityQuerySource = read('src/lib/explorer/entity-query.ts')
+const eventQuerySource = read('src/lib/explorer/event-query.ts')
+const explorePageSource = read('src/app/explore/page.tsx')
 const explorerCss = read('src/components/explorer/entity-explorer-client.module.css')
 
 for (const marker of [
@@ -98,23 +104,39 @@ for (const marker of [
   'aria-label="Archive availability"',
   'aria-label="Sort entities"',
   'aria-label="Country or origin values"',
+  'aria-label="Evidence archive availability"',
+  'evidence_source_type',
+  'evidence_reliability',
+  'verified_from',
+  'verified_to',
   'type="date"',
   'type="checkbox"',
   'type="button"',
 ]) {
-  assert(entitySource.includes(marker), `Entity Explorer accessibility marker missing: ${marker}`)
+  assert(entitySource.includes(marker), `Entity Explorer accessibility/provenance marker missing: ${marker}`)
 }
 
 for (const marker of [
   'aria-label="Search reviewed events"',
   'aria-label="Sort events"',
+  'aria-label="Event evidence archive availability"',
+  'evidence_source_type',
+  'evidence_reliability',
+  'evidence_archive_available',
   'type="date"',
   'type="checkbox"',
   'type="button"',
 ]) {
-  assert(eventSource.includes(marker), `Event Explorer accessibility marker missing: ${marker}`)
+  assert(eventSource.includes(marker), `Event Explorer accessibility/provenance marker missing: ${marker}`)
 }
 
+for (const marker of ['evidenceByEntity', 'evidenceMatches', 'verified_from', 'evidence_source_type']) {
+  assert(entityQuerySource.includes(marker), `Entity provenance filtering not wired: ${marker}`)
+}
+for (const marker of ['evidenceByEvent', 'evidenceMatches', 'evidence_source_type']) {
+  assert(eventQuerySource.includes(marker), `Event provenance filtering not wired: ${marker}`)
+}
+assert(explorePageSource.includes('loadEvidence'), 'Explorer page does not load reviewed evidence')
 assert(explorerCss.includes('@media(max-width:1023px)'), 'Explorer tablet responsive rule missing')
 assert(explorerCss.includes('@media(max-width:720px)'), 'Explorer mobile responsive rule missing')
 assert(entitySource.includes('serializeEntityExplorerState'), 'Entity URL serialization not wired to UI')
@@ -123,4 +145,4 @@ assert(entitySource.includes('getExplorerView'), 'Explorer view parser not wired
 assert(!exploreHtml.includes('data-staging'), 'Explorer output leaks staging path')
 assert(!exploreHtml.includes('candidate_class'), 'Explorer output leaks candidate fields')
 
-console.log(`Explorer final audit passed: base route crawl policy fixed, ${queryLinkCount} Stats/Change query links validated, accessibility and mobile source contracts present.`)
+console.log(`Explorer final audit passed: provenance filters, crawl policy, ${queryLinkCount} Stats/Change query links, accessibility and mobile source contracts validated.`)

--- a/scripts/test-explorer-query-contract.mjs
+++ b/scripts/test-explorer-query-contract.mjs
@@ -31,7 +31,7 @@ function run() {
   assert.equal(
     canonicalizeExplorerQuery('status=dead&type=dex&type=cex&view=entities&type=dex', contract, reviewedValues),
     'view=entities&type=cex&type=dex&status=dead',
-    'canonical parameter order',
+    'canonical parameter order remains backward compatible',
   )
 
   equal(
@@ -76,6 +76,43 @@ function run() {
     'inverted valid ranges are preserved for deterministic empty-result handling',
   )
 
+  equal(
+    parseExplorerQuery('view=entities&verified_from=2026&verified_to=2026-08-16&evidence_source_type=regulatory_notice&evidence_source_type=official_statement&evidence_reliability=high&evidence_archive_available=true', contract, reviewedValues),
+    {
+      view: 'entities',
+      verified_from: '2026-01-01',
+      verified_to: '2026-08-16',
+      evidence_source_type: ['official_statement', 'regulatory_notice'],
+      evidence_reliability: ['high'],
+      evidence_archive_available: 'true',
+    },
+    'entity verification and evidence provenance filters normalize deterministically',
+  )
+
+  assert.equal(
+    canonicalizeExplorerQuery('view=entities&status=dead&evidence_reliability=medium&evidence_source_type=news_article&verified_from=2026'),
+    'view=entities&status=dead&verified_from=2026-01-01&evidence_source_type=news_article&evidence_reliability=medium',
+    'entity provenance keys serialize in additive contract order',
+  )
+
+  equal(
+    parseExplorerQuery('view=events&event_type=regulatory_action&evidence_source_type=regulatory_notice&evidence_reliability=high&evidence_archive_available=false', contract, reviewedValues),
+    {
+      view: 'events',
+      event_type: ['regulatory_action'],
+      evidence_source_type: ['regulatory_notice'],
+      evidence_reliability: ['high'],
+      evidence_archive_available: 'false',
+    },
+    'event provenance filters parse against directly linked evidence dimensions',
+  )
+
+  assert.equal(
+    canonicalizeExplorerQuery('view=events&evidence_archive_available=true&evidence_reliability=low&evidence_source_type=community_reference&sort=entity_name_asc'),
+    'view=events&evidence_source_type=community_reference&evidence_reliability=low&evidence_archive_available=true&sort=entity_name_asc',
+    'event provenance keys have stable serialization order',
+  )
+
   const firstOrigin = reviewedValues.entities.country_or_origin[0]
   assert.ok(firstOrigin, 'reviewed origin values should not be empty')
   const originLower = firstOrigin.toLocaleLowerCase('en-US')
@@ -102,6 +139,7 @@ function run() {
 
   assert.equal(normalizeExplorerDate('2020', 'launch_from', contract), '2020-01-01')
   assert.equal(normalizeExplorerDate('2020', 'launch_to', contract), '2020-12-31')
+  assert.equal(normalizeExplorerDate('2020', 'verified_from', contract), '2020-01-01')
   assert.equal(normalizeExplorerDate('2020-02-29', 'launch_from', contract), '2020-02-29')
   assert.equal(normalizeExplorerDate('2021-02-29', 'launch_from', contract), null)
 
@@ -137,10 +175,10 @@ function run() {
   assert.equal(
     explorerQueryHref({ view: 'entities', status: ['dead'], type: ['dex'] }, contract, reviewedValues),
     '/explore/?view=entities&type=dex&status=dead',
-    'href helper uses canonical route and query order',
+    'href helper preserves existing canonical route and query order',
   )
 
-  console.log('Explorer query contract tests passed.')
+  console.log('Explorer query contract v2 provenance-extension tests passed.')
 }
 
 run()

--- a/scripts/validate-explorer-query-contract.mjs
+++ b/scripts/validate-explorer-query-contract.mjs
@@ -17,8 +17,8 @@ function readJson(filePath) {
 const contract = readJson(contractPath)
 const handoff = readJson(handoffPath)
 
-assert(contract.version === 1, 'contract version must be 1')
-assert(contract.status === 'fixed_for_explorer_v1_implementation', 'contract status is not fixed for v1 implementation')
+assert(contract.version === 2, 'contract version must be 2 after the AI-era provenance extension')
+assert(contract.status === 'extended_for_ai_era_stage_d', 'contract status is not the AI-era Stage D extension')
 assert(contract.route === '/explore/', 'Explorer route must be /explore/')
 assert(contract.view_parameter?.key === 'view', 'view parameter key must be view')
 assert(contract.view_parameter?.default === 'entities', 'default view must be entities')
@@ -29,6 +29,7 @@ assert(contract.combination_semantics?.same_key_multiple_values === 'or', 'same-
 assert(contract.combination_semantics?.different_keys === 'and', 'different keys must use AND semantics')
 assert(contract.combination_semantics?.repeated_parameter_encoding === true, 'multi-value encoding must use repeated parameters')
 assert(contract.combination_semantics?.deduplicate_repeated_values === true, 'multi-value dedupe must be enabled')
+assert(contract.combination_semantics?.evidence_filter_scope === 'all active evidence filters must match the same reviewed evidence item', 'evidence filter scope changed')
 
 assert(contract.invalid_input?.unknown_parameter === 'ignore', 'unknown parameters must be ignored')
 assert(contract.invalid_input?.cross_view_parameter === 'ignore', 'cross-view parameters must be ignored')
@@ -74,10 +75,25 @@ for (const viewName of contract.view_parameter.values) {
   for (const value of sort.values) assert(Array.isArray(view.sort_semantics?.[value]) && view.sort_semantics[value].length > 0, `sort semantics missing: ${viewName}:${value}`)
 }
 
+const entityKeys = new Set(contract.views.entities.parameters.map((parameter) => parameter.key))
+for (const key of ['verified_from', 'verified_to', 'evidence_source_type', 'evidence_reliability', 'evidence_archive_available']) {
+  assert(entityKeys.has(key), `AI-era entity provenance key missing: ${key}`)
+}
+const eventKeys = new Set(contract.views.events.parameters.map((parameter) => parameter.key))
+for (const key of ['evidence_source_type', 'evidence_reliability', 'evidence_archive_available']) {
+  assert(eventKeys.has(key), `AI-era event provenance key missing: ${key}`)
+}
+const sourceTypes = contract.views.entities.parameters.find((parameter) => parameter.key === 'evidence_source_type')?.values
+assert(JSON.stringify(sourceTypes) === JSON.stringify(contract.views.events.parameters.find((parameter) => parameter.key === 'evidence_source_type')?.values), 'entity/event source-type filters differ')
+const reliabilities = contract.views.entities.parameters.find((parameter) => parameter.key === 'evidence_reliability')?.values
+assert(JSON.stringify(reliabilities) === JSON.stringify(['high', 'medium', 'low']), 'evidence reliability filter values changed')
+assert(JSON.stringify(reliabilities) === JSON.stringify(contract.views.events.parameters.find((parameter) => parameter.key === 'evidence_reliability')?.values), 'entity/event reliability filters differ')
+
 assert(contract.crawl_policy?.base_route_indexable === true, 'base Explorer route must be indexable')
 assert(contract.crawl_policy?.canonical_for_all_query_variants === '/explore/', 'query variant canonical must point to /explore/')
 assert(contract.crawl_policy?.query_variants_in_sitemap === false, 'query variants must stay out of sitemap')
 assert(contract.crawl_policy?.generated_filter_landing_pages === false, 'generated filter landing pages must remain disabled')
+assert(contract.compatibility?.stage_d_additive_keys === 'backward_compatible_old_urls_unchanged', 'Stage D compatibility marker missing')
 
 assert(handoff.status === 'deep_links_enabled_on_fixed_explorer_v1_contract', 'Stats handoff status is not enabled')
 assert(handoff.explorer_route === contract.route, 'Stats handoff route differs from query contract')
@@ -96,7 +112,7 @@ for (const dimension of handoff.dimensions) {
 }
 
 const evidenceDimension = handoff.dimensions.find((dimension) => dimension.id === 'evidence_dimensions')
-assert(evidenceDimension?.destination_view === 'deferred_evidence', 'Evidence dimensions must remain deferred')
-assert(evidenceDimension?.query_keys.length === 0, 'Evidence dimensions must expose no query keys')
+assert(evidenceDimension?.destination_view === 'deferred_evidence', 'Evidence dimensions remain outside a dedicated Evidence Explorer')
+assert(evidenceDimension?.query_keys.length === 0, 'Stats evidence dimensions remain unlinked until separately authorized')
 
-console.log(`Validated Explorer query contract v${contract.version}: Stats deep links enabled across ${handoff.dimensions.length} mapped dimensions.`)
+console.log(`Validated Explorer query contract v${contract.version}: AI-era provenance filters enabled; ${handoff.dimensions.length} existing Stats mappings remain compatible.`)

--- a/scripts/validate-v1-baseline.mjs
+++ b/scripts/validate-v1-baseline.mjs
@@ -92,8 +92,20 @@ function checkSitemap() {
 function checkExplorerAndI18n(reviewedCounts) {
   const explorer = readJson('config/explorer-query-contract.json')
   const i18n = readJson('config/i18n-locales.json')
-  if (explorer.version !== contract.schema_versions.explorer_query_contract_version) add('explorer_contract_mismatch', 'explorer_version_mismatch')
+  const baselineExplorerVersion = contract.schema_versions.explorer_query_contract_version
+  if (!Number.isInteger(explorer.version) || explorer.version < baselineExplorerVersion) {
+    add('explorer_contract_mismatch', 'explorer_version_below_v1_baseline', { actual: explorer.version, baseline: baselineExplorerVersion })
+  }
   if (explorer.route !== contract.public_route_contract.explorer_query_canonical) add('explorer_contract_mismatch', 'explorer_route_mismatch')
+  if (explorer.view_parameter?.key !== 'view' || !containsAll(explorer.view_parameter?.values ?? [], ['entities', 'events'])) {
+    add('explorer_contract_mismatch', 'explorer_v1_view_contract_missing')
+  }
+  if (explorer.crawl_policy?.canonical_for_all_query_variants !== contract.public_route_contract.explorer_query_canonical) {
+    add('explorer_contract_mismatch', 'explorer_query_canonical_changed')
+  }
+  if (explorer.crawl_policy?.query_variants_in_sitemap !== contract.public_route_contract.explorer_query_variants_in_sitemap) {
+    add('explorer_contract_mismatch', 'explorer_query_sitemap_policy_changed')
+  }
   const expected = contract.localization_foundation
   if (i18n.version !== contract.schema_versions.i18n_locale_contract_version) add('localization_mismatch', 'i18n_version_mismatch')
   for (const key of ['default_locale', 'fallback_locale']) if (i18n[key] !== expected[key]) add('localization_mismatch', `${key}_mismatch`)

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import EntityExplorerClient from '../../components/explorer/entity-explorer-client'
 import { loadEntities } from '../../lib/data/load-entities'
 import { loadEvents } from '../../lib/data/load-events'
+import { loadEvidence } from '../../lib/data/load-evidence'
 import {
   buildLocalizedPageMetadata,
   getPagePresentation,
@@ -24,6 +25,7 @@ export function generateMetadata(): Metadata {
 export default function ExplorePage() {
   const entities = loadEntities()
   const events = loadEvents()
+  const evidence = loadEvidence()
   const presentation = getPagePresentation('en', 'explore')
   const reviewedOrigins = [...new Set(
     entities
@@ -62,7 +64,7 @@ export default function ExplorePage() {
       </section>
 
       <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>Loading Explorer query state…</div></div></section>}>
-        <EntityExplorerClient entities={entities} events={events} reviewedOrigins={reviewedOrigins} />
+        <EntityExplorerClient entities={entities} events={events} evidence={evidence} reviewedOrigins={reviewedOrigins} />
       </Suspense>
     </main>
   )

--- a/src/app/ja/explore/page.tsx
+++ b/src/app/ja/explore/page.tsx
@@ -4,6 +4,7 @@ import JapanesePilotSurface from '../../../components/i18n/japanese-pilot-surfac
 import EntityExplorerClient from '../../../components/explorer/entity-explorer-client'
 import { loadEntities } from '../../../lib/data/load-entities'
 import { loadEvents } from '../../../lib/data/load-events'
+import { loadEvidence } from '../../../lib/data/load-evidence'
 import { buildLocalizedPageMetadata, getPagePresentation } from '../../../lib/i18n/page-presentations'
 
 export function generateMetadata(): Metadata {
@@ -13,6 +14,7 @@ export function generateMetadata(): Metadata {
 export default function JapaneseExplorePage() {
   const entities = loadEntities()
   const events = loadEvents()
+  const evidence = loadEvidence()
   const reviewedOrigins = [...new Set(
     entities
       .map((entity) => entity.country_or_origin)
@@ -22,7 +24,7 @@ export default function JapaneseExplorePage() {
   return (
     <JapanesePilotSurface presentation={getPagePresentation('ja', 'explore')} englishHref="/explore/">
       <Suspense fallback={<section className="panel table-panel"><div className="results-meta"><div>クエリ状態を読み込み中…</div></div></section>}>
-        <EntityExplorerClient entities={entities} events={events} reviewedOrigins={reviewedOrigins} />
+        <EntityExplorerClient entities={entities} events={events} evidence={evidence} reviewedOrigins={reviewedOrigins} />
       </Suspense>
     </JapanesePilotSurface>
   )

--- a/src/components/explorer/entity-explorer-client.tsx
+++ b/src/components/explorer/entity-explorer-client.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import type { EntityRecord } from '../../lib/types/entity'
 import type { EventRecord } from '../../lib/types/event'
+import type { EvidenceRecord } from '../../lib/types/evidence'
 import {
   countEntityExplorerFilters,
   ENTITY_FILTER_VALUES,
@@ -25,8 +26,8 @@ import styles from './entity-explorer-client.module.css'
 const INITIAL_VISIBLE = 40
 const LOAD_MORE_STEP = 40
 
-type Props = { entities: EntityRecord[]; events: EventRecord[]; reviewedOrigins: string[] }
-type MultiKey = 'type' | 'status' | 'death_reason' | 'official_url_status' | 'confidence' | 'country_or_origin'
+type Props = { entities: EntityRecord[]; events: EventRecord[]; evidence: EvidenceRecord[]; reviewedOrigins: string[] }
+type MultiKey = 'type' | 'status' | 'death_reason' | 'official_url_status' | 'confidence' | 'evidence_source_type' | 'evidence_reliability' | 'country_or_origin'
 
 const titleCase = (value: string) => value.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
 
@@ -60,26 +61,35 @@ function Results({ entities, state }: { entities: EntityRecord[]; state: EntityE
   </>
 }
 
-export default function EntityExplorerClient({ entities, events, reviewedOrigins }: Props) {
+export default function EntityExplorerClient({ entities, events, evidence, reviewedOrigins }: Props) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const view = getExplorerView(searchParams)
   const state = useMemo(() => parseEntityExplorerState(searchParams, reviewedOrigins), [searchParams, reviewedOrigins])
+  const evidenceByEntity = useMemo(() => {
+    const map = new Map<string, EvidenceRecord[]>()
+    for (const item of evidence) {
+      const list = map.get(item.exchange_id) ?? []
+      list.push(item)
+      map.set(item.exchange_id, list)
+    }
+    return map
+  }, [evidence])
   const patch = (next: Partial<EntityExplorerState>) => router.replace(`${pathname}?${serializeEntityExplorerState({ ...state, ...next, view: 'entities' }, reviewedOrigins)}`, { scroll: false })
   const toggle = (key: MultiKey, value: string) => {
     const current = state[key] as string[]
     patch({ [key]: current.includes(value) ? current.filter((item) => item !== value) : [...current, value] } as Partial<EntityExplorerState>)
   }
-  const result = useMemo(() => sortEntityExplorerRecords(filterEntityExplorerRecords(entities, state), state.sort), [entities, state])
+  const result = useMemo(() => sortEntityExplorerRecords(filterEntityExplorerRecords(entities, state, evidenceByEntity), state.sort), [entities, state, evidenceByEntity])
   const filterCount = countEntityExplorerFilters(state)
   const resultKey = serializeEntityExplorerState(state, reviewedOrigins)
 
   return <section className={`panel table-panel ${styles.shell}`}>
     <nav className={styles.viewTabs} aria-label="Explorer views"><Link className={`${styles.viewTab} ${view === 'entities' ? styles.viewTabActive : ''}`} href="/explore/?view=entities">Entity Explorer</Link><Link className={`${styles.viewTab} ${view === 'events' ? styles.viewTabActive : ''}`} href="/explore/?view=events">Event Explorer</Link><Link className={styles.viewTab} href="/compare/">Compare</Link></nav>
-    {view === 'events' ? <EventExplorerPanel events={events} entities={entities} /> : <>
+    {view === 'events' ? <EventExplorerPanel events={events} entities={entities} evidence={evidence} /> : <>
       <div className={styles.controlStack}>
-        <div className={styles.primaryControls}><div className="search"><input className="field" aria-label="Search reviewed entities" placeholder="Search name, alias, slug, summary, or origin" value={state.q} onChange={(event) => patch({ q: event.target.value })} /></div><select className="field" aria-label="Archive availability" value={state.archive_available} onChange={(event) => patch({ archive_available: event.target.value as EntityExplorerState['archive_available'] })}><option value="">Any archive state</option><option value="true">Archive available</option><option value="false">No archive URL</option></select><select className="field" aria-label="Sort entities" value={state.sort} onChange={(event) => patch({ sort: event.target.value as EntityExplorerState['sort'] })}>{ENTITY_FILTER_VALUES.sort.map((value) => <option value={value} key={value}>{titleCase(value)}</option>)}</select></div>
+        <div className={styles.primaryControls}><div className="search"><input className="field" aria-label="Search reviewed entities" placeholder="Search name, alias, slug, summary, or origin" value={state.q} onChange={(event) => patch({ q: event.target.value })} /></div><select className="field" aria-label="Archive availability" value={state.archive_available} onChange={(event) => patch({ archive_available: event.target.value as EntityExplorerState['archive_available'] })}><option value="">Any entity archive state</option><option value="true">Entity archive available</option><option value="false">No entity archive URL</option></select><select className="field" aria-label="Sort entities" value={state.sort} onChange={(event) => patch({ sort: event.target.value as EntityExplorerState['sort'] })}>{ENTITY_FILTER_VALUES.sort.map((value) => <option value={value} key={value}>{titleCase(value)}</option>)}</select></div>
         <div className={styles.filterGrid}>
           <Group title="Type" count={state.type.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.type} selected={state.type} labelFor={(value) => value === 'hybrid' ? 'Hybrid' : value.toUpperCase()} onToggle={(value) => toggle('type', value)} /></Group>
           <Group title="Status" count={state.status.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.status} selected={state.status} labelFor={(value) => STATUS_LABELS[value as keyof typeof STATUS_LABELS]} onToggle={(value) => toggle('status', value)} /></Group>
@@ -88,6 +98,10 @@ export default function EntityExplorerClient({ entities, events, reviewedOrigins
           <Group title="Death date" count={state.death_from || state.death_to ? 'set' : 'all'}><Dates from={state.death_from} to={state.death_to} onFrom={(value) => patch({ death_from: value })} onTo={(value) => patch({ death_to: value })} /></Group>
           <Group title="URL status" count={state.official_url_status.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.official_url_status} selected={state.official_url_status} labelFor={(value) => URL_STATUS_LABELS[value as keyof typeof URL_STATUS_LABELS]} onToggle={(value) => toggle('official_url_status', value)} /></Group>
           <Group title="Confidence" count={state.confidence.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.confidence} selected={state.confidence} labelFor={titleCase} onToggle={(value) => toggle('confidence', value)} /></Group>
+          <Group title="Last verified" count={state.verified_from || state.verified_to ? 'set' : 'all'}><Dates from={state.verified_from} to={state.verified_to} onFrom={(value) => patch({ verified_from: value })} onTo={(value) => patch({ verified_to: value })} /></Group>
+          <Group title="Evidence source type" count={state.evidence_source_type.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.evidence_source_type} selected={state.evidence_source_type} labelFor={titleCase} onToggle={(value) => toggle('evidence_source_type', value)} /></Group>
+          <Group title="Evidence reliability" count={state.evidence_reliability.length || 'all'}><Checks values={ENTITY_FILTER_VALUES.evidence_reliability} selected={state.evidence_reliability} labelFor={titleCase} onToggle={(value) => toggle('evidence_reliability', value)} /></Group>
+          <Group title="Evidence archive" count={state.evidence_archive_available || 'all'}><div className={styles.optionList}><label className={styles.dateLabel}>Reviewed evidence archive state<select className="field" aria-label="Evidence archive availability" value={state.evidence_archive_available} onChange={(event) => patch({ evidence_archive_available: event.target.value as EntityExplorerState['evidence_archive_available'] })}><option value="">Any evidence archive state</option><option value="true">Includes archived evidence</option><option value="false">Includes evidence without archive</option></select></label><div className={styles.originHelp}>When combined with source type or reliability, all evidence constraints must match the same reviewed evidence item.</div></div></Group>
           <Group title="Country / origin" count={state.country_or_origin.length || 'all'}><div className={styles.originHelp}>Select one or more reviewed canonical origin values.</div><div className={styles.optionList}><select className={styles.originSelect} multiple value={state.country_or_origin} onChange={(event) => patch({ country_or_origin: Array.from(event.currentTarget.selectedOptions).map((option) => option.value) })} aria-label="Country or origin values">{reviewedOrigins.map((origin) => <option key={origin} value={origin}>{origin}</option>)}</select></div></Group>
         </div>
         <div className={styles.toolbar}><div className={styles.toolbarMeta}>{filterCount === 0 ? 'No active filters · default Entity view' : `${filterCount} active query constraints`}</div><div className={styles.toolbarActions}>{filterCount > 0 ? <button type="button" className="btn btn-ghost" onClick={() => router.replace(`${pathname}?view=entities`, { scroll: false })}>Clear all filters</button> : null}</div></div>

--- a/src/components/explorer/event-explorer-panel.tsx
+++ b/src/components/explorer/event-explorer-panel.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import type { EntityRecord } from '../../lib/types/entity'
 import type { EventRecord } from '../../lib/types/event'
+import type { EvidenceRecord } from '../../lib/types/evidence'
 import {
   countEventExplorerFilters,
   EVENT_FILTER_VALUES,
@@ -23,9 +24,10 @@ const LOAD_MORE_STEP = 50
 type Props = {
   events: EventRecord[]
   entities: EntityRecord[]
+  evidence: EvidenceRecord[]
 }
 
-type MultiKey = 'event_type' | 'impact_level' | 'event_status_effect' | 'confidence' | 'entity_type' | 'entity_status'
+type MultiKey = 'event_type' | 'impact_level' | 'event_status_effect' | 'confidence' | 'entity_type' | 'entity_status' | 'evidence_source_type' | 'evidence_reliability'
 
 function titleCase(value: string) {
   return value.split('_').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
@@ -145,17 +147,27 @@ function EventResults({ events, entityById, state }: {
           <div className="registry-load-more-note">{remaining} remaining in current query</div>
         </div>
       ) : null}
-      <div className={styles.resultHint}>Sort: {titleCase(state.sort)} · Parent exchange context is reviewed HEI entity data.</div>
+      <div className={styles.resultHint}>Sort: {titleCase(state.sort)} · Evidence filters use directly event-linked reviewed evidence only.</div>
     </>
   )
 }
 
-export default function EventExplorerPanel({ events, entities }: Props) {
+export default function EventExplorerPanel({ events, entities, evidence }: Props) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const state = useMemo(() => parseEventExplorerState(searchParams), [searchParams])
   const entityById = useMemo(() => new Map(entities.map((entity) => [entity.id, entity])), [entities])
+  const evidenceByEvent = useMemo(() => {
+    const map = new Map<string, EvidenceRecord[]>()
+    for (const item of evidence) {
+      if (!item.event_id) continue
+      const list = map.get(item.event_id) ?? []
+      list.push(item)
+      map.set(item.event_id, list)
+    }
+    return map
+  }, [evidence])
 
   const updateState = (next: EventExplorerState) => router.replace(`${pathname}?${serializeEventExplorerState(next)}`, { scroll: false })
   const patchState = (patch: Partial<EventExplorerState>) => updateState({ ...state, ...patch, view: 'events' })
@@ -166,8 +178,8 @@ export default function EventExplorerPanel({ events, entities }: Props) {
   }
 
   const filteredAndSorted = useMemo(
-    () => sortEventExplorerRecords(filterEventExplorerRecords(events, entityById, state), entityById, state.sort),
-    [events, entityById, state],
+    () => sortEventExplorerRecords(filterEventExplorerRecords(events, entityById, state, evidenceByEvent), entityById, state.sort),
+    [events, entityById, state, evidenceByEvent],
   )
   const filterCount = countEventExplorerFilters(state)
   const resultKey = serializeEventExplorerState(state)
@@ -190,6 +202,9 @@ export default function EventExplorerPanel({ events, entities }: Props) {
           <FilterGroup title="Confidence" count={state.confidence.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.confidence} selected={state.confidence} labelFor={titleCase} onToggle={(value) => toggleMulti('confidence', value)} /></FilterGroup>
           <FilterGroup title="Parent type" count={state.entity_type.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.entity_type} selected={state.entity_type} labelFor={(value) => value === 'hybrid' ? 'Hybrid' : value.toUpperCase()} onToggle={(value) => toggleMulti('entity_type', value)} /></FilterGroup>
           <FilterGroup title="Parent status" count={state.entity_status.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.entity_status} selected={state.entity_status} labelFor={(value) => STATUS_LABELS[value as keyof typeof STATUS_LABELS]} onToggle={(value) => toggleMulti('entity_status', value)} /></FilterGroup>
+          <FilterGroup title="Evidence source type" count={state.evidence_source_type.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.evidence_source_type} selected={state.evidence_source_type} labelFor={titleCase} onToggle={(value) => toggleMulti('evidence_source_type', value)} /></FilterGroup>
+          <FilterGroup title="Evidence reliability" count={state.evidence_reliability.length || 'all'}><CheckboxList values={EVENT_FILTER_VALUES.evidence_reliability} selected={state.evidence_reliability} labelFor={titleCase} onToggle={(value) => toggleMulti('evidence_reliability', value)} /></FilterGroup>
+          <FilterGroup title="Evidence archive" count={state.evidence_archive_available || 'all'}><div className={styles.optionList}><label className={styles.dateLabel}>Direct event evidence archive state<select className="field" aria-label="Event evidence archive availability" value={state.evidence_archive_available} onChange={(event) => patchState({ evidence_archive_available: event.target.value as EventExplorerState['evidence_archive_available'] })}><option value="">Any evidence archive state</option><option value="true">Includes archived evidence</option><option value="false">Includes evidence without archive</option></select></label><div className={styles.originHelp}>All active evidence filters must match the same directly linked reviewed evidence item.</div></div></FilterGroup>
         </div>
 
         <div className={styles.toolbar}>

--- a/src/lib/explorer/entity-query.ts
+++ b/src/lib/explorer/entity-query.ts
@@ -1,5 +1,6 @@
 import contractJson from '../../../config/explorer-query-contract.json'
 import type { Confidence, DeathReason, EntityRecord, ExchangeStatus, ExchangeType, UrlStatus } from '../types/entity'
+import type { EvidenceRecord, Reliability, SourceType } from '../types/evidence'
 
 type EntitySort =
   | 'name_asc'
@@ -25,6 +26,11 @@ export interface EntityExplorerState {
   official_url_status: UrlStatus[]
   archive_available: ArchiveAvailable
   confidence: Confidence[]
+  verified_from: string
+  verified_to: string
+  evidence_source_type: SourceType[]
+  evidence_reliability: Reliability[]
+  evidence_archive_available: ArchiveAvailable
   country_or_origin: string[]
   sort: EntitySort
 }
@@ -69,6 +75,8 @@ export const ENTITY_FILTER_VALUES = {
   death_reason: getEnumValues<Exclude<DeathReason, null>>('death_reason'),
   official_url_status: getEnumValues<UrlStatus>('official_url_status'),
   confidence: getEnumValues<Confidence>('confidence'),
+  evidence_source_type: getEnumValues<SourceType>('evidence_source_type'),
+  evidence_reliability: getEnumValues<Reliability>('evidence_reliability'),
   sort: getEnumValues<EntitySort>('sort'),
 }
 
@@ -185,6 +193,11 @@ export function parseEntityExplorerState(
     official_url_status: stableEnumValues<UrlStatus>(params.getAll('official_url_status'), 'official_url_status'),
     archive_available: firstValidBoolean(params, 'archive_available'),
     confidence: stableEnumValues<Confidence>(params.getAll('confidence'), 'confidence'),
+    verified_from: firstValidDate(params, 'verified_from'),
+    verified_to: firstValidDate(params, 'verified_to'),
+    evidence_source_type: stableEnumValues<SourceType>(params.getAll('evidence_source_type'), 'evidence_source_type'),
+    evidence_reliability: stableEnumValues<Reliability>(params.getAll('evidence_reliability'), 'evidence_reliability'),
+    evidence_archive_available: firstValidBoolean(params, 'evidence_archive_available'),
     country_or_origin: stableReviewedValues(params.getAll('country_or_origin'), reviewedOrigins),
     sort: firstValidSort(params),
   }
@@ -210,6 +223,11 @@ export function serializeEntityExplorerState(state: EntityExplorerState, reviewe
   appendMany(params, 'official_url_status', normalized.official_url_status)
   if (normalized.archive_available) params.append('archive_available', normalized.archive_available)
   appendMany(params, 'confidence', normalized.confidence)
+  if (normalized.verified_from) params.append('verified_from', normalized.verified_from)
+  if (normalized.verified_to) params.append('verified_to', normalized.verified_to)
+  appendMany(params, 'evidence_source_type', normalized.evidence_source_type)
+  appendMany(params, 'evidence_reliability', normalized.evidence_reliability)
+  if (normalized.evidence_archive_available) params.append('evidence_archive_available', normalized.evidence_archive_available)
   appendMany(params, 'country_or_origin', normalized.country_or_origin)
   if (normalized.sort !== ENTITY_DEFAULT_SORT) params.append('sort', normalized.sort)
 
@@ -230,6 +248,11 @@ function stateToParams(state: EntityExplorerState) {
   appendMany(params, 'official_url_status', state.official_url_status)
   if (state.archive_available) params.append('archive_available', state.archive_available)
   appendMany(params, 'confidence', state.confidence)
+  if (state.verified_from) params.append('verified_from', state.verified_from)
+  if (state.verified_to) params.append('verified_to', state.verified_to)
+  appendMany(params, 'evidence_source_type', state.evidence_source_type)
+  appendMany(params, 'evidence_reliability', state.evidence_reliability)
+  if (state.evidence_archive_available) params.append('evidence_archive_available', state.evidence_archive_available)
   appendMany(params, 'country_or_origin', state.country_or_origin)
   if (state.sort) params.append('sort', state.sort)
   return params
@@ -268,9 +291,28 @@ function matchesAny<T extends string>(value: T | null, filters: T[]) {
   return filters.length === 0 || (value !== null && filters.includes(value))
 }
 
-export function filterEntityExplorerRecords(entities: EntityRecord[], state: EntityExplorerState) {
+function hasEvidenceConstraints(state: EntityExplorerState) {
+  return state.evidence_source_type.length > 0
+    || state.evidence_reliability.length > 0
+    || Boolean(state.evidence_archive_available)
+}
+
+function evidenceMatches(item: EvidenceRecord, state: EntityExplorerState) {
+  if (!matchesAny(item.source_type, state.evidence_source_type)) return false
+  if (!matchesAny(item.reliability, state.evidence_reliability)) return false
+  if (state.evidence_archive_available === 'true' && !item.archived_url) return false
+  if (state.evidence_archive_available === 'false' && item.archived_url) return false
+  return true
+}
+
+export function filterEntityExplorerRecords(
+  entities: EntityRecord[],
+  state: EntityExplorerState,
+  evidenceByEntity: Map<string, EvidenceRecord[]> = new Map(),
+) {
   if (hasInvertedRange(state.launch_from, state.launch_to)) return []
   if (hasInvertedRange(state.death_from, state.death_to)) return []
+  if (hasInvertedRange(state.verified_from, state.verified_to)) return []
 
   return entities.filter((entity) => {
     if (!matchesSearch(entity, state.q)) return false
@@ -283,6 +325,8 @@ export function filterEntityExplorerRecords(entities: EntityRecord[], state: Ent
     if (state.archive_available === 'true' && !entity.archived_url) return false
     if (state.archive_available === 'false' && entity.archived_url) return false
     if (!matchesAny(entity.confidence, state.confidence)) return false
+    if (!inInclusiveRange(entity.last_verified_at, state.verified_from, state.verified_to)) return false
+    if (hasEvidenceConstraints(state) && !(evidenceByEntity.get(entity.id) ?? []).some((item) => evidenceMatches(item, state))) return false
     if (state.country_or_origin.length > 0 && !matchesAny(entity.country_or_origin, state.country_or_origin)) return false
     return true
   })
@@ -337,6 +381,11 @@ export function countEntityExplorerFilters(state: EntityExplorerState) {
     + state.official_url_status.length
     + Number(Boolean(state.archive_available))
     + state.confidence.length
+    + Number(Boolean(state.verified_from))
+    + Number(Boolean(state.verified_to))
+    + state.evidence_source_type.length
+    + state.evidence_reliability.length
+    + Number(Boolean(state.evidence_archive_available))
     + state.country_or_origin.length
     + Number(Boolean(state.q))
     + Number(state.sort !== ENTITY_DEFAULT_SORT)

--- a/src/lib/explorer/event-query.ts
+++ b/src/lib/explorer/event-query.ts
@@ -1,8 +1,10 @@
 import contractJson from '../../../config/explorer-query-contract.json'
 import type { Confidence, EntityRecord, ExchangeStatus, ExchangeType } from '../types/entity'
+import type { EvidenceRecord, Reliability, SourceType } from '../types/evidence'
 import type { EventRecord, EventStatusEffect, EventType, ImpactLevel } from '../types/event'
 
 export type EventSort = 'date_newest' | 'date_oldest' | 'entity_name_asc'
+export type EvidenceArchiveAvailable = '' | 'true' | 'false'
 
 export interface EventExplorerState {
   view: 'events'
@@ -15,12 +17,15 @@ export interface EventExplorerState {
   confidence: Confidence[]
   entity_type: ExchangeType[]
   entity_status: ExchangeStatus[]
+  evidence_source_type: SourceType[]
+  evidence_reliability: Reliability[]
+  evidence_archive_available: EvidenceArchiveAvailable
   sort: EventSort
 }
 
 type ParameterDefinition = {
   key: string
-  kind: 'text' | 'enum' | 'date'
+  kind: 'text' | 'enum' | 'date' | 'boolean'
   cardinality: 'single' | 'multi'
   values?: string[]
 }
@@ -53,6 +58,8 @@ export const EVENT_FILTER_VALUES = {
   confidence: enumValues<Confidence>('confidence'),
   entity_type: enumValues<ExchangeType>('entity_type'),
   entity_status: enumValues<ExchangeStatus>('entity_status'),
+  evidence_source_type: enumValues<SourceType>('evidence_source_type'),
+  evidence_reliability: enumValues<Reliability>('evidence_reliability'),
   sort: enumValues<EventSort>('sort'),
 }
 
@@ -99,6 +106,14 @@ function stableEnum<T extends string>(params: URLSearchParams, key: string): T[]
   return allowed.filter((value) => requested.has(value))
 }
 
+function firstValidBoolean(params: URLSearchParams, key: string): EvidenceArchiveAvailable {
+  const allowed = new Set(definitions.get(key)?.values ?? [])
+  for (const value of params.getAll(key)) {
+    if (allowed.has(value)) return value as EvidenceArchiveAvailable
+  }
+  return ''
+}
+
 function firstValidSort(params: URLSearchParams): EventSort {
   const allowed = new Set(EVENT_FILTER_VALUES.sort)
   for (const value of params.getAll('sort')) {
@@ -120,6 +135,9 @@ export function parseEventExplorerState(input: string | URLSearchParams): EventE
     confidence: stableEnum<Confidence>(params, 'confidence'),
     entity_type: stableEnum<ExchangeType>(params, 'entity_type'),
     entity_status: stableEnum<ExchangeStatus>(params, 'entity_status'),
+    evidence_source_type: stableEnum<SourceType>(params, 'evidence_source_type'),
+    evidence_reliability: stableEnum<Reliability>(params, 'evidence_reliability'),
+    evidence_archive_available: firstValidBoolean(params, 'evidence_archive_available'),
     sort: firstValidSort(params),
   }
 }
@@ -140,6 +158,9 @@ export function serializeEventExplorerState(state: EventExplorerState) {
   appendMany(params, 'confidence', state.confidence)
   appendMany(params, 'entity_type', state.entity_type)
   appendMany(params, 'entity_status', state.entity_status)
+  appendMany(params, 'evidence_source_type', state.evidence_source_type)
+  appendMany(params, 'evidence_reliability', state.evidence_reliability)
+  if (state.evidence_archive_available) params.append('evidence_archive_available', state.evidence_archive_available)
   if (state.sort !== EVENT_DEFAULT_SORT) params.append('sort', state.sort)
   return params.toString()
 }
@@ -174,10 +195,25 @@ function rangeMatches(value: string | null, from: string, to: string) {
   return true
 }
 
+function hasEvidenceConstraints(state: EventExplorerState) {
+  return state.evidence_source_type.length > 0
+    || state.evidence_reliability.length > 0
+    || Boolean(state.evidence_archive_available)
+}
+
+function evidenceMatches(item: EvidenceRecord, state: EventExplorerState) {
+  if (!matchesAny(item.source_type, state.evidence_source_type)) return false
+  if (!matchesAny(item.reliability, state.evidence_reliability)) return false
+  if (state.evidence_archive_available === 'true' && !item.archived_url) return false
+  if (state.evidence_archive_available === 'false' && item.archived_url) return false
+  return true
+}
+
 export function filterEventExplorerRecords(
   events: EventRecord[],
   entityById: Map<string, EntityRecord>,
   state: EventExplorerState,
+  evidenceByEvent: Map<string, EvidenceRecord[]> = new Map(),
 ) {
   if (state.date_from && state.date_to && state.date_from > state.date_to) return []
 
@@ -192,6 +228,7 @@ export function filterEventExplorerRecords(
     if (!matchesAny(event.confidence, state.confidence)) return false
     if (!matchesAny(parent.type, state.entity_type)) return false
     if (!matchesAny(parent.status, state.entity_status)) return false
+    if (hasEvidenceConstraints(state) && !(evidenceByEvent.get(event.id) ?? []).some((item) => evidenceMatches(item, state))) return false
     return true
   })
 }
@@ -239,5 +276,8 @@ export function countEventExplorerFilters(state: EventExplorerState) {
     + state.confidence.length
     + state.entity_type.length
     + state.entity_status.length
+    + state.evidence_source_type.length
+    + state.evidence_reliability.length
+    + Number(Boolean(state.evidence_archive_available))
     + Number(state.sort !== EVENT_DEFAULT_SORT)
 }


### PR DESCRIPTION
Implements AI-era Stage D as an additive Explorer/Search strengthening step while preserving the existing `/explore/` route and all existing v1 query URLs.

## Added deterministic filters
Entity view:
- `verified_from` / `verified_to` over canonical `last_verified_at`
- `evidence_source_type`
- `evidence_reliability`
- `evidence_archive_available`

Event view:
- `evidence_source_type`
- `evidence_reliability`
- `evidence_archive_available`

Evidence filters use reviewed canonical evidence only. When multiple provenance constraints are active, they must match the same reviewed evidence item; Event Explorer only uses evidence directly linked by `event_id`.

## Compatibility
- existing query keys and canonical serialization remain unchanged;
- new keys are additive;
- query variants stay out of sitemap and canonicalize to `/explore/`;
- English/Japanese routes use the same locale-independent canonical query keys;
- no Evidence Explorer, risk score, LLM search, or generated SEO landing pages.

## Validation
Updates the query-contract validator, round-trip/malformed-input tests, and final Explorer audit to cover provenance filtering, same-item evidence semantics, accessibility, crawl policy and reviewed-only wiring.

The first exact-head matrix exposed two unrelated but real stale-contract assumptions: the maintainer recovery counts still predated the HTX/EXMO lifecycle additions, and the immutable v1 baseline validator required Explorer contract version equality even though the v1 URL/crawl contract is preserved by this additive v2. This PR repairs both fail-close checks rather than bypassing them: recovery counts are synchronized to reviewed aggregation, and the v1 validator now treats the Explorer contract version as a baseline floor while explicitly rechecking the v1 view/route/crawl invariants.

## Non-interference
No canonical records, record-growth queues, L-2 evidence, Compare, Stats, monitoring, or Cloudflare configuration are changed.

Stage D must not be marked complete until the repaired exact-head matrix is green, this PR is merged, and the resulting watched production deployment verifies both the earlier Stage C record-level outputs and the Stage D Explorer surface.