### PR TITLE
Publish deterministic machine-readable Stats outputs

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -41,7 +41,9 @@ jobs:
       - run: npm run monitor:test-completion
       - run: node --check scripts/check-machine-readable-production.mjs
       - run: node --check scripts/check-record-level-machine-readable-production.mjs
+      - run: node --check scripts/check-stats-machine-readable-production.mjs
       - run: npm run build
       - run: npm run machine:validate
       - run: node scripts/validate-record-level-machine-readable.mjs
+      - run: node scripts/validate-stats-machine-readable.mjs
       - run: npm run public:validate

--- a/.github/workflows/machine-readable-production-smoke.yml
+++ b/.github/workflows/machine-readable-production-smoke.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Verify production record-level endpoints
         run: node scripts/check-record-level-machine-readable-production.mjs
+
+      - name: Verify production stats endpoints
+        run: node scripts/check-stats-machine-readable-production.mjs

--- a/config/cloudflare-pages-project.json
+++ b/config/cloudflare-pages-project.json
@@ -12,6 +12,8 @@
       "data/*",
       "records/*",
       "scripts/build-machine-readable-layer.mjs",
+      "scripts/build-record-level-machine-readable.mjs",
+      "scripts/register-stats-machine-readable.mjs",
       "scripts/lib/*",
       "package.json",
       "package-lock.json",

--- a/docs/HEI_AI_ERA_STATS_COMPLETION_SPEC.md
+++ b/docs/HEI_AI_ERA_STATS_COMPLETION_SPEC.md
@@ -1,0 +1,124 @@
+# HEI AI-era Stats Completion Specification
+
+Status: implementation specification  
+Stage: AI-era Stage F  
+Human route: `/stats/`
+
+Authority:
+
+- `docs/HEI_V1_EXECUTION_ROADMAP.md`
+- `docs/HEI_AI_ERA_REGISTRY_SPEC.md`
+- `docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md`
+- existing HEI Stats implementation and Explorer handoff contracts
+
+## 1. Purpose
+
+HEI already exposes a reviewed public `/stats/` analysis surface built from canonical entity, event, and evidence data. Stage F closes the remaining machine-readable gap by publishing deterministic static statistics outputs that correspond to the same reviewed aggregation model.
+
+Stage F does not turn HEI into a market dashboard. It reports registry composition, lifecycle history, evidence coverage, quality, completeness, and historical counts only.
+
+## 2. Public machine-readable outputs
+
+Required endpoints:
+
+```text
+/stats.json
+/stats-history.json
+```
+
+`/stats.json` is the current deterministic registry snapshot.
+
+Minimum top-level sections:
+
+```text
+generated_at
+totals
+by_status
+by_type
+active_analysis
+dead_analysis
+country_origin
+quality
+coverage
+completeness
+events
+evidence
+```
+
+`/stats-history.json` is the deterministic trend/history input.
+
+Minimum top-level sections:
+
+```text
+generated_at
+snapshots
+launch_year_counts
+death_year_counts
+```
+
+The history file may begin with one current reviewed snapshot. It must not invent prior snapshot values that were not captured under the same contract.
+
+## 3. Source of truth
+
+Both outputs are projections from reviewed public aggregation:
+
+```text
+entity -> event -> evidence
+```
+
+Reviewed record-bundle corrections and additions use the same aggregation semantics as the rest of the public site.
+
+Stats-only aggregate fields must not be written back into canonical entity, event, or evidence records.
+
+## 4. Discovery
+
+The normal build must expose the endpoints through both `/version.json` and `/data/manifest.json`:
+
+```text
+stats.snapshot = /stats.json
+stats.history = /stats-history.json
+stats.canonical_only = true
+stats.source = reviewed_entity_event_evidence_aggregation
+```
+
+`llms.txt` and `ai.txt` must also advertise the endpoints.
+
+## 5. Validation
+
+Repository validation must independently verify:
+
+- snapshot entity/event/evidence totals match reviewed aggregation;
+- active-side and dead-side totals match reviewed status semantics;
+- status/type/event/evidence breakdowns reconcile to their denominators;
+- history contains at least one reviewed snapshot;
+- latest history snapshot matches current reviewed totals;
+- launch/death year series reconcile to entities with known dates;
+- discovery metadata is present and consistent;
+- internal monitoring, staging and candidate markers are absent.
+
+## 6. Production verification
+
+The existing machine-readable production workflow must verify the exact merged `main` commit and fetch both Stats endpoints over HTTP. Production completion requires count parity with `/version.json` and safe output.
+
+## 7. Non-goals
+
+Stage F does not add:
+
+- live price, volume, TVL or order-book metrics;
+- exchange rankings;
+- risk or safety scores;
+- investment recommendations;
+- fabricated historical snapshots;
+- unreviewed monitoring statistics;
+- arbitrary AI-generated analysis.
+
+## 8. Completion gate
+
+Stage F is complete only after:
+
+- static Stats endpoints build successfully;
+- repository validator passes;
+- full CI passes;
+- machine-readable discovery exposes both endpoints;
+- exact-commit production verification passes;
+- execution schedule is synchronized before Stage G is declared current.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import './scripts/build-machine-readable-layer.mjs'
 import './scripts/build-record-level-machine-readable.mjs'
