### PR TITLE
Authorize Phase 9 Stage 4 Series index

### DIFF
--- a/config/ledger-series-phase9-stage4-authority.json
+++ b/config/ledger-series-phase9-stage4-authority.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0.0",
+  "authority_id": "hei-ledger-series-phase9-stage4-2026-08-20",
+  "phase": 9,
+  "stage": 4,
+  "title": "Temporary-host Series registry index authority",
+  "status": "review_required_before_implementation",
+  "coordination_issue": 780,
+  "authority_base_main": "6b94227a3427e7255b8cb72244ae526b91a0899e",
+  "stage3_status": "complete_8_of_8_production_accepted",
+  "publication": {
+    "semantic_owner": "badjoke-lab-ledger-series",
+    "temporary_host_repository": "badjoke-lab/historical-exchange-index",
+    "temporary_host_origin": "https://hei.badjoke-lab.com",
+    "public_route": "/data/series/registries.json",
+    "host_is_semantic_owner": false,
+    "portable_to_future_dedicated_repository": true
+  },
+  "source_descriptors": [
+    "https://hei.badjoke-lab.com/data/series/registry.json",
+    "https://mag.badjoke-lab.com/data/series/registry.json",
+    "https://www.stableorgone.com/data/series/registry.json",
+    "https://cya.badjoke-lab.com/data/series/registry.json",
+    "https://bir.badjoke-lab.com/data/series/registry.json",
+    "https://wlr.badjoke-lab.com/data/series/registry.json",
+    "https://ai-tools-history-archive.pages.dev/data/series/registry.json",
+    "https://api-deprecation-archive.pages.dev/data/series/registry.json"
+  ],
+  "allowed_implementation": [
+    "add one reviewed tracked registry-index source/lock containing registry-level descriptor snapshots only",
+    "add a deterministic build generator for /data/series/registries.json with no network access during normal build",
+    "add fail-close validation for exactly eight unique registry identities, origins, descriptor URLs, counts, capabilities and verification facts",
+    "add one build hook after native HEI Series generation",
+    "add read-only CI for deterministic Stage 4 index validation",
+    "add a verification-only workflow/PR that compares the accepted central snapshot with all eight live production Series descriptors",
+    "publish /data/series/registries.json from the temporary HEI host after reviewed merge"
+  ],
+  "forbidden": [
+    "canonical exchange/entity/event/evidence mutation",
+    "copying any registry canonical record into the central index",
+    "cross-registry relationship publication",
+    "candidate or private monitoring publication",
+    "native schema or taxonomy changes",
+    "Search, Compare, Stats or UI behavior changes",
+    "Cloudflare account, DNS, hostname or deployment-project mutation",
+    "retargeting, rebasing or merging unrelated vertical pull requests",
+    "treating HEI as semantic owner of other registries",
+    "automatic Stage 5 continuation without separate reviewed authority"
+  ],
+  "acceptance": [
+    "authority PR merged before implementation",
+    "implementation diff contains only bounded Stage 4 source/generator/validator/build-hook/CI changes",
+    "existing HEI checks and dedicated Stage 4 validation green on exact final head",
+    "implementation merged to main",
+    "production /version.json reports exact accepted implementation main",
+    "production /data/series/registries.json equals exact-main deterministic output apart from explicitly documented deployment timestamps if any",
+    "all eight production descriptor identities/origins/counts/capabilities/verification snapshots agree at acceptance",
+    "representative descriptor URLs return successfully",
+    "Stage 4 acceptance evidence recorded in coordination Issue #780"
+  ],
+  "automatic_continuation": false
+}

