### PR TITLE
Prepare bounded HEI commercial dataset export experiment on current main

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -39,6 +39,8 @@ jobs:
       - run: npm run data:check-projected-enums
       - run: npm run monitor:smoke
       - run: npm run monitor:test-completion
+      - name: Validate bounded commercial dataset sample export
+        run: node tools/export-commercial-dataset.mjs --sample-size=5 --source-commit="${GITHUB_SHA}"
       - run: node --check scripts/check-machine-readable-production.mjs
       - run: node --check scripts/check-record-level-machine-readable-production.mjs
       - run: node --check scripts/check-stats-machine-readable-production.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 .next
 .next/
 out
+.commercial-output/
 
 # Generated during the Next production build
 public/version.json

--- a/docs/HEI_COMMERCIAL_DATASET_EXPERIMENT_SPEC.md
+++ b/docs/HEI_COMMERCIAL_DATASET_EXPERIMENT_SPEC.md
@@ -1,0 +1,147 @@
+# HEI Commercial Dataset Experiment Specification
+
+Status: bounded pre-publication experiment  
+Project: Historical Exchange Index (HEI)  
+Repository: `badjoke-lab/historical-exchange-index`  
+Checkpoint: 2026-08-19
+
+## 1. Purpose
+
+Test whether HEI's existing reviewed registry can be packaged as a paid machine-consumable dataset without creating a new site, weakening the reviewed-public boundary, or interrupting the current HEI roadmap.
+
+This experiment is intentionally narrower than a new API or SaaS product. It reuses reviewed HEI data and produces an offline export package for marketplace qualification and buyer testing.
+
+## 2. Product hypothesis
+
+Working product name:
+
+`Crypto Exchange Lifecycle & Incident Dataset`
+
+The value proposition is not exclusive access to facts that are already public. The paid package would provide:
+
+- a normalized cross-exchange schema;
+- entity, lifecycle-event, and evidence tables joined by stable IDs;
+- CSV and JSON forms suitable for ingestion;
+- deterministic version and hash metadata;
+- dated snapshots and revision tracking when the experiment advances beyond sample stage;
+- a documented field dictionary and reviewed-data boundary.
+
+The free HEI website and public machine-readable layer remain available. The commercial experiment must not remove or degrade existing public output.
+
+## 3. Source-of-truth boundary
+
+Commercial exports must be derived only from the same reviewed canonical state used by HEI public machine-readable output:
+
+- base canonical arrays;
+- reviewed `records/exchanges` bundles;
+- reviewed entity corrections;
+- reviewed aggregation and identity-resolution semantics.
+
+Do not export:
+
+- staging candidates;
+- monitoring output;
+- private research notes;
+- unreviewed classifications;
+- unpublished candidate records.
+
+The existing reviewed `entity -> event -> evidence` model remains authoritative.
+
+## 4. Initial package
+
+The first package contains three joined tables plus a manifest:
+
+### exchanges.csv
+
+Core fields:
+
+`id, slug, canonical_name, aliases, type, status, death_reason, launch_date, death_date, country_or_origin, official_domain_original, official_url_status, archived_url, confidence, last_verified_at, predecessor_id, successor_id`
+
+### events.csv
+
+Core fields:
+
+`id, exchange_id, exchange_slug, event_type, event_date, title, description, confidence, impact_level, event_status_effect, source_count, sort_order`
+
+### evidence.csv
+
+Core fields:
+
+`id, exchange_id, exchange_slug, event_id, source_type, title, url, publisher, published_at, archived_url, accessed_at, reliability, claim_scope`
+
+### manifest.json
+
+Must include:
+
+- package schema version;
+- generation timestamp;
+- export mode (`sample` or `full`);
+- reviewed record counts;
+- SHA-256 hashes for emitted files;
+- source repository and source commit when supplied by the operator;
+- pre-publication status.
+
+## 5. Sample-first safety gate
+
+The exporter defaults to `sample` mode and emits only a bounded subset of reviewed exchanges.
+
+A complete export requires an explicit `--full` argument. This prevents accidental creation or publication of a full commercial package during ordinary repository work.
+
+Generated output is local-only and must not be committed to this public repository.
+
+## 6. Commercial publication gate
+
+No paid marketplace listing is authorized by this specification alone.
+
+Before publication, all of the following must be completed:
+
+1. marketplace/provider eligibility confirmed;
+2. seller identity, tax, payout, and banking steps completed by the account owner where required;
+3. commercial license terms finalized;
+4. sample package reviewed for schema stability and usefulness;
+5. rights review confirms the package redistributes HEI-authored normalized facts/metadata and source references without republishing restricted third-party source content;
+6. pricing and update cadence are explicitly approved;
+7. one marketplace is selected for the first live test;
+8. the first listing has a measurable stop/go criterion.
+
+## 7. First marketplace experiment
+
+AWS Data Exchange / AWS Marketplace is the current first channel to evaluate because it supports paid data products and existing marketplace distribution.
+
+This is a channel hypothesis, not a claim that the dataset will sell.
+
+The first live test must measure actual buyer behavior. Do not expand into SOG, BIR, WLR, CYA, or a cross-ledger bundle merely because the first listing receives no sales.
+
+## 8. Kill criteria
+
+The experiment must be stopped or redesigned rather than expanded if any of the following occurs:
+
+- seller/provider qualification cannot be completed on acceptable terms;
+- license or rights review makes the package impractical;
+- the sample does not provide a meaningful ingestion advantage over HEI's existing free JSON;
+- marketplace publication would require ongoing paid infrastructure before demand is demonstrated;
+- the first marketplace test shows no meaningful qualified interest and no evidence that packaging, rather than demand, is the blocker.
+
+No new public HEI feature is justified solely to support this commercial experiment.
+
+## 9. Operational impact
+
+Canonical count impact: none.  
+Public route impact: none.  
+Cloudflare impact: none.  
+Preview required: no.  
+Production verification: not applicable until a future public-output change is separately proposed.
+
+The exporter is an offline operator tool and must not be connected to the Next.js build, Cloudflare deployment, monitoring, or canonical review pipeline.
+
+## 10. Current implementation step
+
+The first implementation step is a deterministic local exporter that:
+
+- reads reviewed HEI state using existing aggregation/correction logic;
+- emits sample/full CSV tables and a JSON manifest;
+- records hashes;
+- refuses to emit a full bundle unless `--full` is passed;
+- writes only to an ignored local output directory.
+
+Completion of the exporter is preparation only. It does not constitute marketplace publication or proof of demand.

