### PR TITLE
Publish reviewed HEI Stage 5 relationships

### DIFF
--- a/.github/workflows/ledger-series-phase9-adapter.yml
+++ b/.github/workflows/ledger-series-phase9-adapter.yml
@@ -3,6 +3,7 @@ name: Ledger Series Phase 9 Adapter
 on:
   pull_request:
     paths:
+      - "config/ledger-series-phase9-stage5-hei-local-authority.json"
       - "scripts/build-ledger-series-phase9-adapter.mjs"
       - "scripts/validate-ledger-series-phase9-adapter.mjs"
       - "scripts/build-record-level-machine-readable.mjs"
@@ -16,6 +17,7 @@ on:
     branches:
       - main
     paths:
+      - "config/ledger-series-phase9-stage5-hei-local-authority.json"
       - "scripts/build-ledger-series-phase9-adapter.mjs"
       - "scripts/validate-ledger-series-phase9-adapter.mjs"
       - "scripts/build-record-level-machine-readable.mjs"

--- a/scripts/build-ledger-series-phase9-adapter.mjs
+++ b/scripts/build-ledger-series-phase9-adapter.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -10,6 +11,7 @@ const origin = 'https://hei.badjoke-lab.com'
 const seriesSchemaVersion = '1.0.0'
 const registryId = 'historical-exchange-index'
 const nativeRecordType = 'exchange_entity'
