### PR TITLE
Phase 9: add HEI Series adapter

### DIFF
--- a/.github/workflows/ledger-series-phase9-adapter.yml
+++ b/.github/workflows/ledger-series-phase9-adapter.yml
@@ -1,0 +1,54 @@
+name: Ledger Series Phase 9 Adapter
+
+on:
+  pull_request:
+    paths:
+      - "scripts/build-ledger-series-phase9-adapter.mjs"
+      - "scripts/validate-ledger-series-phase9-adapter.mjs"
+      - "scripts/build-record-level-machine-readable.mjs"
+      - "scripts/validate-record-level-machine-readable.mjs"
+      - "scripts/build-machine-readable-layer.mjs"
+      - "next.config.ts"
+      - "data/**"
+      - "records/**"
+      - ".github/workflows/ledger-series-phase9-adapter.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/build-ledger-series-phase9-adapter.mjs"
+      - "scripts/validate-ledger-series-phase9-adapter.mjs"
+      - "scripts/build-record-level-machine-readable.mjs"
+      - "scripts/validate-record-level-machine-readable.mjs"
+      - "scripts/build-machine-readable-layer.mjs"
+      - "next.config.ts"
+      - "data/**"
+      - "records/**"
+      - ".github/workflows/ledger-series-phase9-adapter.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-series-adapter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build exact candidate
+        run: npm run build
+
+      - name: Validate native record-level layer
+        run: node scripts/validate-record-level-machine-readable.mjs
+
+      - name: Validate Ledger Series adapter
+        run: node scripts/validate-ledger-series-phase9-adapter.mjs

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import './scripts/build-machine-readable-layer.mjs'
 import './scripts/build-record-level-machine-readable.mjs'
+import './scripts/build-ledger-series-phase9-adapter.mjs'
 import './scripts/register-stats-machine-readable.mjs'
 import type { NextConfig } from 'next'
 

