### PR TITLE
Authorize HEI Ledger Series Phase 9 adapter

### DIFF
--- a/config/ledger-series-phase9-adapter-authority.json
+++ b/config/ledger-series-phase9-adapter-authority.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "1.0",
+  "authority_id": "hei_ledger_series_phase9_adapter_2026_08_20",
+  "status": "active_after_merge",
+  "entry_main_commit": "f273e61631f0528efd2da57831790ff3450de8e8",
+  "coordination_issue": 780,
+  "official_public_origin": "https://hei.badjoke-lab.com",
+  "purpose": "Authorize only the bounded HEI implementation of the cross-registry Ledger Series Phase 9 Stage 3 adapter. This local authority is required because Issue #780 is coordination-only and does not itself authorize HEI runtime changes.",
+  "mandatory_references": [
+    "AGENTS.md",
+    "docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md",
+    "docs/HEI_V1_EXECUTION_ROADMAP.md",
+    "docs/HEI_AI_ERA_REGISTRY_SPEC.md",
+    "docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md",
+    "docs/HEI_PRODUCT_SURFACES_SPEC.md",
+    "docs/machine-readable-public-layer.md"
+  ],
+  "scope": [
+    "reuse_existing_record_level_exchange_bundles_as_native_authority",
+    "publish_series_registry_descriptor",
+    "publish_series_record_index",
+    "publish_one_series_envelope_per_reviewed_exchange_bundle",
+    "add_deterministic_series_validation",
+    "add_permanent_read_only_series_ci",
+    "run_exact_main_production_verification",
+    "synchronize_phase9_tracker_after_acceptance"
+  ],
+  "public_surface_boundary": {
+    "series_descriptor": "/data/series/registry.json",
+    "series_index": "/data/series/index.json",
+    "series_record_template": "/data/series/records/{slug}.json",
+    "native_index": "/data/exchanges/index.json",
+    "native_record_template": "/data/exchanges/{slug}.json",
+    "search_route": "/explore/",
+    "compare_route": "/compare/",
+    "stats_route": "/stats/",
+    "new_html_route_family_authorized": false,
+    "search_behavior_change_authorized": false,
+    "compare_behavior_change_authorized": false,
+    "stats_behavior_change_authorized": false,
+    "ui_css_change_authorized": false
+  },
+  "canonical_boundary": {
+    "canonical_entity_event_evidence_mutation_authorized": false,
+    "reviewed_bundle_mutation_authorized": false,
+    "schema_or_taxonomy_change_authorized": false,
+    "candidate_or_staging_publication_authorized": false,
+    "monitoring_publication_authorized": false,
+    "relationship_inference_authorized": false
+  },
+  "concurrent_work_protection": {
+    "open_pr_777": "do_not_modify_retarget_rebase_merge_or_depend_on",
+    "open_pr_779": "do_not_modify_retarget_rebase_merge_or_depend_on",
+    "adapter_counts": "derive_from_current_native_record_level_index_at_build_time"
+  },
+  "required_acceptance": [
+    "native_record_level_bundles_remain_authoritative_and_lossless",
+    "series_count_equals_native_record_level_count",
+    "series_global_keys_are_unique_and_stable",
+    "series_urls_use_only_real_existing_public_routes",
+    "series_output_is_canonical_only_and_excludes_candidates_monitoring_private_material",
+    "typed_series_relationships_are_not_emitted_during_stage3",
+    "existing_machine_readable_record_level_explorer_compare_stats_and_public_output_gates_remain_green",
+    "exact_main_production_series_equality_passes_before_acceptance"
+  ],
+  "forbidden": [
+    "canonical_entity_event_evidence_changes",
+    "reviewed_bundle_changes",
+    "schema_or_taxonomy_changes",
+    "candidate_or_monitoring_publication",
+    "ai_generated_canonical_facts",
+    "relationship_inference",
+    "search_compare_stats_ui_behavior_changes",
+    "dns_or_cloudflare_project_configuration_changes",
+    "retarget_rebase_merge_or_modify_concurrent_vertical_prs"
+  ],
+  "closeout": {
+    "automatic_continuation": false,
+    "production_verification_required": true,
+    "coordination_issue": 780
+  }
+}

