### PR TITLE
Reduce monitoring parking false positives

### DIFF
--- a/.github/workflows/hei-monitoring-v2.yml
+++ b/.github/workflows/hei-monitoring-v2.yml
@@ -73,6 +73,7 @@ jobs:
           cache: npm
       - run: npm ci --no-audit --no-fund
       - run: npm run monitor:smoke
+      - run: node scripts/monitoring/test-http-check-classification.mjs
       - name: Run monitoring
         id: monitor
         env:

--- a/scripts/monitoring/adapters/http-check.mjs
+++ b/scripts/monitoring/adapters/http-check.mjs
@@ -4,7 +4,10 @@ const PARKING_PATTERNS = [
   /domain\s+for\s+sale/i,
   /buy\s+this\s+domain/i,
   /this\s+domain\s+is\s+for\s+sale/i,
-  /parking/i,
+  /domain\s+parking/i,
+  /parked\s+domain/i,
+  /domain\s+is\s+parked/i,
+  /parking\s+page/i,
   /sedo/i,
   /afternic/i,
   /dan\.com/i,
@@ -24,7 +27,7 @@ function normalizeUrl(value) {
   return `https://${raw}`;
 }
 
-function classifyStatus({ status, finalUrl, startUrl, body }) {
+export function classifyStatus({ status, finalUrl, startUrl, body }) {
   if (status >= 200 && status < 400) {
     if (PARKING_PATTERNS.some((pattern) => pattern.test(body || ''))) return 'parked_or_for_sale';
     if (finalUrl && startUrl && finalUrl !== startUrl) return 'redirected';

--- a/scripts/monitoring/test-http-check-classification.mjs
+++ b/scripts/monitoring/test-http-check-classification.mjs
@@ -1,0 +1,39 @@
+import { classifyStatus } from './adapters/http-check.mjs';
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const startUrl = 'https://example.test/';
+
+assert(
+  classifyStatus({
+    status: 200,
+    startUrl,
+    finalUrl: startUrl,
+    body: '<html><body><div>Parking is available near the exchange.</div><button>Swap</button></body></html>',
+  }) === 'ok',
+  'ordinary page text containing the word parking must not be classified as a parked domain',
+);
+
+assert(
+  classifyStatus({
+    status: 200,
+    startUrl,
+    finalUrl: startUrl,
+    body: '<html><body>This domain is parked. Buy this domain.</body></html>',
+  }) === 'parked_or_for_sale',
+  'explicit parked-domain language must still be detected',
+);
+
+assert(
+  classifyStatus({
+    status: 200,
+    startUrl,
+    finalUrl: 'https://www.example.test/',
+    body: '<html><body>Live exchange application</body></html>',
+  }) === 'redirected',
+  'healthy redirects must remain redirected',
+);
+
+console.log('HEI HTTP classification regression passed.');


### PR DESCRIPTION
## What changed

- narrowed parked-domain detection so ordinary page text containing the generic word `parking` no longer classifies a live site as `parked_or_for_sale`
- retained explicit parked-domain / for-sale provider detection (`domain parking`, `parked domain`, `domain is parked`, `parking page`, Sedo, Afternic, Dan, HugeDomains)
- exported the response classifier for deterministic regression coverage
- added a regression script proving generic `parking` text stays `ok`, explicit parked-domain language is still detected, and healthy redirects remain `redirected`
- wired the regression into the HEI monitoring workflow before the monitoring run

## Why

The 2026-08-17 monitoring report #770 flagged 10KSwap as `parked_or_for_sale`, but the current site still serves the DEX UI and current external protocol tracking remains live. The root cause in `http-check.mjs` was the unqualified `/parking/i` pattern, which could match unrelated live-page content.

## Safety

- no canonical entity/event/evidence data changed
- no HEI status or death_reason changes are included
- the monitoring canonical guard remains unchanged
- #771 separately tracks source-backed review of the three high-severity active-status findings from #770

## Validation

A deterministic regression script is included and is executed by `.github/workflows/hei-monitoring-v2.yml` before monitoring. Normal PR checks should also exercise the repository-wide validation suite.