### PR TITLE
One-shot: verify HEI Phase 9 Series production

### DIFF
--- a/.github/workflows/phase9-series-production-verification.yml
+++ b/.github/workflows/phase9-series-production-verification.yml
@@ -1,0 +1,45 @@
+name: Phase 9 Series production verification
+
+on:
+  pull_request:
+    paths:
+      - "scripts/verify-ledger-series-phase9-production.mjs"
+      - ".github/workflows/phase9-series-production-verification.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-production:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact merged main
+        uses: actions/checkout@v7
+        with:
+          ref: 6b94227a3427e7255b8cb72244ae526b91a0899e
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Build exact merged main
+        env:
+          CF_PAGES_COMMIT_SHA: 6b94227a3427e7255b8cb72244ae526b91a0899e
+          CF_PAGES_BRANCH: main
+        run: npm run build
+
+      - name: Validate native record-level layer
+        run: node scripts/validate-record-level-machine-readable.mjs
+
+      - name: Validate local Ledger Series adapter
+        run: node scripts/validate-ledger-series-phase9-adapter.mjs
+
+      - name: Verify exact-main production Series equality
+        env:
+          HEI_EXPECTED_MAIN_COMMIT: 6b94227a3427e7255b8cb72244ae526b91a0899e
+        run: node scripts/verify-ledger-series-phase9-production.mjs

--- a/.github/workflows/phase9-series-production-verification.yml
+++ b/.github/workflows/phase9-series-production-verification.yml
@@ -39,7 +39,13 @@ jobs:
       - name: Validate local Ledger Series adapter
         run: node scripts/validate-ledger-series-phase9-adapter.mjs
 
+      - name: Checkout verifier source without changing exact-main workspace
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: verifier-source
+
       - name: Verify exact-main production Series equality
         env:
           HEI_EXPECTED_MAIN_COMMIT: 6b94227a3427e7255b8cb72244ae526b91a0899e
-        run: node scripts/verify-ledger-series-phase9-production.mjs
+        run: node verifier-source/scripts/verify-ledger-series-phase9-production.mjs