--- a/scripts/build-ledger-series-phase9-adapter.mjs
+++ b/scripts/build-ledger-series-phase9-adapter.mjs
@@ -1,0 +1,176 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const publicDir = path.join(root, 'public')
+const nativeDir = path.join(publicDir, 'data', 'exchanges')
+const seriesDir = path.join(publicDir, 'data', 'series')
+const recordsDir = path.join(seriesDir, 'records')
+const origin = 'https://hei.badjoke-lab.com'
+const seriesSchemaVersion = '1.0.0'
+const registryId = 'historical-exchange-index'
+const nativeRecordType = 'exchange_entity'
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) throw new Error(`Ledger Series adapter missing required input: ${path.relative(root, filePath)}`)
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function globalRecordKey(id) {
+  return `${registryId}:${nativeRecordType}:${id}`
+}
+
+const version = readJson(path.join(publicDir, 'version.json'))
+const manifest = readJson(path.join(publicDir, 'data', 'manifest.json'))
+const nativeIndex = readJson(path.join(nativeDir, 'index.json'))
+
+if (version.project_id !== registryId || manifest.project_id !== registryId || nativeIndex.project_id !== registryId) {
+  throw new Error('Ledger Series adapter project identity mismatch')
+}
+if (nativeIndex.canonical_only !== true || manifest.data_safety?.canonical_only !== true) {
+  throw new Error('Ledger Series adapter requires canonical-only native inputs')
+}
+if (!Array.isArray(nativeIndex.records) || nativeIndex.record_count !== nativeIndex.records.length) {
+  throw new Error('Ledger Series adapter native index count mismatch')
+}
+
+fs.rmSync(seriesDir, { recursive: true, force: true })
+fs.mkdirSync(recordsDir, { recursive: true })
+
+const descriptor = {
+  series_schema_version: seriesSchemaVersion,
+  object_type: 'registry_descriptor',
+  registry: {
+    id: registryId,
+    name: version.site_name,
+    type: version.registry_type,
+    origin,
+    native_machine_schema_version: nativeIndex.schema_version,
+    native_data_schema_version: nativeIndex.data_schema_version,
+  },
+  canonical_only: true,
+  record_counts: {
+    primary_records: nativeIndex.record_count,
+    series_records: nativeIndex.record_count,
+  },
+  routes: {
+    descriptor: '/data/series/registry.json',
+    index: '/data/series/index.json',
+    record_template: '/data/series/records/{slug}.json',
+    native_record_template: '/data/exchanges/{slug}.json',
+    search: '/explore/',
+    compare: '/compare/',
+    stats: '/stats/',
+  },
+  capabilities: {
+    search: true,
+    compare: true,
+    stats: true,
+    typed_relationships: false,
+  },
+  data_safety: {
+    ...manifest.data_safety,
+    ai_generated_canonical_facts: false,
+  },
+  verification: {
+    build: version.build,
+    native_verification_marker: version.build?.verification_marker ?? null,
+  },
+}
+
+const indexRecords = []
+for (const item of [...nativeIndex.records].sort((a, b) => String(a.slug).localeCompare(String(b.slug)))) {
+  const nativePath = path.join(nativeDir, `${item.slug}.json`)
+  const native = readJson(nativePath)
+  const entity = native.entity
+  if (!entity || entity.id !== item.id || entity.slug !== item.slug) {
+    throw new Error(`Ledger Series adapter native identity mismatch: ${item.slug}`)
+  }
+  if (native.canonical_only !== true) throw new Error(`Ledger Series adapter noncanonical native record: ${item.slug}`)
+
+  const machineUrl = `${origin}/data/series/records/${item.slug}.json`
+  const envelope = {
+    series_schema_version: seriesSchemaVersion,
+    object_type: 'record_envelope',
+    registry_id: registryId,
+    global_record_key: globalRecordKey(entity.id),
+    record_key: {
+      native_record_type: nativeRecordType,
+      native_record_id: entity.id,
+      slug: entity.slug,
+    },
+    identity: {
+      name: entity.canonical_name,
+      aliases: Array.isArray(entity.aliases) ? entity.aliases : [],
+    },
+    urls: {
+      human: native.canonical_page_url,
+      machine: machineUrl,
+      native_machine: native.record_json_url,
+    },
+    current_state: {
+      status: entity.status ?? null,
+      native: {
+        bundle: native,
+      },
+    },
+    events: {
+      records: native.events ?? [],
+    },
+    evidence: {
+      records: native.evidence ?? [],
+    },
+    relationships: [],
+    verification: {
+      build: version.build,
+      last_verified_at: native.verification?.last_verified_at ?? null,
+      confidence: native.verification?.confidence ?? null,
+    },
+    provenance: {
+      canonical_only: true,
+      data_safety: manifest.data_safety,
+      native_schema_version: native.schema_version,
+      native_data_schema_version: native.data_schema_version,
+      native_project_id: native.project_id,
+    },
+  }
+
+  writeJson(path.join(recordsDir, `${item.slug}.json`), envelope)
+  indexRecords.push({
+    global_record_key: envelope.global_record_key,
+    native_record_type: nativeRecordType,
+    native_record_id: entity.id,
+    slug: entity.slug,
+    name: entity.canonical_name,
+    current_state: entity.status ?? null,
+    human_url: native.canonical_page_url,
+    machine_url: machineUrl,
+    native_machine_url: native.record_json_url,
+    last_verified_at: native.verification?.last_verified_at ?? null,
+  })
+}
+
+const seriesIndex = {
+  series_schema_version: seriesSchemaVersion,
+  object_type: 'record_index',
+  registry_id: registryId,
+  canonical_only: true,
+  record_count: indexRecords.length,
+  record_counts: {
+    exchange_entities: indexRecords.length,
+  },
+  verification: {
+    build: version.build,
+  },
+  records: indexRecords,
+}
+
+writeJson(path.join(seriesDir, 'registry.json'), descriptor)
+writeJson(path.join(seriesDir, 'index.json'), seriesIndex)
+
+console.log(`Built HEI Ledger Series Phase 9 adapter: ${indexRecords.length} canonical exchange envelopes.`)

