### PR TITLE
Trigger reviewed HEI Stage 5 production build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+// Build order is deliberate: native machine layer -> record-level layer -> reviewed Series relationships -> registry index -> stats.
 import './scripts/build-machine-readable-layer.mjs'
 import './scripts/build-record-level-machine-readable.mjs'
 import './scripts/build-ledger-series-phase9-adapter.mjs'


### PR DESCRIPTION
Bounded Stage 5 production-publication fix after #796 proved that `https://hei.badjoke-lab.com/data/series/relationships.json` remained HTTP 404 for all 20 verification attempts.

Root cause: the Cloudflare Pages GitHub source policy deploys `main` only when an allowed path changes. The Stage 5 implementation/verification merges changed generator/workflow paths that are not in the current Pages path allowlist, so no production build was triggered. The actual Next build already imports the machine layer, record-level layer, Stage 5 Series adapter, registry index, and stats in the correct order.

This PR changes only a maintenance comment in the already-allowed `next.config.ts`, so merging it triggers the existing production build without changing Cloudflare configuration or runtime semantics. After merge, #796 production proof will be rerun against the deployed site.

Cloudflare configuration delta: 0. Canonical/UI/Search/Compare/Stats data-model delta: 0. Stage 6 remains blocked.