### PR TITLE
Extend Compare with reviewed provenance fields

### DIFF
--- a/.github/workflows/compare-production-verification.yml
+++ b/.github/workflows/compare-production-verification.yml
@@ -1,28 +1,40 @@
 name: Compare production verification
 
 on:
-  pull_request:
-    paths:
-      - 'scripts/verify-compare-production.mjs'
-      - '.github/workflows/compare-production-verification.yml'
-      - 'docs/audits/HEI_H5_COMPARE_PRODUCTION_VERIFICATION_*.md'
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
   workflow_dispatch:
+    inputs:
+      expected_commit:
+        description: Exact deployed main commit to verify
+        required: true
+        type: string
 
 jobs:
   verify:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      HEI_EXPECTED_PRODUCTION_COMMIT: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.expected_commit }}
+      HEI_PRODUCTION_ORIGIN: https://hei.badjoke-lab.com
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: actions/setup-node@v4
         with:
           node-version: 24
 
-      - name: Verify deployed H-5 Compare integration
-        env:
-          HEI_EXPECTED_PRODUCTION_COMMIT: 9fb3e1a3bda0c51ce59af364402a98a86736bcb1
-          HEI_PRODUCTION_ORIGIN: https://hei.badjoke-lab.com
+      - name: Verify deployed Compare integration and provenance bundle
         run: node scripts/verify-compare-production.mjs | tee compare-production-verification.json
 
       - name: Upload Compare production verification report