--- a/scripts/verify-ledger-series-phase9-production.mjs
+++ b/scripts/verify-ledger-series-phase9-production.mjs
@@ -1,0 +1,124 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const origin = 'https://hei.badjoke-lab.com'
+const expectedCommit = process.env.HEI_EXPECTED_MAIN_COMMIT
+if (!expectedCommit) throw new Error('HEI_EXPECTED_MAIN_COMMIT is required')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`HEI Series production verification failed: ${message}`)
+}
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'))
+}
+
+function normalize(value) {
+  if (Array.isArray(value)) return value.map(normalize)
+  if (value && typeof value === 'object') {
+    const out = {}
+    for (const key of Object.keys(value).sort()) {
+      if (key === 'generated_at') continue
+      out[key] = normalize(value[key])
+    }
+    return out
+  }
+  return value
+}
+
+function stable(value) {
+  return JSON.stringify(normalize(value))
+}
+
+async function fetchResponse(url) {
+  const joiner = url.includes('?') ? '&' : '?'
+  return fetch(`${url}${joiner}verify=${Date.now()}-${Math.random()}`, {
+    cache: 'no-store',
+    headers: { 'user-agent': 'hei-phase9-series-production-verifier' },
+    signal: AbortSignal.timeout(20000),
+  })
+}
+
+async function fetchJson(url) {
+  const response = await fetchResponse(url)
+  assert(response.ok, `${url} returned ${response.status}`)
+  return response.json()
+}
+
+async function waitForExactProductionCommit() {
+  let observed = null
+  for (let attempt = 1; attempt <= 36; attempt += 1) {
+    try {
+      const version = await fetchJson(`${origin}/version.json`)
+      observed = version.build?.commit ?? null
+      if (observed === expectedCommit) return version
+    } catch (error) {
+      observed = `fetch-error:${error.message}`
+    }
+    console.log(`Production convergence attempt ${attempt}/36: observed ${observed}`)
+    await new Promise((resolve) => setTimeout(resolve, 10000))
+  }
+  throw new Error(`production did not converge to ${expectedCommit}; last observed ${observed}`)
+}
+
+const localVersion = readJson('public/version.json')
+assert(localVersion.build?.commit === expectedCommit, `local build commit is ${localVersion.build?.commit}`)
+
+const productionVersion = await waitForExactProductionCommit()
+assert(productionVersion.build?.commit === expectedCommit, 'production version commit mismatch after convergence')
+
+const localDescriptor = readJson('public/data/series/registry.json')
+const localIndex = readJson('public/data/series/index.json')
+const productionDescriptor = await fetchJson(`${origin}/data/series/registry.json`)
+const productionIndex = await fetchJson(`${origin}/data/series/index.json`)
+
+assert(stable(productionDescriptor) === stable(localDescriptor), 'registry descriptor semantic mismatch')
+assert(stable(productionIndex) === stable(localIndex), 'record index semantic mismatch')
+assert(localIndex.record_count === localIndex.records.length, 'local index count mismatch')
+assert(productionIndex.record_count === productionIndex.records.length, 'production index count mismatch')
+
+const globalKeys = new Set()
+for (const item of productionIndex.records) {
+  assert(!globalKeys.has(item.global_record_key), `duplicate global key ${item.global_record_key}`)
+  globalKeys.add(item.global_record_key)
+}
+assert(globalKeys.size === productionIndex.record_count, 'global key uniqueness count mismatch')
+
+let verifiedRecords = 0
+const chunkSize = 20
+for (let offset = 0; offset < localIndex.records.length; offset += chunkSize) {
+  const chunk = localIndex.records.slice(offset, offset + chunkSize)
+  await Promise.all(chunk.map(async (item) => {
+    const local = readJson(`public/data/series/records/${item.slug}.json`)
+    const production = await fetchJson(`${origin}/data/series/records/${item.slug}.json`)
+    assert(stable(production) === stable(local), `${item.slug} Series envelope semantic mismatch`)
+    verifiedRecords += 1
+  }))
+  console.log(`Verified Series records: ${verifiedRecords}/${localIndex.record_count}`)
+}
+
+const representativeUrls = [
+  `${origin}/explore/`,
+  `${origin}/compare/`,
+  `${origin}/stats/`,
+]
+const firstRecord = localIndex.records[0]
+if (firstRecord?.human_url) representativeUrls.push(firstRecord.human_url)
+const zedcex = localIndex.records.find((item) => item.slug === 'zedcex')
+if (zedcex?.human_url) representativeUrls.push(zedcex.human_url)
+
+for (const url of [...new Set(representativeUrls)]) {
+  const response = await fetchResponse(url)
+  assert(response.ok, `representative human route ${url} returned ${response.status}`)
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  expected_main_commit: expectedCommit,
+  production_commit: productionVersion.build?.commit,
+  series_json_verified: verifiedRecords + 2,
+  series_records_verified: verifiedRecords,
+  global_keys_unique: globalKeys.size,
+  representative_human_routes: [...new Set(representativeUrls)].length,
+}, null, 2))


### PR DESCRIPTION
Read-only one-shot verifier for the merged HEI Ledger Series Phase 9 Stage 3 adapter.

Exact target main: `6b94227a3427e7255b8cb72244ae526b91a0899e` (merged implementation PR #782).

## Accepted production verification

Final verifier head: `c1761e48a2649b6a2f2749469e7e972488ecd7a3`
Accepted run: `32334424438`
Accepted job: `96321057178`
Conclusion: **success**

Verified against exact merged main and current production:
- exact merged-main checkout: PASS
- exact merged-main build: PASS
- native record-level validation: **1038/1038 exchange bundles PASS**
- local Series adapter validation: **1038/1038 exchange envelopes PASS**
- production `/version.json` build commit: exact `6b94227a3427e7255b8cb72244ae526b91a0899e`
- production Series descriptor/index semantic equality: PASS
- production Series record envelopes: **1038/1038 PASS**
- total Series JSON verified: **1040** (descriptor + index + 1038 records)
- global keys unique: **1038/1038**
- representative human routes: **5/5 PASS** (`/explore/`, `/compare/`, `/stats/`, representative dossier, Zedcex dossier)
- exact-main corpus at acceptance: **1038 primary records / 1046 events / 3889 evidence**
- only deployment-specific `generated_at` values were excluded from semantic comparison; build commit and reviewed content were required to match.

The initial run `32333839076` failed only because the verification-only script disappeared when the workflow intentionally checked out exact main; exact-main build/native/Series validation had already passed. The workflow was corrected to checkout verifier source into a separate subdirectory without changing the exact-main workspace. No runtime or production code was changed by that correction.

This PR is verification-only and is closed without merge after acceptance. It makes no canonical, runtime, production, Cloudflare, DNS, Search, Compare, Stats, UI, or relationship mutation.