### PR TITLE
Harden monitoring candidate name extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "monitor:check": "node scripts/check-monitoring-completion.mjs",
     "monitor:test-completion": "node scripts/test-monitoring-completion.mjs",
     "monitor:promote-candidate": "node scripts/monitoring/promote-candidate-to-staging.mjs",
-    "monitor:smoke": "node scripts/monitoring/smoke-test.mjs",
+    "monitor:smoke": "node scripts/monitoring/smoke-test.mjs && node scripts/monitoring/test-news-extract-noise.mjs",
     "watchlists:check": "node scripts/check-watchlist-resolutions.mjs",
     "watchlists:test": "node scripts/check-watchlist-resolutions.mjs --self-test",
     "counts:check": "node scripts/check-count-semantics-regression.mjs",

--- a/scripts/monitoring/core/news-extract.mjs
+++ b/scripts/monitoring/core/news-extract.mjs
@@ -36,6 +36,15 @@ const KNOWN_BAD_NAMES = new Set([
   'regulators',
   'popular',
   'top crypto',
+  'top',
+  'exploits cost',
+  'fca',
+  'cftc',
+  'sec',
+  'six',
+  'johnson supporting',
+  'concluding cftc',
+  'hong kong',
   'russia',
 ]);
 

--- a/scripts/monitoring/test-news-extract-noise.mjs
+++ b/scripts/monitoring/test-news-extract-noise.mjs
@@ -1,0 +1,55 @@
+import { extractCandidateNameFromNews } from './core/news-extract.mjs';
+
+function assertNullCandidate(item, label) {
+  const candidate = extractCandidateNameFromNews(item);
+  if (candidate !== null) {
+    throw new Error(`${label}: expected null candidate, received ${candidate}`);
+  }
+}
+
+assertNullCandidate(
+  {
+    title: 'FCA Shuts Down Unregistered P2P Crypto Trading in London',
+    snippet: 'The UK regulator acted against unregistered peer-to-peer crypto trading.',
+    source_name: 'CoinMarketCap',
+  },
+  'regulator abbreviation used as headline subject',
+);
+
+assertNullCandidate(
+  {
+    title: 'Best Decentralized Crypto Exchanges in July 2026: Discover the Top DEX for Your Crypto Needs!',
+    snippet: 'A ranking headline must not manufacture an exchange named Top.',
+    source_name: 'Coin Bureau',
+  },
+  'ranking adjective used as exchange identity',
+);
+
+assertNullCandidate(
+  {
+    title: 'Crypto Exploits Cost Exchanges Millions as Security Incidents Rise',
+    snippet: 'A generic incident headline must not manufacture an exchange named Exploits Cost.',
+    source_name: 'Example News',
+  },
+  'headline fragment used as exchange identity',
+);
+
+assertNullCandidate(
+  {
+    title: 'Hong Kong Exchange Warning Issued in New Regulatory Notice',
+    snippet: 'A geographic market label must not become a canonical exchange candidate.',
+    source_name: 'Example News',
+  },
+  'geographic label used as exchange identity',
+);
+
+assertNullCandidate(
+  {
+    title: 'Six Crypto Exchanges Face New Regulatory Restrictions',
+    snippet: 'A count word must not become a canonical exchange candidate.',
+    source_name: 'Example News',
+  },
+  'count word used as exchange identity',
+);
+
+console.log('HEI news candidate noise regressions passed.');


### PR DESCRIPTION
## What changed

- reject known regulator/geographic/headline fragments that #770 incorrectly promoted as exchange candidates (`FCA`, `Top`, `Exploits Cost`, `Six`, `Johnson Supporting`, `Concluding CFTC`, `Hong Kong`)
- retain real brand-like candidates such as `Ord.io` for separate scope review rather than blanket-dropping them
- add deterministic regression cases for the concrete #770 false-positive headline shapes
- run the new regressions as part of `npm run monitor:smoke`, so normal CI covers the fix

## Why

The 2026-08-17 monitoring run produced obvious non-entity candidates from generic news/regulatory headlines. This is monitoring quality debt, not canonical data work. The fix tightens extraction without weakening the reviewed-only publishing boundary.

## Safety

- no canonical entity/event/evidence data changed
- no status/death_reason changes
- raw monitoring remains non-canonical
- real ambiguous candidates are still retained for manual review rather than silently published

## Validation

`npm run monitor:smoke` now includes `test-news-extract-noise.mjs` with regression cases for the observed false positives.