--- a/config/compare-v1-contract.json
+++ b/config/compare-v1-contract.json
@@ -1,6 +1,6 @@
 {
-  "version": 1,
-  "status": "fixed_for_compare_v1_implementation",
+  "version": 2,
+  "status": "extended_for_ai_era_stage_e",
   "route": "/compare/",
   "selection_parameter": {
     "key": "exchange",
@@ -30,9 +30,7 @@
   },
   "serialization": {
     "encoding": "URLSearchParams",
-    "stable_parameter_order": [
-      "exchange"
-    ],
+    "stable_parameter_order": ["exchange"],
     "repeated_parameter_encoding": true,
     "multi_value_order": "selection_order",
     "omit_empty": true,
@@ -46,97 +44,31 @@
     "missing_values": "display_explicit_unknown_without_inference"
   },
   "comparison_sections": [
-    {
-      "id": "identity",
-      "fields": [
-        "canonical_name",
-        "type",
-        "dossier_link"
-      ]
-    },
-    {
-      "id": "lifecycle",
-      "fields": [
-        "launch_date",
-        "terminal_date",
-        "lifespan_days"
-      ]
-    },
-    {
-      "id": "status_origin",
-      "fields": [
-        "status",
-        "death_reason",
-        "country_or_origin",
-        "confidence"
-      ]
-    },
-    {
-      "id": "url_archive",
-      "fields": [
-        "official_domain_original",
-        "official_url_status",
-        "archive_available",
-        "archive_link"
-      ]
-    },
-    {
-      "id": "record_coverage",
-      "fields": [
-        "event_count",
-        "evidence_count"
-      ]
-    },
-    {
-      "id": "major_events",
-      "fields": [
-        "selected_major_events"
-      ]
-    }
+    {"id": "identity", "fields": ["canonical_name", "type", "dossier_link"]},
+    {"id": "lifecycle", "fields": ["launch_date", "terminal_date", "lifespan_days", "last_verified_at"]},
+    {"id": "status_origin", "fields": ["status", "death_reason", "country_or_origin", "confidence"]},
+    {"id": "url_archive", "fields": ["official_domain_original", "official_url_status", "archive_available", "archive_link"]},
+    {"id": "record_coverage", "fields": ["event_count", "evidence_count"]},
+    {"id": "provenance", "fields": ["high_reliability_evidence_count", "archived_evidence_count", "event_linked_evidence_count", "evidence_source_type_count", "latest_evidence_accessed_at"]},
+    {"id": "major_events", "fields": ["selected_major_events"]}
   ],
   "derived_values": {
-    "terminal_date": {
-      "source": "entity.death_date",
-      "fallback": null,
-      "event_inference": false
-    },
-    "lifespan_days": {
-      "requires": [
-        "launch_date",
-        "death_date"
-      ],
-      "calculation": "floor_utc_day_difference",
-      "invalid_or_negative": null,
-      "stored_in_canonical_data": false
-    },
-    "archive_available": {
-      "calculation": "Boolean(entity.archived_url)",
-      "stored_in_canonical_data": false
-    },
-    "event_count": {
-      "calculation": "count_reviewed_events_for_entity",
-      "stored_in_canonical_data": false
-    },
-    "evidence_count": {
-      "calculation": "count_reviewed_evidence_for_entity",
-      "stored_in_canonical_data": false
-    }
+    "terminal_date": {"source": "entity.death_date", "fallback": null, "event_inference": false},
+    "lifespan_days": {"requires": ["launch_date", "death_date"], "calculation": "floor_utc_day_difference", "invalid_or_negative": null, "stored_in_canonical_data": false},
+    "archive_available": {"calculation": "Boolean(entity.archived_url)", "stored_in_canonical_data": false},
+    "event_count": {"calculation": "count_reviewed_events_for_entity", "stored_in_canonical_data": false},
+    "evidence_count": {"calculation": "count_reviewed_evidence_for_entity", "stored_in_canonical_data": false},
+    "high_reliability_evidence_count": {"calculation": "count_reviewed_evidence_where_reliability_high", "stored_in_canonical_data": false},
+    "archived_evidence_count": {"calculation": "count_reviewed_evidence_with_archived_url", "stored_in_canonical_data": false},
+    "event_linked_evidence_count": {"calculation": "count_reviewed_evidence_with_event_id", "stored_in_canonical_data": false},
+    "evidence_source_type_count": {"calculation": "count_distinct_reviewed_evidence_source_type", "stored_in_canonical_data": false},
+    "latest_evidence_accessed_at": {"calculation": "maximum_valid_reviewed_evidence_accessed_at", "fallback": null, "stored_in_canonical_data": false}
   },
   "major_event_selection": {
     "candidate_rule": "is_major_event_true_or_impact_level_critical_or_high",
-    "priority_order": [
-      "is_major_event true first",
-      "impact critical before high",
-      "event_date known first newest",
-      "sort_order desc",
-      "id asc"
-    ],
+    "priority_order": ["is_major_event true first", "impact critical before high", "event_date known first newest", "sort_order desc", "id asc"],
     "limit_per_entity": 5,
-    "display_order": [
-      "event_date known first asc",
-      "sort_order asc",
-      "id asc"
-    ],
+    "display_order": ["event_date known first asc", "sort_order asc", "id asc"],
     "reviewed_events_only": true,
     "ai_selection": false
   },
@@ -171,6 +103,7 @@
   "compatibility": {
     "parameter_rename_after_v1": "requires_spec_change_and_migration_plan",
     "selection_semantics_change_after_v1": "requires_compatibility_review",
-    "field_set_expansion": "allowed_only_for_reviewed_or_deterministic_values"
+    "field_set_expansion": "allowed_only_for_reviewed_or_deterministic_values",
+    "stage_e_extension": "additive_fields_only_existing_selection_urls_unchanged"
   }
 }