+import './scripts/register-stats-machine-readable.mjs'
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {

--- a/scripts/check-stats-machine-readable-production.mjs
+++ b/scripts/check-stats-machine-readable-production.mjs
@@ -1,0 +1,83 @@
+const origin = (process.env.HEI_PUBLIC_ORIGIN || 'https://hei.badjoke-lab.com').replace(/\/$/, '')
+const expectedCommit = process.env.EXPECTED_COMMIT?.trim() || null
+const maxAttempts = Number(process.env.SMOKE_MAX_ATTEMPTS || 12)
+const retryDelayMs = Number(process.env.SMOKE_RETRY_DELAY_MS || 30000)
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchJson(path, cacheKey) {
+  const response = await fetch(`${origin}${path}?hei_stats_smoke=${encodeURIComponent(cacheKey)}`, {
+    headers: { accept: 'application/json', 'cache-control': 'no-cache', 'user-agent': 'HEI stats production checker' },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(20000),
+  })
+  assert(response.ok, `${path} returned HTTP ${response.status}`)
+  const contentType = (response.headers.get('content-type') || '').toLowerCase()
+  assert(contentType.includes('application/json'), `${path} returned unexpected content-type: ${contentType}`)
+  return response.json()
+}
+
+async function verifyProduction() {
+  const cacheKey = expectedCommit || Date.now().toString()
+  const [version, manifest, stats, history] = await Promise.all([
+    fetchJson('/version.json', cacheKey),
+    fetchJson('/data/manifest.json', cacheKey),
+    fetchJson('/stats.json', cacheKey),
+    fetchJson('/stats-history.json', cacheKey),
+  ])
+
+  if (expectedCommit) assert(version.build?.commit === expectedCommit, `deployment is not current: expected ${expectedCommit}, got ${version.build?.commit}`)
+  const expectedDiscovery = {
+    snapshot: '/stats.json',
+    history: '/stats-history.json',
+    canonical_only: true,
+    source: 'reviewed_entity_event_evidence_aggregation',
+  }
+  assert(JSON.stringify(version.stats) === JSON.stringify(expectedDiscovery), 'version stats discovery mismatch')
+  assert(JSON.stringify(manifest.stats) === JSON.stringify(expectedDiscovery), 'manifest stats discovery mismatch')
+
+  const counts = version.data?.record_counts
+  assert(stats.totals?.total_entities === counts?.primary_records, 'production stats entity count mismatch')
+  assert(stats.totals?.total_events === counts?.events, 'production stats event count mismatch')
+  assert(stats.totals?.total_evidence === counts?.evidence, 'production stats evidence count mismatch')
+  assert(stats.totals?.dead_side_total === version.data?.record_count_breakdown?.dead_side, 'production stats dead-side count mismatch')
+  assert(stats.totals?.active_side_total === version.data?.record_count_breakdown?.active_side, 'production stats active-side count mismatch')
+  assert(!Number.isNaN(Date.parse(stats.generated_at)), 'production stats generated_at invalid')
+
+  assert(Array.isArray(history.snapshots) && history.snapshots.length >= 1, 'production stats history has no snapshots')
+  const latest = history.snapshots.at(-1)
+  assert(latest.total_entities === counts.primary_records, 'production stats history entity count mismatch')
+  assert(latest.total_events === counts.events, 'production stats history event count mismatch')
+  assert(latest.total_evidence === counts.evidence, 'production stats history evidence count mismatch')
+  assert(Array.isArray(history.launch_year_counts), 'production launch_year_counts missing')
+  assert(Array.isArray(history.death_year_counts), 'production death_year_counts missing')
+
+  const serialized = `${JSON.stringify(stats)}\n${JSON.stringify(history)}`
+  for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+    assert(!serialized.includes(forbidden), `production stats leaked forbidden marker: ${forbidden}`)
+  }
+
+  console.log(`Production stats verified at ${origin}`)
+  console.log(`commit=${version.build?.commit}, entities=${counts.primary_records}, snapshots=${history.snapshots.length}`)
+}
+
+let lastError
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  try {
+    console.log(`Stats production verification attempt ${attempt}/${maxAttempts}`)
+    await verifyProduction()
+    process.exit(0)
+  } catch (error) {
+    lastError = error
+    console.error(error instanceof Error ? error.message : error)
+    if (attempt < maxAttempts) await sleep(retryDelayMs)
+  }
+}
+
+throw lastError

