### PR TITLE
Collect live Stage 5 registry descriptors

### DIFF
--- a/.github/workflows/phase9-stage5-descriptor-collect.yml
+++ b/.github/workflows/phase9-stage5-descriptor-collect.yml
@@ -1,0 +1,38 @@
+name: Phase 9 Stage 5 Descriptor Collect
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/phase9-stage5-descriptor-collect.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  collect-live-descriptors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Collect reviewed remote descriptor snapshots
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs'
+          const source = JSON.parse(fs.readFileSync('scripts/lib/ledger-series-registry-index-source.json', 'utf8'))
+          for (const entry of source.registries) {
+            const response = await fetch(entry.descriptor_url, {
+              headers: { accept: 'application/json', 'cache-control': 'no-cache', 'user-agent': 'HEI-stage5-descriptor-collector/1.0' },
+              signal: AbortSignal.timeout(30000),
+            })
+            if (!response.ok) throw new Error(`${entry.descriptor_url}: HTTP ${response.status}`)
+            const snapshot = await response.json()
+            const id = snapshot?.registry?.id
+            if (!id) throw new Error(`${entry.descriptor_url}: missing registry id`)
+            console.log(`DESCRIPTOR ${id} ${Buffer.from(JSON.stringify(snapshot), 'utf8').toString('base64')}`)
+          }
+          console.log(`COLLECTED_AT ${new Date().toISOString()}`)
+          NODE


### PR DESCRIPTION
Temporary verification-only collector for Phase 9 Stage 5 closeout. Do not merge.

Reads the existing seven reviewed remote descriptor URLs from the Stage 4 source lock and fetches only `/data/series/registry.json` snapshots. It prints each descriptor as base64 so the central reviewed lock can be rebuilt from exact live descriptors without copying relationship records or canonical payloads.

No public/canonical/runtime/UI/Cloudflare changes. Close without merge after the descriptor snapshots are captured.