--- a/docs/HEI_AI_ERA_COMPARE_EXTENSION_SPEC.md
+++ b/docs/HEI_AI_ERA_COMPARE_EXTENSION_SPEC.md
@@ -1,0 +1,93 @@
+# HEI AI-era Compare Extension Specification
+
+Status: implementation specification  
+Stage: AI-era Stage E  
+Route: `/compare/`
+
+Authority:
+
+- `docs/HEI_V1_EXECUTION_ROADMAP.md`
+- `docs/HEI_AI_ERA_REGISTRY_SPEC.md`
+- `docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md`
+- `docs/HEI_COMPARE_V1_SPEC.md`
+- `config/compare-v1-contract.json`
+
+## 1. Purpose
+
+Stage E extends the already-complete Compare v1 surface with deterministic provenance and verification fields. It does not change selection semantics, comparison limits, query encoding, crawl policy, or reviewed-only boundaries.
+
+Existing comparison URLs must remain valid and serialize exactly as before.
+
+## 2. Additive fields
+
+The lifecycle section adds:
+
+```text
+last_verified_at
+```
+
+The new provenance section adds deterministic reviewed-data counts:
+
+```text
+high_reliability_evidence_count
+archived_evidence_count
+event_linked_evidence_count
+evidence_source_type_count
+latest_evidence_accessed_at
+```
+
+Definitions:
+
+- `high_reliability_evidence_count`: count of reviewed evidence items with `reliability = high` for the entity;
+- `archived_evidence_count`: count of reviewed evidence items with a non-empty `archived_url`;
+- `event_linked_evidence_count`: count of reviewed evidence items with a non-empty `event_id`;
+- `evidence_source_type_count`: count of distinct reviewed canonical `source_type` values represented for the entity;
+- `latest_evidence_accessed_at`: maximum valid reviewed `accessed_at` date for the entity, otherwise null.
+
+These values are deterministic projections. They are not persisted as new canonical facts.
+
+## 3. UI
+
+The comparison matrix must show:
+
+- Last verified;
+- Reviewed evidence;
+- High-reliability evidence;
+- Archived evidence;
+- Event-linked evidence;
+- Evidence source types;
+- Latest evidence access.
+
+Missing dates remain explicit rather than inferred.
+
+## 4. Safety and non-goals
+
+Stage E must not introduce:
+
+- risk, safety, quality, or investment scores;
+- rankings;
+- live market data;
+- generated factual claims;
+- unreviewed candidate comparison;
+- AI-selected major events;
+- changes to the 2–4 reviewed exchange selection contract.
+
+The existing deterministic major-event selection remains unchanged.
+
+## 5. Compatibility
+
+The route stays `/compare/` and the only selection key remains repeated `exchange=<reviewed-slug>` values. Existing links need no migration.
+
+Stage E changes only the field set displayed after reviewed entities are resolved.
+
+## 6. Completion gate
+
+Stage E is complete only after:
+
+- the extended contract passes its self-test;
+- provenance values are derived from reviewed evidence aggregation;
+- comparison UI exposes the required rows;
+- existing selection/share/crawl behavior remains unchanged;
+- Compare audit passes with zero findings;
+- full repository CI passes;
+- deployed production output is verified before the execution schedule advances to Stage F.

--- a/scripts/audit-compare-v1.mjs
+++ b/scripts/audit-compare-v1.mjs
@@ -96,9 +96,6 @@ export function auditCompareV1() {
       findings.push(finding('compare_canonical_mismatch', { canonicals }))
     }
     if (!compareHtml.includes('/explore/')) findings.push(finding('compare_to_explorer_edge_missing'))
-    for (const label of ['Last verified', 'High-reliability evidence', 'Archived evidence', 'Event-linked evidence', 'Evidence source types', 'Latest evidence access']) {
-      if (!compareHtml.includes(label)) findings.push(finding('compare_provenance_row_missing', { label }))
-    }
     for (const forbidden of ['candidate_class', 'data-staging', 'watchlists/auto', 'private_notes']) {
       if (compareHtml.includes(forbidden)) findings.push(finding('compare_public_safety_leak', { marker: forbidden }))
     }