--- a/scripts/register-stats-machine-readable.mjs
+++ b/scripts/register-stats-machine-readable.mjs
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const publicDir = path.join(root, 'public')
+const versionPath = path.join(publicDir, 'version.json')
+const manifestPath = path.join(publicDir, 'data', 'manifest.json')
+const llmsPath = path.join(publicDir, 'llms.txt')
+const aiPath = path.join(publicDir, 'ai.txt')
+
+function assertFile(filePath) {
+  if (!fs.existsSync(filePath)) throw new Error(`stats discovery requires ${path.relative(root, filePath)}`)
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function appendOnce(filePath, marker, block) {
+  const current = fs.readFileSync(filePath, 'utf8').trimEnd()
+  if (current.includes(marker)) return
+  fs.writeFileSync(filePath, `${current}\n\n${block.trim()}\n`, 'utf8')
+}
+
+for (const filePath of [versionPath, manifestPath, llmsPath, aiPath]) assertFile(filePath)
+
+const discovery = {
+  snapshot: '/stats.json',
+  history: '/stats-history.json',
+  canonical_only: true,
+  source: 'reviewed_entity_event_evidence_aggregation',
+}
+
+const version = JSON.parse(fs.readFileSync(versionPath, 'utf8'))
+version.stats = discovery
+writeJson(versionPath, version)
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+manifest.stats = discovery
+writeJson(manifestPath, manifest)
+
+appendOnce(llmsPath, '/stats-history.json', `## Registry statistics
+- Current deterministic snapshot: /stats.json
+- Deterministic history/trend input: /stats-history.json
+- Both outputs are derived from reviewed entity/event/evidence data and do not add fields to canonical records.`)
+
+appendOnce(aiPath, '/stats-history.json', `Registry statistics:
+/stats.json
+/stats-history.json
+These deterministic aggregate files are derived from reviewed entity/event/evidence data only.`)
+
+console.log('Registered HEI stats machine-readable endpoints.')

--- a/scripts/validate-stats-machine-readable.mjs
+++ b/scripts/validate-stats-machine-readable.mjs
@@ -25,9 +25,10 @@ function sumCounts(rows) {
   return rows.reduce((sum, row) => sum + Number(row.count || 0), 0)
 }
 
-function validYear(date) {
-  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return null
-  return Number(date.slice(0, 4))
+function extractedYear(value) {
+  if (!value) return null
+  const match = String(value).match(/(\d{4})/)
+  return match ? Number(match[1]) : null
 }
 
 const stats = readJson('out/stats.json')
@@ -75,10 +76,10 @@ const latest = history.snapshots.at(-1)
 for (const key of ['total_entities', 'dead_side_total', 'active_side_total', 'total_events', 'total_evidence']) {
   assert(latest?.[key] === expected[key], `stats history latest snapshot mismatch ${key}`)
 }
-const knownLaunchDates = entities.filter((entity) => validYear(entity.launch_date) !== null).length
-const knownDeathDates = entities.filter((entity) => validYear(entity.death_date) !== null).length
-assert(sumCounts(history.launch_year_counts) === knownLaunchDates, 'launch year history count mismatch')
-assert(sumCounts(history.death_year_counts) === knownDeathDates, 'death year history count mismatch')
+const knownLaunchYears = entities.filter((entity) => extractedYear(entity.launch_date) !== null).length
+const knownDeathYears = entities.filter((entity) => extractedYear(entity.death_date) !== null).length
+assert(sumCounts(history.launch_year_counts) === knownLaunchYears, `launch year history count mismatch: expected ${knownLaunchYears}, got ${sumCounts(history.launch_year_counts)}`)
+assert(sumCounts(history.death_year_counts) === knownDeathYears, `death year history count mismatch: expected ${knownDeathYears}, got ${sumCounts(history.death_year_counts)}`)
 
 const expectedDiscovery = {
   snapshot: '/stats.json',

--- a/scripts/validate-stats-machine-readable.mjs
+++ b/scripts/validate-stats-machine-readable.mjs
@@ -1,0 +1,101 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { loadReviewedBundles, mergeRecords } from './lib/reviewed-bundle-aggregation.mjs'
+import { applyReviewedEntityCorrections } from './lib/entity-corrections.mjs'
+
+const root = process.cwd()
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`stats machine-readable validation failed: ${message}`)
+}
+
+function readJson(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function readText(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function sumCounts(rows) {
+  return rows.reduce((sum, row) => sum + Number(row.count || 0), 0)
+}
+
+function validYear(date) {
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return null
+  return Number(date.slice(0, 4))
+}
+
+const stats = readJson('out/stats.json')
+const history = readJson('out/stats-history.json')
+const version = readJson('out/version.json')
+const manifest = readJson('out/data/manifest.json')
+const llms = readText('out/llms.txt')
+const ai = readText('out/ai.txt')
+
+const canonicalEntities = readJson('data/entities.json')
+const canonicalEvents = readJson('data/events.json')
+const canonicalEvidence = readJson('data/evidence.json')
+const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, reviewedBundles)
+const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event')
+const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence')
+
+const deadSide = new Set(['dead', 'merged', 'acquired', 'rebranded'])
+const activeSide = new Set(['active', 'limited', 'inactive'])
+const expected = {
+  total_entities: entities.length,
+  dead_side_total: entities.filter((entity) => deadSide.has(entity.status)).length,
+  active_side_total: entities.filter((entity) => activeSide.has(entity.status)).length,
+  total_events: events.length,
+  total_evidence: evidence.length,
+}
+
+for (const key of ['generated_at', 'totals', 'by_status', 'by_type', 'active_analysis', 'dead_analysis', 'country_origin', 'quality', 'coverage', 'completeness', 'events', 'evidence']) {
+  assert(Object.hasOwn(stats, key), `stats.json missing top-level key ${key}`)
+}
+assert(!Number.isNaN(Date.parse(stats.generated_at)), 'stats.json generated_at is invalid')
+for (const [key, value] of Object.entries(expected)) assert(stats.totals?.[key] === value, `stats total mismatch ${key}: expected ${value}, got ${stats.totals?.[key]}`)
+assert(Array.isArray(stats.by_status) && sumCounts(stats.by_status) === entities.length, 'status breakdown does not cover all entities')
+assert(Array.isArray(stats.by_type) && sumCounts(stats.by_type) === entities.length, 'type breakdown does not cover all entities')
+assert(Array.isArray(stats.active_analysis?.status_breakdown) && sumCounts(stats.active_analysis.status_breakdown) === expected.active_side_total, 'active-side breakdown mismatch')
+assert(Array.isArray(stats.dead_analysis?.status_breakdown) && sumCounts(stats.dead_analysis.status_breakdown) === expected.dead_side_total, 'dead-side breakdown mismatch')
+assert(Array.isArray(stats.events?.event_type_breakdown) && sumCounts(stats.events.event_type_breakdown) === events.length, 'event type breakdown mismatch')
+assert(Array.isArray(stats.evidence?.source_type_breakdown) && sumCounts(stats.evidence.source_type_breakdown) === evidence.length, 'evidence source-type breakdown mismatch')
+
+for (const key of ['generated_at', 'snapshots', 'launch_year_counts', 'death_year_counts']) assert(Object.hasOwn(history, key), `stats-history.json missing top-level key ${key}`)
+assert(!Number.isNaN(Date.parse(history.generated_at)), 'stats-history generated_at is invalid')
+assert(Array.isArray(history.snapshots) && history.snapshots.length >= 1, 'stats history requires at least one snapshot')
+const latest = history.snapshots.at(-1)
+for (const key of ['total_entities', 'dead_side_total', 'active_side_total', 'total_events', 'total_evidence']) {
+  assert(latest?.[key] === expected[key], `stats history latest snapshot mismatch ${key}`)
+}
+const knownLaunchDates = entities.filter((entity) => validYear(entity.launch_date) !== null).length
+const knownDeathDates = entities.filter((entity) => validYear(entity.death_date) !== null).length
+assert(sumCounts(history.launch_year_counts) === knownLaunchDates, 'launch year history count mismatch')
+assert(sumCounts(history.death_year_counts) === knownDeathDates, 'death year history count mismatch')
+
+const expectedDiscovery = {
+  snapshot: '/stats.json',
+  history: '/stats-history.json',
+  canonical_only: true,
+  source: 'reviewed_entity_event_evidence_aggregation',
+}
+assert(JSON.stringify(version.stats) === JSON.stringify(expectedDiscovery), 'version stats discovery mismatch')
+assert(JSON.stringify(manifest.stats) === JSON.stringify(expectedDiscovery), 'manifest stats discovery mismatch')
+for (const text of [llms, ai]) {
+  assert(text.includes('/stats.json'), 'stats.json missing from discovery text')
+  assert(text.includes('/stats-history.json'), 'stats-history.json missing from discovery text')
+}
+
+const serialized = `${JSON.stringify(stats)}\n${JSON.stringify(history)}`
+for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+  assert(!serialized.includes(forbidden), `stats output leaked forbidden marker: ${forbidden}`)
+}
+
+console.log(`Validated HEI stats outputs: ${entities.length} entities, ${events.length} events, ${evidence.length} evidence, ${history.snapshots.length} history snapshot(s).`)

--- a/src/app/stats-history.json/route.ts
+++ b/src/app/stats-history.json/route.ts
@@ -1,0 +1,13 @@
+import { buildStatsView } from '../../lib/stats/build-stats'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  const { history } = buildStatsView()
+  return Response.json(history, {
+    headers: {
+      'Cache-Control': 'public, max-age=300, s-maxage=300',
+    },
+  })
+}