+const relationshipAuthorityPath = path.join(root, 'config', 'ledger-series-phase9-stage5-hei-local-authority.json')
 
 function readJson(filePath) {
   if (!fs.existsSync(filePath)) throw new Error(`Ledger Series adapter missing required input: ${path.relative(root, filePath)}`)
@@ -25,9 +27,27 @@ function globalRecordKey(id) {
   return `${registryId}:${nativeRecordType}:${id}`
 }
 
+function parseGlobalKey(globalKey) {
+  const parts = String(globalKey).split(':')
+  if (parts.length !== 3 || parts.some((part) => !part)) throw new Error(`Ledger Series adapter invalid global key: ${globalKey}`)
+  return {
+    registry_id: parts[0],
+    native_record_type: parts[1],
+    native_record_id: parts[2],
+  }
+}
+
+function relationshipId(relationType, sourceGlobalKey, targetGlobalKey) {
+  const digest = createHash('sha256')
+    .update(`${relationType}\n${sourceGlobalKey}\n${targetGlobalKey}`, 'utf8')
+    .digest('hex')
+  return `series_rel_${digest}`
+}
+
 const version = readJson(path.join(publicDir, 'version.json'))
 const manifest = readJson(path.join(publicDir, 'data', 'manifest.json'))
 const nativeIndex = readJson(path.join(nativeDir, 'index.json'))
+const relationshipAuthority = readJson(relationshipAuthorityPath)
 
 if (version.project_id !== registryId || manifest.project_id !== registryId || nativeIndex.project_id !== registryId) {
   throw new Error('Ledger Series adapter project identity mismatch')
@@ -38,50 +58,15 @@ if (nativeIndex.canonical_only !== true || manifest.data_safety?.canonical_only 
 if (!Array.isArray(nativeIndex.records) || nativeIndex.record_count !== nativeIndex.records.length) {
   throw new Error('Ledger Series adapter native index count mismatch')
 }
+if (relationshipAuthority.registry_id !== registryId || relationshipAuthority.reviewed_audit?.accepted_count !== 21) {
+  throw new Error('Ledger Series adapter unexpected HEI Stage 5 relationship authority')
+}
+if (!Array.isArray(relationshipAuthority.finite_allowlist) || relationshipAuthority.finite_allowlist.length !== 21) {
+  throw new Error('Ledger Series adapter HEI Stage 5 allowlist must contain exactly 21 rows')
+}
 
 fs.rmSync(seriesDir, { recursive: true, force: true })
 fs.mkdirSync(recordsDir, { recursive: true })
-
-const descriptor = {
-  series_schema_version: seriesSchemaVersion,
-  object_type: 'registry_descriptor',
-  registry: {
-    id: registryId,
-    name: version.site_name,
-    type: version.registry_type,
-    origin,
-    native_machine_schema_version: nativeIndex.schema_version,
-    native_data_schema_version: nativeIndex.data_schema_version,
-  },
-  canonical_only: true,
-  record_counts: {
-    primary_records: nativeIndex.record_count,
-    series_records: nativeIndex.record_count,
-  },
-  routes: {
-    descriptor: '/data/series/registry.json',
-    index: '/data/series/index.json',
-    record_template: '/data/series/records/{slug}.json',
-    native_record_template: '/data/exchanges/{slug}.json',
-    search: '/explore/',
-    compare: '/compare/',
-    stats: '/stats/',
-  },
-  capabilities: {
-    search: true,
-    compare: true,
-    stats: true,
-    typed_relationships: false,
-  },
-  data_safety: {
-    ...manifest.data_safety,
-    ai_generated_canonical_facts: false,
-  },
-  verification: {
-    build: version.build,
-    native_verification_marker: version.build?.verification_marker ?? null,
-  },
-}
 
 const indexRecords = []
 for (const item of [...nativeIndex.records].sort((a, b) => String(a.slug).localeCompare(String(b.slug)))) {
@@ -155,6 +140,87 @@ for (const item of [...nativeIndex.records].sort((a, b) => String(a.slug).locale
   })
 }
 
+const availableGlobalKeys = new Set(indexRecords.map((record) => record.global_record_key))
+const relationshipTuples = new Set()
+const relationshipIds = new Set()
+const relationshipRecords = relationshipAuthority.finite_allowlist.map((entry, index) => {
+  if (!Array.isArray(entry) || entry.length !== 3) {
+    throw new Error(`Ledger Series adapter relationship row ${index + 1} must be [relation_type, source, target]`)
+  }
+  const [relationType, sourceGlobalKey, targetGlobalKey] = entry
+  if (!['predecessor_of', 'successor_of'].includes(relationType)) {
+    throw new Error(`Ledger Series adapter relationship row ${index + 1} unauthorized type: ${relationType}`)
+  }
+  if (sourceGlobalKey === targetGlobalKey) throw new Error(`Ledger Series adapter relationship row ${index + 1} is a self-loop`)
+  if (!availableGlobalKeys.has(sourceGlobalKey) || !availableGlobalKeys.has(targetGlobalKey)) {
+    throw new Error(`Ledger Series adapter relationship row ${index + 1} references a missing Stage 3 endpoint`)
+  }
+  const tuple = `${relationType}\n${sourceGlobalKey}\n${targetGlobalKey}`
+  if (relationshipTuples.has(tuple)) throw new Error(`Ledger Series adapter duplicate relationship tuple at row ${index + 1}`)
+  relationshipTuples.add(tuple)
+
+  const id = relationshipId(relationType, sourceGlobalKey, targetGlobalKey)
+  if (relationshipIds.has(id)) throw new Error(`Ledger Series adapter relationship ID collision: ${id}`)
+  relationshipIds.add(id)
+
+  return {
+    series_schema_version: seriesSchemaVersion,
+    object_type: 'relationship_record',
+    id,
+    relation_type: relationType,
+    source: parseGlobalKey(sourceGlobalKey),
+    target: parseGlobalKey(targetGlobalKey),
+    direction: 'directed',
+    provenance: {
+      basis: 'native_reviewed_relationship',
+      native_evidence_refs: [],
+    },
+  }
+})
+
+const descriptor = {
+  series_schema_version: seriesSchemaVersion,
+  object_type: 'registry_descriptor',
+  registry: {
+    id: registryId,
+    name: version.site_name,
+    type: version.registry_type,
+    origin,
+    native_machine_schema_version: nativeIndex.schema_version,
+    native_data_schema_version: nativeIndex.data_schema_version,
+  },
+  canonical_only: true,
+  record_counts: {
+    primary_records: nativeIndex.record_count,
+    series_records: nativeIndex.record_count,
+    relationships: relationshipRecords.length,
+  },
+  routes: {
+    descriptor: '/data/series/registry.json',
+    index: '/data/series/index.json',
+    relationships: '/data/series/relationships.json',
+    record_template: '/data/series/records/{slug}.json',
+    native_record_template: '/data/exchanges/{slug}.json',
+    search: '/explore/',
+    compare: '/compare/',
+    stats: '/stats/',
+  },
+  capabilities: {
+    search: true,
+    compare: true,
+    stats: true,
+    relationships: 'adapter',
+  },
+  data_safety: {
+    ...manifest.data_safety,
+    ai_generated_canonical_facts: false,
+  },
+  verification: {
+    build: version.build,
+    native_verification_marker: version.build?.verification_marker ?? null,
+  },
+}
+
 const seriesIndex = {
   series_schema_version: seriesSchemaVersion,
   object_type: 'record_index',
@@ -172,5 +238,6 @@ const seriesIndex = {
 
 writeJson(path.join(seriesDir, 'registry.json'), descriptor)
 writeJson(path.join(seriesDir, 'index.json'), seriesIndex)
+writeJson(path.join(seriesDir, 'relationships.json'), relationshipRecords)
 
-console.log(`Built HEI Ledger Series Phase 9 adapter: ${indexRecords.length} canonical exchange envelopes.`)
+console.log(`Built HEI Ledger Series Phase 9 adapter: ${indexRecords.length} canonical exchange envelopes, ${relationshipRecords.length} reviewed relationships.`)

--- a/scripts/validate-ledger-series-phase9-adapter.mjs
+++ b/scripts/validate-ledger-series-phase9-adapter.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -24,11 +25,23 @@ function stable(value) {
   return JSON.stringify(value)
 }
 
+function endpointGlobalKey(endpoint) {
+  return `${endpoint?.registry_id}:${endpoint?.native_record_type}:${endpoint?.native_record_id}`
+}
+
+function relationshipId(relationType, sourceGlobalKey, targetGlobalKey) {
+  return `series_rel_${createHash('sha256')
+    .update(`${relationType}\n${sourceGlobalKey}\n${targetGlobalKey}`, 'utf8')
+    .digest('hex')}`
+}
+
 const version = readJson('public/version.json')
 const manifest = readJson('public/data/manifest.json')
 const nativeIndex = readJson('public/data/exchanges/index.json')
 const descriptor = readJson('public/data/series/registry.json')
 const seriesIndex = readJson('public/data/series/index.json')
+const relationships = readJson('public/data/series/relationships.json')
+const relationshipAuthority = readJson('config/ledger-series-phase9-stage5-hei-local-authority.json')
 
 assert(descriptor.series_schema_version === '1.0.0', 'descriptor schema version')
 assert(descriptor.object_type === 'registry_descriptor', 'descriptor object type')
@@ -37,11 +50,13 @@ assert(descriptor.registry?.origin === origin, 'descriptor origin')
 assert(descriptor.canonical_only === true, 'descriptor canonical_only')
 assert(descriptor.record_counts?.primary_records === nativeIndex.record_count, 'descriptor primary count')
 assert(descriptor.record_counts?.series_records === nativeIndex.record_count, 'descriptor series count')
+assert(descriptor.record_counts?.relationships === 21, 'descriptor relationship count')
 assert(descriptor.routes?.native_record_template === '/data/exchanges/{slug}.json', 'native record template')
+assert(descriptor.routes?.relationships === '/data/series/relationships.json', 'relationship route')
 assert(descriptor.routes?.search === '/explore/', 'search route')
 assert(descriptor.routes?.compare === '/compare/', 'compare route')
 assert(descriptor.routes?.stats === '/stats/', 'stats route')
-assert(descriptor.capabilities?.typed_relationships === false, 'typed relationships must remain disabled')
+assert(descriptor.capabilities?.relationships === 'adapter', 'relationship capability')
 assert(stable(descriptor.verification?.build) === stable(version.build), 'descriptor build metadata mismatch')
 assert(stable(descriptor.data_safety) === stable({ ...manifest.data_safety, ai_generated_canonical_facts: false }), 'descriptor data safety mismatch')
 
@@ -52,6 +67,11 @@ assert(seriesIndex.canonical_only === true, 'index canonical_only')
 assert(seriesIndex.record_count === nativeIndex.record_count, 'index count')
 assert(seriesIndex.records.length === nativeIndex.records.length, 'index records length')
 assert(stable(seriesIndex.verification?.build) === stable(version.build), 'index build metadata mismatch')
+
+assert(relationshipAuthority.registry_id === registryId, 'relationship authority registry id')
+assert(relationshipAuthority.reviewed_audit?.accepted_count === 21, 'relationship authority accepted count')
+assert(Array.isArray(relationshipAuthority.finite_allowlist) && relationshipAuthority.finite_allowlist.length === 21, 'relationship authority finite allowlist count')
+assert(Array.isArray(relationships) && relationships.length === 21, 'relationship transport must contain 21 records')
 
 const nativeBySlug = new Map(nativeIndex.records.map((item) => [item.slug, item]))
 const globalKeys = new Set()
@@ -85,7 +105,7 @@ for (const item of seriesIndex.records) {
   assert(stable(envelope.current_state?.native?.bundle) === stable(native), `${item.slug} native bundle not lossless`)
   assert(stable(envelope.events?.records) === stable(native.events ?? []), `${item.slug} events mismatch`)
   assert(stable(envelope.evidence?.records) === stable(native.evidence ?? []), `${item.slug} evidence mismatch`)
-  assert(Array.isArray(envelope.relationships) && envelope.relationships.length === 0, `${item.slug} typed relationships must be empty`)
+  assert(Array.isArray(envelope.relationships) && envelope.relationships.length === 0, `${item.slug} record-envelope relationships must remain empty during Stage 5 publication`)
   assert(stable(envelope.verification?.build) === stable(version.build), `${item.slug} build metadata mismatch`)
   assert(envelope.verification?.last_verified_at === (native.verification?.last_verified_at ?? null), `${item.slug} last verified mismatch`)
   assert(envelope.verification?.confidence === (native.verification?.confidence ?? null), `${item.slug} confidence mismatch`)
@@ -101,9 +121,41 @@ for (const item of seriesIndex.records) {
   }
 }
 
+const expectedTuples = relationshipAuthority.finite_allowlist.map(([relationType, source, target]) => `${relationType}\n${source}\n${target}`)
+const expectedTupleSet = new Set(expectedTuples)
+assert(expectedTupleSet.size === expectedTuples.length, 'relationship authority contains duplicate tuples')
+const actualTupleSet = new Set()
+const relationshipIds = new Set()
+for (const [index, relationship] of relationships.entries()) {
+  const label = `relationship ${index + 1}`
+  assert(relationship.series_schema_version === '1.0.0', `${label} schema version`)
+  assert(relationship.object_type === 'relationship_record', `${label} object type`)
+  assert(['predecessor_of', 'successor_of'].includes(relationship.relation_type), `${label} relation type`)
+  assert(relationship.direction === 'directed', `${label} direction`)
+  assert(relationship.provenance?.basis === 'native_reviewed_relationship', `${label} provenance basis`)
+  assert(Array.isArray(relationship.provenance?.native_evidence_refs), `${label} native evidence refs`)
+
+  const sourceGlobalKey = endpointGlobalKey(relationship.source)
+  const targetGlobalKey = endpointGlobalKey(relationship.target)
+  assert(globalKeys.has(sourceGlobalKey), `${label} source endpoint missing from Stage 3 index`)
+  assert(globalKeys.has(targetGlobalKey), `${label} target endpoint missing from Stage 3 index`)
+  assert(sourceGlobalKey !== targetGlobalKey, `${label} self-loop`)
+  const tuple = `${relationship.relation_type}\n${sourceGlobalKey}\n${targetGlobalKey}`
+  assert(expectedTupleSet.has(tuple), `${label} tuple outside reviewed finite allowlist`)
+  assert(!actualTupleSet.has(tuple), `${label} duplicate tuple`)
+  actualTupleSet.add(tuple)
+
+  const expectedId = relationshipId(relationship.relation_type, sourceGlobalKey, targetGlobalKey)
+  assert(relationship.id === expectedId, `${label} deterministic id`)
+  assert(!relationshipIds.has(relationship.id), `${label} duplicate id`)
+  relationshipIds.add(relationship.id)
+}
+assert(actualTupleSet.size === expectedTupleSet.size, 'relationship set size does not equal reviewed allowlist')
+for (const tuple of expectedTupleSet) assert(actualTupleSet.has(tuple), `missing reviewed relationship ${tuple.replaceAll('\n', ' | ')}`)
+
 const seriesFiles = fs.readdirSync(path.join(root, 'public', 'data', 'series', 'records')).filter((name) => name.endsWith('.json'))
 assert(seriesFiles.length === nativeIndex.record_count, 'stale or missing Series record files')
 assert(globalKeys.size === nativeIndex.record_count, 'global key uniqueness count mismatch')
 
-console.log(`HEI Ledger Series Phase 9 adapter validation passed: ${nativeIndex.record_count} canonical exchange envelopes.`)
+console.log(`HEI Ledger Series Phase 9 adapter validation passed: ${nativeIndex.record_count} canonical exchange envelopes, ${relationships.length} reviewed relationships.`)
 console.log(`Build commit: ${version.build?.commit ?? 'unknown'}`)


### PR DESCRIPTION
Implements merged local authority PR #793 from exact main `63633571cdcdf72197e177fc589d248a73ec76ed`.

## Scope
- publish exactly 21 reviewed HEI same-registry Series v1 `relationship_record` objects
- transport: `/data/series/relationships.json`
- deterministic IDs from relation type + source global key + target global key
- descriptor adds exact relationship count/route/capability
- existing record-envelope `relationships` arrays remain empty
- specialized Series CI now also triggers if the merged finite authority file changes

## Authority
- local: #793
- audit: #791
- cross-registry publication authority: #792
- coordination: #780

## Boundary
- canonical entity/event/evidence delta: 0
- Search/Compare/Stats/UI/localization delta: 0
- Cloudflare configuration delta: 0
- cross-registry relationships: 0
- Stage 6 continuation: none

The validator proves exact finite-allowlist equality, endpoint existence, unique deterministic IDs and unchanged record-envelope relationship arrays.

Production verification is a separate post-merge gate.