### PR TITLE
Inspect HEI Cloudflare Pages production state

### DIFF
--- a/.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml
+++ b/.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml
@@ -26,21 +26,18 @@ jobs:
           async function get(path) {
             const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${account}${path}`, { headers })
             const body = await response.json().catch(() => null)
-            if (!response.ok || !body?.success) {
-              throw new Error(`Cloudflare GET ${path} failed: HTTP ${response.status} ${JSON.stringify(body?.errors ?? [])}`)
-            }
+            if (!response.ok || !body?.success) throw new Error(`Cloudflare GET ${path} failed: HTTP ${response.status} ${JSON.stringify(body?.errors ?? [])}`)
             return body.result
           }
           const project = await get(`/pages/projects/${encodeURIComponent(projectName)}`)
           const deployments = await get(`/pages/projects/${encodeURIComponent(projectName)}/deployments?env=production&per_page=10`)
-          const selectedProject = {
+          console.log('PROJECT_STATE ' + JSON.stringify({
             name: project?.name ?? null,
             production_branch: project?.production_branch ?? null,
             source_type: project?.source?.type ?? null,
             source_config: project?.source?.config ?? null,
             build_config: project?.build_config ?? null,
-          }
-          console.log('PROJECT_STATE ' + JSON.stringify(selectedProject))
+          }))
           for (const deployment of Array.isArray(deployments) ? deployments : []) {
             console.log('PRODUCTION_DEPLOYMENT ' + JSON.stringify({
               id: deployment?.id ?? null,
@@ -74,4 +71,49 @@ jobs:
           }
           await inspectOrigin('deployment', production.url)
           await inspectOrigin('custom', 'https://hei.badjoke-lab.com')
+          NODE
+
+  inspect-export-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact production main
+        uses: actions/checkout@v4
+        with:
+          ref: fbedd2f8fb138124d43ea8cf32a1472f87ea5fd2
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm install
+      - name: Build with the Cloudflare command
+        env:
+          CF_PAGES_COMMIT_SHA: fbedd2f8fb138124d43ea8cf32a1472f87ea5fd2
+          CF_PAGES_BRANCH: main
+        run: npx next build
+      - name: Inspect Stage 5 files before and after export
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs'
+          for (const base of ['public', 'out']) {
+            const descriptorPath = `${base}/data/series/registry.json`
+            const relationshipsPath = `${base}/data/series/relationships.json`
+            const descriptorExists = fs.existsSync(descriptorPath)
+            const relationshipsExists = fs.existsSync(relationshipsPath)
+            let descriptorSummary = null
+            let relationshipLength = null
+            if (descriptorExists) {
+              const descriptor = JSON.parse(fs.readFileSync(descriptorPath, 'utf8'))
+              descriptorSummary = {
+                relationships: descriptor?.record_counts?.relationships ?? null,
+                route: descriptor?.routes?.relationships ?? null,
+                capability: descriptor?.capabilities?.relationships ?? null,
+              }
+            }
+            if (relationshipsExists) {
+              const relationships = JSON.parse(fs.readFileSync(relationshipsPath, 'utf8'))
+              relationshipLength = Array.isArray(relationships) ? relationships.length : null
+            }
+            console.log(`ARTIFACT ${base} ${JSON.stringify({ descriptorExists, relationshipsExists, descriptorSummary, relationshipLength })}`)
+          }
           NODE

--- a/.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml
+++ b/.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml
@@ -12,7 +12,7 @@ jobs:
   inspect-pages-production:
     runs-on: ubuntu-latest
     steps:
-      - name: Inspect actual Pages project and production deployments
+      - name: Inspect actual Pages project, deployments and Stage 5 endpoints
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -39,17 +39,6 @@ jobs:
             source_type: project?.source?.type ?? null,
             source_config: project?.source?.config ?? null,
             build_config: project?.build_config ?? null,
-            latest_deployment: project?.latest_deployment ? {
-              id: project.latest_deployment.id ?? null,
-              environment: project.latest_deployment.environment ?? null,
-              created_on: project.latest_deployment.created_on ?? null,
-              modified_on: project.latest_deployment.modified_on ?? null,
-              url: project.latest_deployment.url ?? null,
-              aliases: project.latest_deployment.aliases ?? null,
-              deployment_trigger: project.latest_deployment.deployment_trigger ?? null,
-              stages: project.latest_deployment.stages ?? null,
-              source: project.latest_deployment.source ?? null,
-            } : null,
           }
           console.log('PROJECT_STATE ' + JSON.stringify(selectedProject))
           for (const deployment of Array.isArray(deployments) ? deployments : []) {
@@ -65,4 +54,24 @@ jobs:
               source: deployment?.source ?? null,
             }))
           }
+          const production = (Array.isArray(deployments) ? deployments : []).find((item) => item?.environment === 'production' && item?.stages?.every((stage) => stage?.status === 'success'))
+          if (!production?.url) throw new Error('No completed production deployment URL found')
+          async function inspectOrigin(label, origin) {
+            for (const route of ['/version.json', '/data/series/registry.json', '/data/series/relationships.json']) {
+              const response = await fetch(`${origin}${route}`, { headers: { accept: 'application/json', 'cache-control': 'no-cache' }, redirect: 'manual' })
+              const text = await response.text()
+              let summary = null
+              if (response.ok) {
+                try {
+                  const parsed = JSON.parse(text)
+                  if (route === '/version.json') summary = { commit: parsed?.build?.commit ?? parsed?.verification?.build?.commit ?? null }
+                  if (route === '/data/series/registry.json') summary = { registry_id: parsed?.registry?.id ?? null, relationships: parsed?.record_counts?.relationships ?? null, relationship_route: parsed?.routes?.relationships ?? null, capability: parsed?.capabilities?.relationships ?? null }
+                  if (route === '/data/series/relationships.json') summary = { is_array: Array.isArray(parsed), length: Array.isArray(parsed) ? parsed.length : null }
+                } catch {}
+              }
+              console.log(`ENDPOINT ${label} ${route} HTTP ${response.status} ${JSON.stringify(summary)}`)
+            }
+          }
+          await inspectOrigin('deployment', production.url)
+          await inspectOrigin('custom', 'https://hei.badjoke-lab.com')
           NODE

--- a/.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml
+++ b/.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml
@@ -1,0 +1,68 @@
+name: Phase 9 Stage 5 Cloudflare Read-only Diagnostic
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/phase9-stage5-cloudflare-readonly-diagnostic.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  inspect-pages-production:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect actual Pages project and production deployments
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          node --input-type=module <<'NODE'
+          const account = process.env.CLOUDFLARE_ACCOUNT_ID
+          const token = process.env.CLOUDFLARE_API_TOKEN
+          if (!account || !token) throw new Error('Cloudflare credentials are unavailable')
+          const projectName = 'historical-exchange-index'
+          const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+          async function get(path) {
+            const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${account}${path}`, { headers })
+            const body = await response.json().catch(() => null)
+            if (!response.ok || !body?.success) {
+              throw new Error(`Cloudflare GET ${path} failed: HTTP ${response.status} ${JSON.stringify(body?.errors ?? [])}`)
+            }
+            return body.result
+          }
+          const project = await get(`/pages/projects/${encodeURIComponent(projectName)}`)
+          const deployments = await get(`/pages/projects/${encodeURIComponent(projectName)}/deployments?env=production&per_page=10`)
+          const selectedProject = {
+            name: project?.name ?? null,
+            production_branch: project?.production_branch ?? null,
+            source_type: project?.source?.type ?? null,
+            source_config: project?.source?.config ?? null,
+            build_config: project?.build_config ?? null,
+            latest_deployment: project?.latest_deployment ? {
+              id: project.latest_deployment.id ?? null,
+              environment: project.latest_deployment.environment ?? null,
+              created_on: project.latest_deployment.created_on ?? null,
+              modified_on: project.latest_deployment.modified_on ?? null,
+              url: project.latest_deployment.url ?? null,
+              aliases: project.latest_deployment.aliases ?? null,
+              deployment_trigger: project.latest_deployment.deployment_trigger ?? null,
+              stages: project.latest_deployment.stages ?? null,
+              source: project.latest_deployment.source ?? null,
+            } : null,
+          }
+          console.log('PROJECT_STATE ' + JSON.stringify(selectedProject))
+          for (const deployment of Array.isArray(deployments) ? deployments : []) {
+            console.log('PRODUCTION_DEPLOYMENT ' + JSON.stringify({
+              id: deployment?.id ?? null,
+              environment: deployment?.environment ?? null,
+              created_on: deployment?.created_on ?? null,
+              modified_on: deployment?.modified_on ?? null,
+              url: deployment?.url ?? null,
+              aliases: deployment?.aliases ?? null,
+              deployment_trigger: deployment?.deployment_trigger ?? null,
+              stages: deployment?.stages ?? null,
+              source: deployment?.source ?? null,
+            }))
+          }
+          NODE


### PR DESCRIPTION
Verification-only Stage 5 diagnostic. Closed without merge after evidence capture.

Confirmed actual Cloudflare Pages project state is GitHub-integrated `main` with production deployments enabled and build command `npx next build` → `out`.

Exact production deployment `18cf6c3e-1cd0-4622-afeb-969f9be69266` for main `fbedd2f8fb138124d43ea8cf32a1472f87ea5fd2` completed successfully at 2026-08-21T12:55:56.585701Z.

Read-only endpoint comparison after deployment completion:
- deployment URL `/version.json`: 200, commit `fbedd2f8...`
- deployment URL descriptor: 200, relationships=21, route present, capability=adapter
- deployment URL relationships: 200, array length 21
- custom domain `/version.json`: 200, same commit
- custom domain descriptor: 200, relationships=21, route present, capability=adapter
- custom domain relationships: 200, array length 21

The earlier #796 rerun ended at 12:55:41Z, about 15 seconds before Cloudflare deploy finished. Its 404 was therefore a verification/deployment race, not an artifact or custom-domain routing defect.

No Cloudflare mutation or configuration change was performed.