--- a/src/app/stats.json/route.ts
+++ b/src/app/stats.json/route.ts
@@ -1,0 +1,13 @@
+import { buildStatsView } from '../../lib/stats/build-stats'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  const { snapshot } = buildStatsView()
+  return Response.json(snapshot, {
+    headers: {
+      'Cache-Control': 'public, max-age=300, s-maxage=300',
+    },
+  })
+}


### PR DESCRIPTION
Implements AI-era Stage F as a deterministic machine-readable extension of the existing reviewed `/stats/` surface.

## Public outputs
- `/stats.json` current reviewed aggregate snapshot
- `/stats-history.json` deterministic trend/history input

The history output begins only with captured reviewed snapshots and does not invent historical values.

## Discovery
The normal build advertises both endpoints through:
- `/version.json`
- `/data/manifest.json`
- `llms.txt`
- `ai.txt`

## Validation and production gate
- independent repository validator reconciles entity/event/evidence totals and breakdowns against reviewed aggregation;
- CI validates the generated static outputs;
- the existing exact-commit machine-readable production smoke checks both endpoints after successful main CI;
- Cloudflare watched-path policy includes the derived public-output builders needed for these files.

The first Stage F CI exposed one validator mismatch: the Stats history builder intentionally extracts the first four-digit year from reviewed lifecycle strings, while the new validator initially counted only strict `YYYY-MM-DD` values. The generated endpoints/build were already successful. The validator now mirrors the authoritative history builder's deterministic `toYear` semantics and reports expected/actual counts on failure rather than weakening the history contract.

## Safety
No canonical records are modified. No market metrics, rankings, risk/safety scores, fabricated history, unreviewed monitoring data, or generated factual claims are introduced.

## Sequencing
Stage E PR #766 is merged as `39f4eb4a6b19f30a256fba643cf453c6f0097a6f` and exact-commit Compare production verification run `31928424433` passed. This branch is based directly on that Stage E merge. Stage F may merge once the repaired exact-head CI is green; completion still requires exact merged-commit Stats production verification.