--- a/docs/tasks/HEI_LEDGER_SERIES_PHASE9_STAGE4_AUTHORITY_2026-08-20.md
+++ b/docs/tasks/HEI_LEDGER_SERIES_PHASE9_STAGE4_AUTHORITY_2026-08-20.md
@@ -1,0 +1,113 @@
+# HEI Ledger Series Phase 9 Stage 4 Authority — 2026-08-20
+
+Status: **review required; no Stage 4 runtime write until this authority merges**
+
+Coordination authority: HEI Issue #780  
+Stage 3 accepted implementation main: `6b94227a3427e7255b8cb72244ae526b91a0899e`  
+Stage 3 production verifier: PR #783 / run `32334424438` / job `96321057178`
+
+## Purpose
+
+Authorize one bounded Phase 9 Stage 4 implementation: a deterministic registry-level Series index referencing the eight production Series registry descriptors.
+
+This authority does not make HEI the semantic owner of MAG, SOG, CYA, BIR, WLR, AI Tools or API Deprecation. HEI is only a temporary publication host because the connected GitHub capabilities cannot create a dedicated Series repository.
+
+## Publication boundary
+
+Temporary public route:
+
+`https://hei.badjoke-lab.com/data/series/registries.json`
+
+Semantic owner/family:
+
+`badjoke-lab-ledger-series`
+
+The index is explicitly portable. A later reviewed migration may move the same contract to a dedicated Series repository/origin without changing native registry ownership.
+
+## Source descriptor set
+
+Stage 4 is limited to the eight Stage 3 production-accepted descriptors:
+
+1. HEI — `https://hei.badjoke-lab.com/data/series/registry.json`
+2. MAG — `https://mag.badjoke-lab.com/data/series/registry.json`
+3. SOG — `https://www.stableorgone.com/data/series/registry.json`
+4. CYA — `https://cya.badjoke-lab.com/data/series/registry.json`
+5. BIR — `https://bir.badjoke-lab.com/data/series/registry.json`
+6. WLR — `https://wlr.badjoke-lab.com/data/series/registry.json`
+7. AI Tools — `https://ai-tools-history-archive.pages.dev/data/series/registry.json`
+8. API Deprecation — `https://api-deprecation-archive.pages.dev/data/series/registry.json`
+
+## Index contract
+
+The public index may contain registry-level discovery and synchronization facts only:
+
+- stable registry id, name and type;
+- public origin;
+- descriptor URL;
+- Series index/record route metadata exposed by the descriptor;
+- Series schema/native schema facts exposed by the descriptor;
+- synchronized primary/Series record counts;
+- supported common capabilities such as Search, Compare, Stats and typed relationships;
+- verification/build/revision facts actually exposed by the descriptor;
+- synchronization metadata for the reviewed snapshot.
+
+The index must not contain copied canonical records or newly inferred lifecycle/relationship claims.
+
+## Deterministic source design
+
+Normal HEI builds must remain network-independent.
+
+Stage 4 implementation therefore uses a reviewed tracked registry-index source/lock populated from the eight accepted production descriptors. The normal build transforms that source deterministically into `/data/series/registries.json`.
+
+A separate read-only synchronization verifier performs network reads after merge/at acceptance and compares the central snapshot with all eight live production descriptors. Network fetch is not part of normal site generation.
+
+## Allowed implementation surface
+
+A single Stage 4 implementation PR may:
+
+- add the reviewed Stage 4 registry-index source/lock;
+- add one deterministic index builder;
+- add one fail-close validator;
+- add a build hook after the native HEI Series adapter generator;
+- add read-only CI for the new index;
+- add a verification-only production workflow in a separate one-shot PR after implementation merge.
+
+## Hard prohibitions
+
+This authority does **not** allow:
+
+- canonical exchange/entity/event/evidence changes;
+- changes to any other registry repository;
+- copying native records into the central index;
+- Stage 5 cross-registry relationship publication;
+- candidate/private/monitoring publication;
+- HEI native schema/taxonomy changes;
+- public UI, Explorer, Compare or Stats behavior changes;
+- Cloudflare account/project/DNS/hostname mutations;
+- touching PR #777 or other unrelated vertical branches;
+- claiming HEI owns other registries;
+- automatic Stage 5 implementation.
+
+## Required validation
+
+Before implementation merge:
+
+1. exactly eight unique registry ids;
+2. exactly eight unique public origins and descriptor URLs;
+3. descriptor URLs use HTTPS and `/data/series/registry.json`;
+4. central entries contain registry metadata only and no record arrays/canonical payloads;
+5. counts/capabilities/verification fields are copied from reviewed descriptor snapshots without inference;
+6. deterministic rebuild produces identical public index content;
+7. existing HEI CI remains green;
+8. dedicated Stage 4 validator/CI is green on exact final head.
+
+After implementation merge:
+
+1. production `/version.json` must report the exact accepted implementation main;
+2. production `/data/series/registries.json` must equal the exact-main build output;
+3. a read-only verifier must fetch all eight live descriptors and confirm identity/origin/count/capability/verification agreement at the acceptance snapshot;
+4. accepted run/job and synchronized registry facts must be recorded in Issue #780.
+
+## Completion rule
+
+After production acceptance, this authority is exhausted. Stage 5 relationship work requires separately reviewed authority and must not begin automatically from this HEI-local authority.


### PR DESCRIPTION
Authorizes one bounded Ledger Series Phase 9 Stage 4 implementation after Stage 3 production acceptance reached 8/8.

Coordination authority: Issue #780.
Accepted Stage 3 HEI main: `6b94227a3427e7255b8cb72244ae526b91a0899e`.
Accepted HEI production verifier: PR #783 / run `32334424438` / job `96321057178`.

This PR is authority-only. It makes no runtime/public/canonical/UI change.

Key placement decision:
- temporary public host after a later implementation merge: `https://hei.badjoke-lab.com/data/series/registries.json`
- semantic owner: `badjoke-lab-ledger-series`
- HEI is operational host only; it does not own other registries
- index is portable to a future dedicated Series repository

The later implementation is limited to a reviewed tracked registry-index source/lock, deterministic network-free normal-build generator, fail-close validator, one build hook, read-only CI, and a separate post-merge production synchronization verifier across the eight accepted registry descriptors.

Forbidden: canonical data changes, copied records, Stage 5 relationships, UI/Search/Compare/Stats behavior changes, Cloudflare/DNS changes, candidate/private monitoring publication, or interference with PR #777/other vertical work.

Merge of this authority is required before any Stage 4 runtime write.