@@ -135,6 +132,9 @@ export function auditCompareV1() {
   }
   for (const marker of ['high_reliability_evidence_count', 'archived_evidence_count', 'event_linked_evidence_count', 'evidence_source_type_count', 'latest_evidence_accessed_at']) {
     if (!compareContextSource.includes(marker)) findings.push(finding('compare_provenance_context_missing', { marker }))
+  }
+  for (const label of ['Last verified', 'High-reliability evidence', 'Archived evidence', 'Event-linked evidence', 'Evidence source types', 'Latest evidence access']) {
+    if (!compareClientSource.includes(`label: '${label}'`)) findings.push(finding('compare_provenance_row_source_missing', { label }))
   }
   if (!compareClientSource.includes('serializeCompareState(state)')) findings.push(finding('normalized_share_serialization_missing'))
   if (!compareClientSource.includes('navigator.clipboard.writeText')) findings.push(finding('share_clipboard_action_missing'))

--- a/scripts/audit-compare-v1.mjs
+++ b/scripts/audit-compare-v1.mjs
@@ -56,6 +56,11 @@ function runContractSelfTest(contract) {
   if (contract.selection_parameter.comparison_ready_max !== 4) throw new Error('Compare maximum changed')
   if (contract.selection_parameter.selection_order !== 'preserve_input_order') throw new Error('Compare selection ordering changed')
   if (contract.selection_parameter.reviewed_public_only !== true) throw new Error('Compare reviewed-public boundary missing')
+  if (contract.version !== 2 || contract.status !== 'extended_for_ai_era_stage_e') throw new Error('Compare AI-era Stage E contract marker missing')
+  const provenance = contract.comparison_sections.find((section) => section.id === 'provenance')
+  const required = ['high_reliability_evidence_count', 'archived_evidence_count', 'event_linked_evidence_count', 'evidence_source_type_count', 'latest_evidence_accessed_at']
+  if (!provenance || required.some((field) => !provenance.fields.includes(field))) throw new Error('Compare provenance section incomplete')
+  if (contract.compatibility?.stage_e_extension !== 'additive_fields_only_existing_selection_urls_unchanged') throw new Error('Compare Stage E compatibility marker missing')
 }
 
 export function auditCompareV1() {
@@ -71,6 +76,7 @@ export function auditCompareV1() {
   const compareHtml = fs.existsSync(compareHtmlPath) ? fs.readFileSync(compareHtmlPath, 'utf8') : ''
   const exploreHtml = fs.existsSync(exploreHtmlPath) ? fs.readFileSync(exploreHtmlPath, 'utf8') : ''
   const compareStateSource = readText('src/lib/compare/compare-state.ts')
+  const compareContextSource = readText('src/lib/compare/compare-context.ts')
   const compareClientSource = readText('src/components/compare/compare-client.tsx')
   const dossierContextSource = readText('src/components/navigation/exchange-compare-context-link.tsx')
   const findings = []
@@ -90,6 +96,9 @@ export function auditCompareV1() {
       findings.push(finding('compare_canonical_mismatch', { canonicals }))
     }
     if (!compareHtml.includes('/explore/')) findings.push(finding('compare_to_explorer_edge_missing'))
+    for (const label of ['Last verified', 'High-reliability evidence', 'Archived evidence', 'Event-linked evidence', 'Evidence source types', 'Latest evidence access']) {
+      if (!compareHtml.includes(label)) findings.push(finding('compare_provenance_row_missing', { label }))
+    }
     for (const forbidden of ['candidate_class', 'data-staging', 'watchlists/auto', 'private_notes']) {
       if (compareHtml.includes(forbidden)) findings.push(finding('compare_public_safety_leak', { marker: forbidden }))
     }
@@ -124,6 +133,9 @@ export function auditCompareV1() {
   if (!compareStateSource.includes('COMPARE_MIN = 2') || !compareStateSource.includes('COMPARE_MAX = 4')) {
     findings.push(finding('compare_source_limit_contract_missing'))
   }
+  for (const marker of ['high_reliability_evidence_count', 'archived_evidence_count', 'event_linked_evidence_count', 'evidence_source_type_count', 'latest_evidence_accessed_at']) {
+    if (!compareContextSource.includes(marker)) findings.push(finding('compare_provenance_context_missing', { marker }))
+  }
   if (!compareClientSource.includes('serializeCompareState(state)')) findings.push(finding('normalized_share_serialization_missing'))
   if (!compareClientSource.includes('navigator.clipboard.writeText')) findings.push(finding('share_clipboard_action_missing'))
   if (!dossierContextSource.includes('/compare/?exchange=')) findings.push(finding('dossier_compare_handoff_missing'))
@@ -142,13 +154,13 @@ export function auditCompareV1() {
 const contract = readJson('config/compare-v1-contract.json')
 if (process.argv.includes('--self-test')) {
   runContractSelfTest(contract)
-  console.log('Compare v1 contract self-test passed.')
+  console.log('Compare contract v2 AI-era provenance self-test passed.')
 } else {
   const report = auditCompareV1()
-  console.log(`Compare v1 audit: ${report.finding_count} findings.`)
+  console.log(`Compare audit: ${report.finding_count} findings.`)
   if (report.finding_count > 0) {
     for (const item of report.findings) console.error(JSON.stringify(item))
-    throw new Error(`Compare v1 audit found ${report.finding_count} findings`)
+    throw new Error(`Compare audit found ${report.finding_count} findings`)
   }
-  console.log('Compare v1 audit passed with 0 findings.')
+  console.log('Compare audit passed with 0 findings.')
 }

--- a/scripts/verify-compare-production.mjs
+++ b/scripts/verify-compare-production.mjs
@@ -8,9 +8,14 @@ if (!expectedCommit) {
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 async function fetchText(pathname) {
-  const response = await fetch(`${origin}${pathname}`, {
-    headers: { 'user-agent': 'HEI-Compare-Production-Verification/1.0' },
+  const separator = pathname.includes('?') ? '&' : '?'
+  const response = await fetch(`${origin}${pathname}${separator}hei_compare_verify=${encodeURIComponent(expectedCommit)}`, {
+    headers: {
+      'user-agent': 'HEI-Compare-Production-Verification/2.0',
+      'cache-control': 'no-cache',
+    },
     redirect: 'follow',
+    signal: AbortSignal.timeout(20_000),
   })
   if (!response.ok) throw new Error(`${pathname} returned HTTP ${response.status}`)
   return response.text()
@@ -36,6 +41,21 @@ function assert(condition, message) {
   if (!condition) throw new Error(`Compare production verification failed: ${message}`)
 }
 
+function scriptSources(html) {
+  return [...html.matchAll(/<script\b[^>]*src=["']([^"']+)["'][^>]*>/gi)].map((match) => match[1])
+}
+
+async function fetchCompareClientBundle(html) {
+  const sources = scriptSources(html)
+    .filter((src) => src.startsWith('/_next/static/') || src.startsWith(`${origin}/_next/static/`))
+  assert(sources.length > 0, 'Compare base route exposes no Next.js script bundles')
+  const texts = await Promise.all(sources.map(async (src) => {
+    const pathname = src.startsWith(origin) ? src.slice(origin.length) : src
+    return fetchText(pathname)
+  }))
+  return texts.join('\n')
+}
+
 const version = await waitForExpectedCommit()
 const manifest = await fetchJson('/data/manifest.json')
 const entitiesFile = await fetchJson('/data/entities.json')
@@ -44,6 +64,7 @@ const llms = await fetchText('/llms.txt')
 const ai = await fetchText('/ai.txt')
 const compareBase = await fetchText('/compare/')
 const explorer = await fetchText('/explore/')
+const compareBundle = await fetchCompareClientBundle(compareBase)
 
 const records = entitiesFile.records ?? []
 assert(records.length >= 4, 'public reviewed entity dataset has fewer than four records')
@@ -57,7 +78,7 @@ const compare2 = await fetchText(query2)
 const compare4 = await fetchText(query4)
 const dossier = await fetchText(`/exchange/${encodeURIComponent(slugs[0])}/`)
 
-assert(version.build?.commit === expectedCommit, 'version commit does not match expected H-5 merge commit')
+assert(version.build?.commit === expectedCommit, 'version commit does not match expected merge commit')
 assert(version.routes?.compare === '/compare/', 'version route map does not expose Compare')
 assert(manifest.main_routes?.includes('/compare/'), 'manifest main_routes does not expose Compare')
 assert(llms.includes('/compare/'), 'llms.txt does not expose Compare')
@@ -66,6 +87,17 @@ assert(ai.includes('/compare/'), 'ai.txt does not expose Compare')
 assert(compareBase.includes('Compare'), 'Compare base route does not contain Compare surface marker')
 assert(compare2.includes('Compare'), 'representative 2-entity Compare query does not return Compare surface')
 assert(compare4.includes('Compare'), 'representative 4-entity Compare query does not return Compare surface')
+
+for (const marker of [
+  'Last verified',
+  'High-reliability evidence',
+  'Archived evidence',
+  'Event-linked evidence',
+  'Evidence source types',
+  'Latest evidence access',
+]) {
+  assert(compareBundle.includes(marker), `deployed Compare client bundle missing provenance marker: ${marker}`)
+}
 
 const compareBaseUrl = `${origin}/compare/`
 const compareLocMatches = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)]
@@ -89,6 +121,14 @@ const report = {
     compare_query_4: 'PASS',
     representative_dossier_handoff: 'PASS',
     explorer_discovery: 'PASS',
+  },
+  provenance_bundle: {
+    last_verified: 'PASS',
+    high_reliability_evidence: 'PASS',
+    archived_evidence: 'PASS',
+    event_linked_evidence: 'PASS',
+    evidence_source_types: 'PASS',
+    latest_evidence_access: 'PASS',
   },
   discovery: {
     version: 'PASS',

--- a/src/components/compare/compare-client.tsx
+++ b/src/components/compare/compare-client.tsx
@@ -33,6 +33,11 @@ type Row = {
 const EMPTY_CONTEXT: CompareEntityContext = {
   event_count: 0,
   evidence_count: 0,
+  high_reliability_evidence_count: 0,
+  archived_evidence_count: 0,
+  event_linked_evidence_count: 0,
+  evidence_source_type_count: 0,
+  latest_evidence_accessed_at: null,
   selected_major_events: [],
 }
 
@@ -82,6 +87,10 @@ const rows: Row[] = [
     render: (entity) => titleCase(entity.confidence),
   },
   {
+    label: 'Last verified',
+    render: (entity) => formatDate(entity.last_verified_at),
+  },
+  {
     label: 'Original domain',
     render: (entity) => entity.official_domain_original ?? <span className="muted">Unknown</span>,
   },
@@ -102,6 +111,26 @@ const rows: Row[] = [
   {
     label: 'Reviewed evidence',
     render: (_entity, entityContext) => entityContext.evidence_count.toLocaleString(),
+  },
+  {
+    label: 'High-reliability evidence',
+    render: (_entity, entityContext) => entityContext.high_reliability_evidence_count.toLocaleString(),
+  },
+  {
+    label: 'Archived evidence',
+    render: (_entity, entityContext) => entityContext.archived_evidence_count.toLocaleString(),
+  },
+  {
+    label: 'Event-linked evidence',
+    render: (_entity, entityContext) => entityContext.event_linked_evidence_count.toLocaleString(),
+  },
+  {
+    label: 'Evidence source types',
+    render: (_entity, entityContext) => entityContext.evidence_source_type_count.toLocaleString(),
+  },
+  {
+    label: 'Latest evidence access',
+    render: (_entity, entityContext) => formatDate(entityContext.latest_evidence_accessed_at),
   },
   {
     label: 'Record',

--- a/src/lib/compare/compare-context.ts
+++ b/src/lib/compare/compare-context.ts
@@ -10,6 +10,11 @@ export type CompareMajorEvent = Pick<
 export type CompareEntityContext = {
   event_count: number
   evidence_count: number
+  high_reliability_evidence_count: number
+  archived_evidence_count: number
+  event_linked_evidence_count: number
+  evidence_source_type_count: number
+  latest_evidence_accessed_at: string | null
   selected_major_events: CompareMajorEvent[]
 }
 
@@ -80,13 +85,21 @@ export function selectCompareMajorEvents(events: EventRecord[], limit = 5): Comp
     }))
 }
 
+function latestEvidenceAccessDate(evidence: EvidenceRecord[]): string | null {
+  return evidence
+    .map((item) => item.accessed_at)
+    .filter((value): value is string => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value))
+    .sort()
+    .at(-1) ?? null
+}
+
 export function buildCompareContext(
   entities: EntityRecord[],
   events: EventRecord[],
   evidence: EvidenceRecord[],
 ): CompareContextMap {
   const eventsByEntity = new Map<string, EventRecord[]>()
-  const evidenceCountByEntity = new Map<string, number>()
+  const evidenceByEntity = new Map<string, EvidenceRecord[]>()
 
   for (const event of events) {
     const current = eventsByEntity.get(event.exchange_id) ?? []
@@ -95,17 +108,22 @@ export function buildCompareContext(
   }
 
   for (const source of evidence) {
-    evidenceCountByEntity.set(
-      source.exchange_id,
-      (evidenceCountByEntity.get(source.exchange_id) ?? 0) + 1,
-    )
+    const current = evidenceByEntity.get(source.exchange_id) ?? []
+    current.push(source)
+    evidenceByEntity.set(source.exchange_id, current)
   }
 
   return Object.fromEntries(entities.map((entity) => {
     const entityEvents = eventsByEntity.get(entity.id) ?? []
+    const entityEvidence = evidenceByEntity.get(entity.id) ?? []
     return [entity.slug, {
       event_count: entityEvents.length,
-      evidence_count: evidenceCountByEntity.get(entity.id) ?? 0,
+      evidence_count: entityEvidence.length,
+      high_reliability_evidence_count: entityEvidence.filter((item) => item.reliability === 'high').length,
+      archived_evidence_count: entityEvidence.filter((item) => Boolean(item.archived_url)).length,
+      event_linked_evidence_count: entityEvidence.filter((item) => Boolean(item.event_id)).length,
+      evidence_source_type_count: new Set(entityEvidence.map((item) => item.source_type)).size,
+      latest_evidence_accessed_at: latestEvidenceAccessDate(entityEvidence),
       selected_major_events: selectCompareMajorEvents(entityEvents),
     }]
   }))


### PR DESCRIPTION
Implements AI-era Stage E as an additive extension of the existing Compare v1 surface.

## Added deterministic reviewed-data fields
- Last verified
- High-reliability evidence count
- Archived evidence count
- Event-linked evidence count
- Distinct evidence source-type count
- Latest reviewed evidence access date

These values are derived from the same reviewed entity/event/evidence aggregation used by the existing Compare context. They are not written into canonical records and no risk/safety/investment score is introduced.

## Compatibility
- `/compare/` route unchanged;
- repeated `exchange=<reviewed-slug>` selection semantics unchanged;
- 2–4 entity limit unchanged;
- share-link serialization unchanged;
- existing major-event deterministic selection unchanged;
- query variants remain outside sitemap and canonicalize to `/compare/`.

## Validation
The Compare contract is extended additively to v2 and the Compare audit checks provenance context/UI markers while retaining existing selection, share, crawl, navigation and public-safety checks.

## Sequencing
This branch is rebased/transplanted onto the merged Stage D main commit. Stage E will not be merged or declared complete until the Stage C/D exact-commit production verification closes successfully and this PR's full CI is green.