--- a/docs/tasks/HEI_LEDGER_SERIES_PHASE9_ADAPTER_AUTHORITY_2026-08-20.md
+++ b/docs/tasks/HEI_LEDGER_SERIES_PHASE9_ADAPTER_AUTHORITY_2026-08-20.md
@@ -1,0 +1,92 @@
+# HEI Ledger Series Phase 9 Adapter Authority
+
+Status: active after merge  
+Date: 2026-08-20  
+Coordination: Issue #780
+
+## Why this authority exists
+
+Issue #780 coordinates the cross-registry Ledger Series Phase 9 work but explicitly does not authorize HEI runtime or canonical changes. This document and `config/ledger-series-phase9-adapter-authority.json` are the HEI-local reviewed authority required before the final Stage 3 adapter is implemented.
+
+## Native source of truth
+
+The adapter must reuse the existing reviewed HEI machine-readable surfaces:
+
+- `/version.json`
+- `/data/manifest.json`
+- `/data/exchanges/index.json`
+- `/data/exchanges/{slug}.json`
+
+The native record-level bundle already contains the reviewed exchange entity, events, evidence, explicit predecessor/successor IDs, confidence, last verification, counts, human URL and machine URL. The adapter must not create a second canonical model.
+
+## Authorized Series output
+
+Only the following new public machine-readable routes are authorized:
+
+- `/data/series/registry.json`
+- `/data/series/index.json`
+- `/data/series/records/{slug}.json`
+
+The descriptor must point to existing public research surfaces:
+
+- search/explorer: `/explore/`
+- compare: `/compare/`
+- stats: `/stats/`
+
+No new HTML route is authorized.
+
+## Stage 3 mapping rules
+
+- one Series envelope per current reviewed native exchange bundle;
+- record count is derived dynamically from the native record-level index;
+- stable global key: `historical-exchange-index:exchange_entity:<native-id>`;
+- preserve the complete native bundle losslessly under the Series envelope;
+- expose native events and evidence without reinterpretation;
+- preserve native explicit predecessor/successor fields as native facts inside the lossless payload;
+- do not promote them into typed Series relationships during Stage 3;
+- `relationships` in the common envelope remains empty until the separately reviewed Phase 9 relationship stage;
+- preserve unknowns as unknowns;
+- preserve build/revision/provenance metadata from the native public layer;
+- never infer lifecycle facts, safety, ranking, quality or investment meaning.
+
+## Hard boundaries
+
+This authority does not authorize:
+
+- canonical entity/event/evidence changes;
+- reviewed record-bundle changes;
+- data-staging/candidate publication;
+- monitoring publication;
+- schema/taxonomy changes;
+- Explorer query/behavior changes;
+- Compare behavior changes;
+- Stats behavior changes;
+- UI/CSS changes;
+- DNS or Cloudflare project configuration changes;
+- AI-generated canonical facts;
+- typed relationship inference;
+- changes to the localization roadmap.
+
+## Concurrent work protection
+
+Open PR #777 and #779 are independent vertical work. The Phase 9 adapter task must not modify, retarget, rebase, merge, or depend on them. Because the adapter count is derived from the native record-level index at build time, either vertical PR may merge later without requiring a hard-coded Series count change.
+
+## Validation and deployment gate
+
+Implementation must follow the repository gate:
+
+1. branch from reviewed main after this authority merges;
+2. implement only the bounded adapter/output/validation scope;
+3. run existing relevant HEI CI and machine-readable/record-level/public-output validations;
+4. require exact final-head CI success before merge;
+5. merge normally;
+6. wait until production `/version.json` reports the exact merged main commit;
+7. compare the production Series descriptor, index and every record envelope against the exact-main build;
+8. verify representative `/explore/`, `/compare/`, `/stats/` and exchange dossier routes;
+9. record acceptance in Issue #780.
+
+Preview deployment is not required for the authority-only PR. For the adapter implementation, automatic Cloudflare previews remain disabled under the deployment policy; production verification occurs only after merge and exact-main convergence.
+
+## Completion
+
+This authority is exhausted when the HEI Stage 3 adapter is accepted in production and Issue #780 records HEI as accepted. It does not authorize automatic continuation into Phase 9 Stage 4 or relationship work.


### PR DESCRIPTION
HEI-local reviewed authority required before implementing the final cross-registry Ledger Series Phase 9 Stage 3 adapter.

Issue #780 is coordination-only and explicitly does not authorize direct HEI runtime changes, so this PR contains authority/specification only. It makes no canonical, runtime, machine-output, UI, Search, Compare, Stats, Cloudflare, or DNS change.

After merge, the authorized implementation scope is limited to:
- `/data/series/registry.json`
- `/data/series/index.json`
- `/data/series/records/{slug}.json`
- deterministic adapter validation / read-only CI
- exact-main production verification

The adapter must reuse `/data/exchanges/index.json` and `/data/exchanges/{slug}.json` as the native reviewed authority, preserve native bundles losslessly, derive counts dynamically, use `/explore/`, `/compare/`, `/stats/`, emit no typed Series relationships during Stage 3, and never infer new facts.

Concurrent open PR #777 and #779 are explicitly protected and must remain untouched.

This authority is exhausted after HEI Stage 3 production acceptance; it does not authorize automatic continuation into Stage 4 or relationship work.