### PR TITLE
Downgrade transient active-status network failures

### DIFF
--- a/scripts/monitoring/monitors/active-status-watch.mjs
+++ b/scripts/monitoring/monitors/active-status-watch.mjs
@@ -95,19 +95,23 @@ function shouldCreateFinding(entity, check) {
   return true;
 }
 
-function severityForCheck(entity, check) {
-  if (['dns_failure', 'tls_failure', 'parked_or_for_sale'].includes(check.status)) return entity.status === 'active' ? 'high' : 'medium';
-  if (['not_found', 'server_error', 'timeout'].includes(check.status)) return entity.status === 'active' ? 'medium' : 'low';
+export function severityForCheck(entity, check) {
+  if (check.status === 'parked_or_for_sale') return entity.status === 'active' ? 'high' : 'medium';
+
+  // A single scheduled run performs only one immediate retry. Persistent DNS,
+  // TLS, server, and timeout failures can still be caused by resolver, CDN,
+  // bot-protection, or runner-specific conditions. They are review signals,
+  // not sufficient high-severity lifecycle evidence by themselves.
+  if (['dns_failure', 'tls_failure', 'not_found'].includes(check.status)) {
+    return entity.status === 'active' ? 'medium' : 'low';
+  }
+  if (['server_error', 'timeout'].includes(check.status)) return 'low';
   return 'low';
 }
 
-function actionForCheck(entity, check) {
+export function actionForCheck(entity, check) {
   if (check.status === 'parked_or_for_sale') return 'investigate_active_status_and_domain_repurpose';
-  if (check.status === 'dns_failure') {
-    return entity.status === 'active'
-      ? 'investigate_active_to_inactive_candidate'
-      : 'review_inactive_official_url_status';
-  }
+  if (check.status === 'dns_failure') return 'recheck_before_status_change';
   if (check.status === 'tls_failure') return 'review_official_site_tls_status';
   if (check.status === 'not_found') return 'review_official_url_or_archive';
   if (check.status === 'server_error' || check.status === 'timeout') return 'recheck_before_status_change';

--- a/scripts/monitoring/smoke-test.mjs
+++ b/scripts/monitoring/smoke-test.mjs
@@ -4,7 +4,7 @@ import { loadCanonicalData } from './core/load-canonical-data.mjs';
 import { createMonitorResult, runMonitorSafely } from './core/finding-utils.mjs';
 import { buildSummaryMarkdown } from './core/summary-writer.mjs';
 import { extractCandidateNameFromNews } from './core/news-extract.mjs';
-import { prioritizeActiveStatusTargets, shouldRetryOfficialSiteCheck } from './monitors/active-status-watch.mjs';
+import { actionForCheck, prioritizeActiveStatusTargets, severityForCheck, shouldRetryOfficialSiteCheck } from './monitors/active-status-watch.mjs';
 import { normalizeSitemapUrl } from './adapters/sitemap-check.mjs';
 import { runReviewedBundleAggregationRegression } from '../test-reviewed-bundle-aggregation.mjs';
 import { buildRegistryMetrics, parseReviewMonth } from '../review/monthly-registry-core.mjs';
@@ -100,6 +100,28 @@ function runMonitoringOutputRegressions() {
   assert(shouldRetryOfficialSiteCheck({ status: 'timeout' }), 'timeouts must be retried before creating an active-status finding');
   assert(!shouldRetryOfficialSiteCheck({ status: 'ok' }), 'healthy responses must not be retried');
   assert(!shouldRetryOfficialSiteCheck({ status: 'redirected', http_status: 200 }), 'healthy redirects must not be retried');
+
+  const activeEntity = { status: 'active' };
+  assert(
+    severityForCheck(activeEntity, { status: 'dns_failure' }) === 'medium',
+    'a retry-surviving DNS failure must not become a high-severity lifecycle signal by itself',
+  );
+  assert(
+    severityForCheck(activeEntity, { status: 'tls_failure' }) === 'medium',
+    'a retry-surviving TLS failure must remain a medium review signal',
+  );
+  assert(
+    severityForCheck(activeEntity, { status: 'server_error' }) === 'low',
+    'runner-specific server failures must remain low-severity recheck signals',
+  );
+  assert(
+    severityForCheck(activeEntity, { status: 'parked_or_for_sale' }) === 'high',
+    'explicit parked-domain evidence must remain high severity for active entities',
+  );
+  assert(
+    actionForCheck(activeEntity, { status: 'dns_failure' }) === 'recheck_before_status_change',
+    'DNS failure must not directly recommend an active-to-inactive transition',
+  );
 
   const prioritizedTargets = prioritizeActiveStatusTargets(
     [


### PR DESCRIPTION
## What changed

- keep explicit parked/for-sale evidence as a high-severity active-status signal
- downgrade retry-surviving DNS/TLS/not-found failures to medium for active entities
- downgrade server-error/timeout failures to low recheck signals
- change DNS failure guidance from `investigate_active_to_inactive_candidate` to `recheck_before_status_change`
- export the severity/action helpers and add deterministic smoke-test coverage

## Why

The 2026-08-17 monitoring run produced high-severity DNS findings for Aborean Finance and Amaterasu Finance even though current source-backed review did not justify a lifecycle change. A single GitHub runner plus one immediate retry is not enough evidence to treat resolver/CDN/network failure as a high-confidence active-to-inactive candidate.

This preserves sensitivity to explicit domain repurposing while preventing transient infrastructure failures from dominating the high-severity queue.

## Safety

- no canonical entity/event/evidence data changed
- no status/death_reason transitions are automated
- failures remain visible for review
- repeated/source-backed lifecycle evidence can still produce normal reviewed Lane A changes

## Validation

`npm run monitor:smoke` now asserts that DNS/TLS failures are not high by themselves, server/timeout failures are low recheck signals, parked-domain evidence remains high, and DNS failure no longer recommends an immediate lifecycle transition.