--- a/tools/export-commercial-dataset.mjs
+++ b/tools/export-commercial-dataset.mjs
@@ -1,0 +1,231 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  buildBundleEntityIdMap,
+  loadReviewedBundles,
+  mergeRecords,
+} from '../scripts/lib/reviewed-bundle-aggregation.mjs'
+import { applyReviewedEntityCorrections } from '../scripts/lib/entity-corrections.mjs'
+
+const root = process.cwd()
+const args = process.argv.slice(2)
+const full = args.includes('--full')
+const sampleSizeArg = args.find((arg) => arg.startsWith('--sample-size='))
+const outArg = args.find((arg) => arg.startsWith('--out='))
+const sourceCommitArg = args.find((arg) => arg.startsWith('--source-commit='))
+const sampleSize = sampleSizeArg ? Number(sampleSizeArg.split('=')[1]) : 25
+
+if (!Number.isInteger(sampleSize) || sampleSize < 1 || sampleSize > 250) {
+  throw new Error('--sample-size must be an integer between 1 and 250')
+}
+
+const mode = full ? 'full' : 'sample'
+const defaultOut = path.join(root, '.commercial-output', `hei-dataset-${mode}`)
+const outputDir = path.resolve(root, outArg ? outArg.slice('--out='.length) : defaultOut)
+const sourceCommit = sourceCommitArg?.slice('--source-commit='.length) || process.env.HEI_SOURCE_COMMIT || null
+
+const protectedRoots = [
+  path.join(root, 'data'),
+  path.join(root, 'records'),
+  path.join(root, 'public'),
+  path.join(root, 'data-staging'),
+]
+for (const protectedRoot of protectedRoots) {
+  if (outputDir === protectedRoot || outputDir.startsWith(`${protectedRoot}${path.sep}`)) {
+    throw new Error(`Refusing to write commercial output into protected repository path: ${outputDir}`)
+  }
+}
+
+function readJson(relativePath, fallback = []) {
+  const filePath = path.join(root, relativePath)
+  return fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, 'utf8')) : fallback
+}
+
+function csvValue(value) {
+  if (value === null || value === undefined) return ''
+  const text = typeof value === 'object' ? JSON.stringify(value) : String(value)
+  return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text
+}
+
+function writeCsv(filePath, columns, rows) {
+  const lines = [columns.join(',')]
+  for (const row of rows) {
+    lines.push(columns.map((column) => csvValue(row[column])).join(','))
+  }
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8')
+}
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+const canonicalEntities = readJson('data/entities.json')
+const canonicalEvents = readJson('data/events.json')
+const canonicalEvidence = readJson('data/evidence.json')
+const { all: reviewedBundles, newEntityBundles } = loadReviewedBundles(root, canonicalEntities)
+const correctedCanonicalEntities = applyReviewedEntityCorrections(canonicalEntities, reviewedBundles)
+const entities = [...correctedCanonicalEntities, ...newEntityBundles.map(({ bundle }) => bundle.entity)]
+const entityIdMap = buildBundleEntityIdMap(correctedCanonicalEntities, reviewedBundles)
+const events = mergeRecords(canonicalEvents, reviewedBundles, 'events', 'event', entityIdMap)
+const evidence = mergeRecords(canonicalEvidence, reviewedBundles, 'evidence', 'evidence', entityIdMap)
+
+const entityById = new Map(entities.map((entity) => [entity.id, entity]))
+const sortedEntities = [...entities].sort((a, b) => String(a.slug).localeCompare(String(b.slug)))
+const selectedEntities = full ? sortedEntities : sortedEntities.slice(0, sampleSize)
+const selectedIds = new Set(selectedEntities.map((entity) => entity.id))
+const selectedEvents = events
+  .filter((event) => selectedIds.has(event.exchange_id))
+  .sort((a, b) => {
+    const byExchange = String(a.exchange_id).localeCompare(String(b.exchange_id))
+    if (byExchange !== 0) return byExchange
+    const byDate = String(a.event_date ?? '').localeCompare(String(b.event_date ?? ''))
+    if (byDate !== 0) return byDate
+    return String(a.id).localeCompare(String(b.id))
+  })
+const selectedEvidence = evidence
+  .filter((item) => selectedIds.has(item.exchange_id))
+  .sort((a, b) => {
+    const byExchange = String(a.exchange_id).localeCompare(String(b.exchange_id))
+    if (byExchange !== 0) return byExchange
+    return String(a.id).localeCompare(String(b.id))
+  })
+
+const forbiddenMarkers = ['candidate_class', 'data-staging', 'internal monitoring', 'private research note']
+const serialized = JSON.stringify({
+  entities: selectedEntities,
+  events: selectedEvents,
+  evidence: selectedEvidence,
+})
+for (const marker of forbiddenMarkers) {
+  if (serialized.includes(marker)) throw new Error(`Commercial export leaked forbidden marker: ${marker}`)
+}
+
+fs.rmSync(outputDir, { recursive: true, force: true })
+fs.mkdirSync(outputDir, { recursive: true })
+
+const exchangeColumns = [
+  'id',
+  'slug',
+  'canonical_name',
+  'aliases',
+  'type',
+  'status',
+  'death_reason',
+  'launch_date',
+  'death_date',
+  'country_or_origin',
+  'official_domain_original',
+  'official_url_status',
+  'archived_url',
+  'confidence',
+  'last_verified_at',
+  'predecessor_id',
+  'successor_id',
+]
+
+const eventColumns = [
+  'id',
+  'exchange_id',
+  'exchange_slug',
+  'event_type',
+  'event_date',
+  'title',
+  'description',
+  'confidence',
+  'impact_level',
+  'event_status_effect',
+  'source_count',
+  'sort_order',
+]
+
+const evidenceColumns = [
+  'id',
+  'exchange_id',
+  'exchange_slug',
+  'event_id',
+  'source_type',
+  'title',
+  'url',
+  'publisher',
+  'published_at',
+  'archived_url',
+  'accessed_at',
+  'reliability',
+  'claim_scope',
+]
+
+const exchangeRows = selectedEntities.map((entity) => ({
+  ...entity,
+  aliases: entity.aliases ?? [],
+}))
+const eventRows = selectedEvents.map((event) => ({
+  ...event,
+  exchange_slug: entityById.get(event.exchange_id)?.slug ?? '',
+}))
+const evidenceRows = selectedEvidence.map((item) => ({
+  ...item,
+  exchange_slug: entityById.get(item.exchange_id)?.slug ?? '',
+}))
+
+const exchangesPath = path.join(outputDir, 'exchanges.csv')
+const eventsPath = path.join(outputDir, 'events.csv')
+const evidencePath = path.join(outputDir, 'evidence.csv')
+writeCsv(exchangesPath, exchangeColumns, exchangeRows)
+writeCsv(eventsPath, eventColumns, eventRows)
+writeCsv(evidencePath, evidenceColumns, evidenceRows)
+
+const bundlePath = path.join(outputDir, 'dataset.json')
+fs.writeFileSync(
+  bundlePath,
+  `${JSON.stringify(
+    {
+      schema_version: '1.0.0',
+      data_schema_version: 'hei_commercial_exchange_lifecycle_v1',
+      project_id: 'historical-exchange-index',
+      export_mode: mode,
+      canonical_only: true,
+      records: {
+        exchanges: exchangeRows,
+        events: eventRows,
+        evidence: evidenceRows,
+      },
+    },
+    null,
+    2,
+  )}\n`,
+  'utf8',
+)
+
+const files = ['exchanges.csv', 'events.csv', 'evidence.csv', 'dataset.json']
+const hashes = Object.fromEntries(
+  files.map((name) => [name, { sha256: sha256(path.join(outputDir, name)), bytes: fs.statSync(path.join(outputDir, name)).size }]),
+)
+
+const manifest = {
+  schema_version: '1.0.0',
+  data_schema_version: 'hei_commercial_exchange_lifecycle_v1',
+  project_id: 'historical-exchange-index',
+  product_name: 'Crypto Exchange Lifecycle & Incident Dataset',
+  export_mode: mode,
+  canonical_only: true,
+  prepublication: true,
+  generated_at: new Date().toISOString(),
+  source_repository: 'badjoke-lab/historical-exchange-index',
+  source_commit: sourceCommit,
+  counts: {
+    exchanges: exchangeRows.length,
+    events: eventRows.length,
+    evidence: evidenceRows.length,
+  },
+  files: hashes,
+  notice: 'Pre-publication evaluation output. Commercial license, marketplace approval, pricing, and update cadence are not finalized.',
+}
+fs.writeFileSync(path.join(outputDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+
+console.log(
+  `Built HEI commercial dataset ${mode} export: ${exchangeRows.length} exchanges / ${eventRows.length} events / ${evidenceRows.length} evidence -> ${outputDir}`,
+)
+if (!full) {
+  console.log('Sample mode is the default. Re-run with --full only for an explicitly authorized complete local export.')
+}


### PR DESCRIPTION
Clean replacement for stale PR #777, rebased by reconstruction onto accepted main `95b50e56398d3d29d4766e1451082c4fd6a5a79d`.

## Scope
- add the bounded pre-publication commercial dataset experiment spec
- add offline reviewed-data exporter
- ignore `.commercial-output/`
- validate a 5-record sample export inside existing core CI

## Boundaries
- no canonical mutation
- no public route or Cloudflare change
- no marketplace publication authorization
- no full export unless `--full` is explicitly passed
- no staging/monitoring/private-research export

This PR intentionally carries only the four clean changes from #777 onto current main.