--- a/scripts/validate-ledger-series-phase9-adapter.mjs
+++ b/scripts/validate-ledger-series-phase9-adapter.mjs
@@ -1,0 +1,109 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const origin = 'https://hei.badjoke-lab.com'
+const registryId = 'historical-exchange-index'
+const nativeRecordType = 'exchange_entity'
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`HEI Ledger Series adapter validation failed: ${message}`)
+}
+
+function readJson(relativePath) {
+  const filePath = path.join(root, relativePath)
+  assert(fs.existsSync(filePath), `missing ${relativePath}`)
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+const version = readJson('public/version.json')
+const manifest = readJson('public/data/manifest.json')
+const nativeIndex = readJson('public/data/exchanges/index.json')
+const descriptor = readJson('public/data/series/registry.json')
+const seriesIndex = readJson('public/data/series/index.json')
+
+assert(descriptor.series_schema_version === '1.0.0', 'descriptor schema version')
+assert(descriptor.object_type === 'registry_descriptor', 'descriptor object type')
+assert(descriptor.registry?.id === registryId, 'descriptor registry id')
+assert(descriptor.registry?.origin === origin, 'descriptor origin')
+assert(descriptor.canonical_only === true, 'descriptor canonical_only')
+assert(descriptor.record_counts?.primary_records === nativeIndex.record_count, 'descriptor primary count')
+assert(descriptor.record_counts?.series_records === nativeIndex.record_count, 'descriptor series count')
+assert(descriptor.routes?.native_record_template === '/data/exchanges/{slug}.json', 'native record template')
+assert(descriptor.routes?.search === '/explore/', 'search route')
+assert(descriptor.routes?.compare === '/compare/', 'compare route')
+assert(descriptor.routes?.stats === '/stats/', 'stats route')
+assert(descriptor.capabilities?.typed_relationships === false, 'typed relationships must remain disabled')
+assert(stable(descriptor.verification?.build) === stable(version.build), 'descriptor build metadata mismatch')
+assert(stable(descriptor.data_safety) === stable({ ...manifest.data_safety, ai_generated_canonical_facts: false }), 'descriptor data safety mismatch')
+
+assert(seriesIndex.series_schema_version === '1.0.0', 'index schema version')
+assert(seriesIndex.object_type === 'record_index', 'index object type')
+assert(seriesIndex.registry_id === registryId, 'index registry id')
+assert(seriesIndex.canonical_only === true, 'index canonical_only')
+assert(seriesIndex.record_count === nativeIndex.record_count, 'index count')
+assert(seriesIndex.records.length === nativeIndex.records.length, 'index records length')
+assert(stable(seriesIndex.verification?.build) === stable(version.build), 'index build metadata mismatch')
+
+const nativeBySlug = new Map(nativeIndex.records.map((item) => [item.slug, item]))
+const globalKeys = new Set()
+
+for (const item of seriesIndex.records) {
+  const nativeIndexItem = nativeBySlug.get(item.slug)
+  assert(nativeIndexItem, `series index slug missing from native index: ${item.slug}`)
+  assert(item.native_record_type === nativeRecordType, `${item.slug} native record type`)
+  assert(item.native_record_id === nativeIndexItem.id, `${item.slug} native id`)
+  assert(item.human_url === nativeIndexItem.canonical_page_url, `${item.slug} human url`)
+  assert(item.native_machine_url === nativeIndexItem.record_json_url, `${item.slug} native machine url`)
+  assert(item.machine_url === `${origin}/data/series/records/${item.slug}.json`, `${item.slug} series machine url`)
+  assert(!globalKeys.has(item.global_record_key), `${item.slug} duplicate global key`)
+  globalKeys.add(item.global_record_key)
+
+  const native = readJson(`public/data/exchanges/${item.slug}.json`)
+  const envelope = readJson(`public/data/series/records/${item.slug}.json`)
+  const expectedKey = `${registryId}:${nativeRecordType}:${native.entity.id}`
+
+  assert(envelope.series_schema_version === '1.0.0', `${item.slug} envelope schema version`)
+  assert(envelope.object_type === 'record_envelope', `${item.slug} envelope object type`)
+  assert(envelope.registry_id === registryId, `${item.slug} registry id`)
+  assert(envelope.global_record_key === expectedKey, `${item.slug} global key`)
+  assert(envelope.record_key?.native_record_type === nativeRecordType, `${item.slug} record type`)
+  assert(envelope.record_key?.native_record_id === native.entity.id, `${item.slug} record id`)
+  assert(envelope.record_key?.slug === native.entity.slug, `${item.slug} record slug`)
+  assert(envelope.urls?.human === native.canonical_page_url, `${item.slug} human url mismatch`)
+  assert(envelope.urls?.native_machine === native.record_json_url, `${item.slug} native machine mismatch`)
+  assert(envelope.urls?.machine === `${origin}/data/series/records/${item.slug}.json`, `${item.slug} machine url mismatch`)
+  assert(envelope.current_state?.status === (native.entity.status ?? null), `${item.slug} current status`)
+  assert(stable(envelope.current_state?.native?.bundle) === stable(native), `${item.slug} native bundle not lossless`)
+  assert(stable(envelope.events?.records) === stable(native.events ?? []), `${item.slug} events mismatch`)
+  assert(stable(envelope.evidence?.records) === stable(native.evidence ?? []), `${item.slug} evidence mismatch`)
+  assert(Array.isArray(envelope.relationships) && envelope.relationships.length === 0, `${item.slug} typed relationships must be empty`)
+  assert(stable(envelope.verification?.build) === stable(version.build), `${item.slug} build metadata mismatch`)
+  assert(envelope.verification?.last_verified_at === (native.verification?.last_verified_at ?? null), `${item.slug} last verified mismatch`)
+  assert(envelope.verification?.confidence === (native.verification?.confidence ?? null), `${item.slug} confidence mismatch`)
+  assert(envelope.provenance?.canonical_only === true, `${item.slug} provenance canonical_only`)
+  assert(stable(envelope.provenance?.data_safety) === stable(manifest.data_safety), `${item.slug} provenance data safety`)
+  assert(envelope.provenance?.native_schema_version === native.schema_version, `${item.slug} native schema version`)
+  assert(envelope.provenance?.native_data_schema_version === native.data_schema_version, `${item.slug} native data schema version`)
+  assert(envelope.provenance?.native_project_id === native.project_id, `${item.slug} native project id`)
+
+  const serialized = JSON.stringify(envelope)
+  for (const forbidden of ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']) {
+    assert(!serialized.includes(forbidden), `${item.slug} contains forbidden marker ${forbidden}`)
+  }
+}
+
+const seriesFiles = fs.readdirSync(path.join(root, 'public', 'data', 'series', 'records')).filter((name) => name.endsWith('.json'))
+assert(seriesFiles.length === nativeIndex.record_count, 'stale or missing Series record files')
+assert(globalKeys.size === nativeIndex.record_count, 'global key uniqueness count mismatch')
+
+console.log(`HEI Ledger Series Phase 9 adapter validation passed: ${nativeIndex.record_count} canonical exchange envelopes.`)
+console.log(`Build commit: ${version.build?.commit ?? 'unknown'}`)


### PR DESCRIPTION
Implements the final Ledger Series Phase 9 Stage 3 registry adapter under merged HEI-local authority PR #781, on top of current main `ad6f620dc312de305d4418be788809a43a7c03c8` (including merged Zedcex PR #779).

Scope:
- adds `/data/series/registry.json`
- adds `/data/series/index.json`
- adds `/data/series/records/{slug}.json` for every current reviewed exchange bundle
- reuses `/data/exchanges/index.json` and `/data/exchanges/{slug}.json` as the native reviewed authority
- preserves each native exchange bundle losslessly inside the Series envelope
- derives counts dynamically from the current native index
- uses `/explore/`, `/compare/`, `/stats/` as actual HEI public capabilities
- emits no typed Series relationships during Stage 3; native predecessor/successor facts remain preserved only inside the native bundle
- adds fail-close adapter validation for identity, count parity, global-key uniqueness, native-bundle equality, canonical-only safety, URLs, build metadata, events/evidence parity, and forbidden-marker leakage
- adds permanent read-only Series CI
- hooks the adapter generator into the existing Next/Cloudflare build path after the native record-level generator

Hard boundaries:
- canonical/data/records delta: 0 in this PR
- native schema/taxonomy delta: 0
- no UI/Search/Compare/Stats behavior change
- no monitoring/candidate publication
- no relationship inference
- concurrent commercial experiment PR #777 is untouched
- merged Zedcex canonical growth is inherited from current main rather than overwritten

Merge gate: all existing HEI checks plus the dedicated Ledger Series adapter CI must pass on the exact final head. Exact-main production verification is required after merge. Authority is exhausted after production acceptance; Stage 4 is not automatically authorized.