### PR TITLE
Implement Phase 9 Stage 6 production equality verifier

### DIFF
--- a/.github/workflows/ledger-series-phase9-stage6-production-equality.yml
+++ b/.github/workflows/ledger-series-phase9-stage6-production-equality.yml
@@ -1,0 +1,75 @@
+name: Ledger Series Phase 9 Stage 6 production equality
+
+on:
+  pull_request:
+    paths:
+      - "scripts/verify-ledger-series-phase9-stage6-production-equality.mjs"
+      - ".github/workflows/ledger-series-phase9-stage6-production-equality.yml"
+      - "docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_2026-08-22.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  review-syntax:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify Stage 6 script syntax
+        run: node --check scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
+
+      - name: Verify authority boundary
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const authority = JSON.parse(fs.readFileSync('config/ledger-series-phase9-stage6-production-equality-authority.json', 'utf8'));
+          if (authority.authority_id !== 'hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2') throw new Error('unexpected authority id');
+          if (authority.network_read_only_verification_authorized_after_merge !== true) throw new Error('network verification not authorized');
+          if (authority.production_mutation_authorized !== false || authority.vertical_repository_mutation_authorized !== false || authority.central_descriptor_resync_authorized !== false) throw new Error('mutation boundary weakened');
+          if (authority.reviewed_repository_baselines?.length !== 8) throw new Error('expected exactly eight reviewed registries');
+          console.log('Stage 6 authority boundary PASS');
+          NODE
+
+  verify-production-equality:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact main execution revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify Stage 6 script syntax
+        run: node --check scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
+
+      - name: Run bounded read-only eight-registry equality verification
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          STAGE6_RESULT_PATH: .stage6/phase9-stage6-production-equality-result.json
+          STAGE6_TIMEOUT_MS: "20000"
+          STAGE6_CONCURRENCY: "12"
+        run: node scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
+
+      - name: Upload Stage 6 result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ledger-series-phase9-stage6-production-equality-result
+          path: .stage6/phase9-stage6-production-equality-result.json
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_2026-08-22.md
+++ b/docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_2026-08-22.md
@@ -1,0 +1,31 @@
+# Ledger Series Phase 9 Stage 6 — pre-execution baseline review
+
+Date: 2026-08-22 JST
+Coordination issue: #780
+Execution authority: `hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2`
+Authority merge: `1ff8303924c6c7d60dee4e63c0a9346cc3de8dcf`
+
+## Re-read repository mains
+
+| Registry | Audit baseline | Execution-reviewed main | Result |
+| --- | --- | --- | --- |
+| Historical Exchange Index | `00544ca0d80b6e7762993f9b57868ecb788811a0` | `10b9546f386ce9e99c0169871e4277cb1891ab3a` | advanced; separately reviewed below |
+| Minted & Gone | `f7892a04edf4cba49e4ae3d9f04109e3faf429a2` | same | unchanged |
+| Stable or Gone | `f86ae68772783f9930b855effefbc781ea7ecb28` | same | unchanged |
+| Crypto Yield Archive | `df87a4efe16d7370e9c42be7397282ac3ae04f2a` | same | unchanged |
+| Bridge Incident Registry | `38651a2961ba89dbc0aedfbdb2f13bedb08df516` | same | unchanged |
+| Wallet Lifecycle Registry | `e0e9de465a71aa54c0f6a4ec69bdac84bb3e4f8d` | same | unchanged |
+| AI Tools History Archive | `76ef103329813f0174db121117c932bff53fbf8e` | same | unchanged |
+| API Deprecation Archive | `641a6d4243d30f95f48436455d2cbc12a8aded53` | same | unchanged |
+
+## HEI advance review
+
+HEI advanced after the Stage 6 audit through reviewed coordination PR #804, reviewed authority PR #805, and canonical record PR #806. PR #806 changed only `records/exchanges/mantra-finance.json`, recording the MANTRA Chain halt impact while retaining MANTRA Finance as active. Its exact head `f275c835798e8d64f94f47863829acab5458206d` completed all 18 applicable checks successfully, including Records validation, Ledger Series Phase 9 Adapter, Machine/public consistency, URL safety, CI, count semantics, localization gates, and the permanent quality gates. PR #806 merged as `10b9546f386ce9e99c0169871e4277cb1891ab3a`.
+
+Therefore `10b9546f386ce9e99c0169871e4277cb1891ab3a` is the separately reviewed HEI execution baseline required by the Stage 6 authority. The verifier implementation PR may advance HEI main once more only by the authorized verifier script, verification-only workflow, and this review record; the execution workflow requires the observed `main` SHA to equal its own `GITHUB_SHA` so any later concurrent main movement fails closed.
+
+The production equality check uses `10b9546f386ce9e99c0169871e4277cb1891ab3a` as the reviewed HEI native/Series source revision. No earlier audit baseline is silently treated as current after the canonical MANTRA record change.
+
+## Boundary
+
+This review does not assert that production has deployed `10b9546f...`. The later read-only network execution must prove that independently. It authorizes no production mutation, no vertical repository mutation, no central descriptor resync, no automatic repair, and no Stage 7/8 work.

--- a/scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
+++ b/scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
@@ -1,0 +1,407 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const authority = JSON.parse(fs.readFileSync(path.join(root, 'config', 'ledger-series-phase9-stage6-production-equality-authority.json'), 'utf8'))
+const timeoutMs = Math.max(1000, Number(process.env.STAGE6_TIMEOUT_MS ?? 20000))
+const concurrency = Math.max(1, Number(process.env.STAGE6_CONCURRENCY ?? 12))
+const resultPath = process.env.STAGE6_RESULT_PATH || path.join(root, '.stage6', 'phase9-stage6-production-equality-result.json')
+const githubToken = process.env.GITHUB_TOKEN?.trim() || null
+const githubSha = process.env.GITHUB_SHA?.trim() || null
+const cacheNonce = `${Date.now()}`
+
+const executionMainOverride = {
+  'historical-exchange-index': '10b9546f386ce9e99c0169871e4277cb1891ab3a',
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable)
+  if (value && typeof value === 'object') return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]))
+  return value
+}
+
+function same(left, right) {
+  return JSON.stringify(stable(left)) === JSON.stringify(stable(right))
+}
+
+function assertSame(actual, expected, label) {
+  if (!same(actual, expected)) throw new Error(`${label}: live/reviewed mismatch`)
+}
+
+function normalizeRoute(route) {
+  return route.startsWith('/') ? route : `/${route}`
+}
+
+function rawPath(prefix, route) {
+  const relative = normalizeRoute(route).replace(/^\//, '')
+  return prefix ? `${prefix.replace(/\/$/, '')}/${relative}` : relative
+}
+
+function rawUrl(repository, sha, sourcePath) {
+  return `https://raw.githubusercontent.com/${repository}/${sha}/${sourcePath.split('/').map(encodeURIComponent).join('/')}`
+}
+
+function productionUrl(origin, route) {
+  const normalizedOrigin = origin.replace(/\/$/, '')
+  const normalizedRoute = normalizeRoute(route)
+  const separator = normalizedRoute.includes('?') ? '&' : '?'
+  return `${normalizedOrigin}${normalizedRoute}${separator}stage6_verify=${cacheNonce}`
+}
+
+const cache = new Map()
+
+async function fetchJson(url, label, githubApi = false) {
+  if (cache.has(url)) return cache.get(url)
+  const headers = {
+    accept: 'application/json',
+    'cache-control': 'no-cache',
+    'user-agent': 'HEI-Ledger-Series-Stage6-verifier/1.0',
+  }
+  if (githubApi && githubToken) headers.authorization = `Bearer ${githubToken}`
+  const response = await fetch(url, { headers, redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) })
+  const text = await response.text()
+  if (!response.ok) throw new Error(`${label}: HTTP ${response.status}`)
+  let parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    throw new Error(`${label}: malformed JSON (${error.message})`)
+  }
+  cache.set(url, parsed)
+  return parsed
+}
+
+async function mapLimit(items, limit, worker) {
+  const output = new Array(items.length)
+  let next = 0
+  async function runner() {
+    while (true) {
+      const index = next++
+      if (index >= items.length) return
+      output[index] = await worker(items[index], index)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, Math.max(items.length, 1)) }, () => runner()))
+  return output
+}
+
+function normalizeDescriptor(descriptorUrl, snapshot) {
+  return {
+    descriptor_url: descriptorUrl,
+    series_schema_version: snapshot.series_schema_version,
+    canonical_only: snapshot.canonical_only,
+    registry: snapshot.registry,
+    ...(snapshot.native_contract ? { native_contract: snapshot.native_contract } : {}),
+    record_counts: snapshot.record_counts,
+    ...(snapshot.record_types ? { record_types: snapshot.record_types } : {}),
+    routes: snapshot.routes,
+    capabilities: snapshot.capabilities,
+    verification: snapshot.verification,
+    data_safety: snapshot.data_safety,
+  }
+}
+
+const perRegistry = {
+  'historical-exchange-index': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/entities.json', '/data/events.json', '/data/evidence.json'] },
+  'minted-and-gone': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/marketplaces.json'] },
+  'stable-or-gone': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json'] },
+  'crypto-yield-archive': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json'] },
+  'bridge-incident-registry': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/bridges.json', '/data/incidents.json', '/data/events.json', '/data/evidence.json'] },
+  'cryptocurrency-wallet-lifecycle-registry': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/wallet-index.json', '/data/product-index.json'] },
+  'ai-tools-history-archive': { source_prefix: 'public', native_routes: ['/version.json', '/data/records/index.json'] },
+  'api-deprecation-archive': { source_prefix: '', native_routes: ['/version.json', '/data/machine/manifest.json', '/data/machine/index.json'] },
+}
+
+assert(authority.authority_id === 'hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2', 'unexpected Stage 6 authority id')
+assert(authority.reviewed_repository_baselines?.length === 8, 'Stage 6 authority must contain exactly eight registries')
+
+const registries = authority.reviewed_repository_baselines.map((entry) => ({
+  ...entry,
+  audit_main: entry.reviewed_main,
+  reviewed_main: executionMainOverride[entry.registry_id] ?? entry.reviewed_main,
+  ...perRegistry[entry.registry_id],
+  expected_relationships: authority.frozen_stage5_relationship_counts[entry.registry_id] ?? 0,
+}))
+
+const report = {
+  schema_version: '1.0.0',
+  phase: 9,
+  stage: 6,
+  authority_id: authority.authority_id,
+  execution_kind: 'read_only_cross_registry_production_equality',
+  started_at: new Date().toISOString(),
+  github_workflow_sha: githubSha,
+  repository_preflight: [],
+  registries: [],
+  central_descriptor: null,
+  stage5_relationships: null,
+  overall: 'RUNNING',
+}
+
+function writeReport() {
+  fs.mkdirSync(path.dirname(resultPath), { recursive: true })
+  fs.writeFileSync(resultPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+}
+
+async function production(registry, route, label = route) {
+  return fetchJson(productionUrl(registry.origin, route), `${registry.registry_id} ${label}`)
+}
+
+async function reviewed(registry, route, label = route) {
+  const source = rawPath(registry.source_prefix, route)
+  return fetchJson(rawUrl(registry.repository, registry.reviewed_main, source), `${registry.registry_id} reviewed ${label}`)
+}
+
+async function readMain(registry) {
+  const branch = await fetchJson(`https://api.github.com/repos/${registry.repository}/branches/main`, `${registry.registry_id} GitHub main`, true)
+  return branch?.commit?.sha ?? null
+}
+
+async function preflight() {
+  const failures = []
+  for (const registry of registries) {
+    try {
+      const observed = await readMain(registry)
+      if (registry.registry_id === 'historical-exchange-index') {
+        assert(githubSha, 'HEI execution requires GITHUB_SHA')
+        assert(observed === githubSha, `HEI main moved after workflow checkout: expected ${githubSha}, observed ${observed}`)
+      } else {
+        assert(observed === registry.reviewed_main, `main advanced beyond reviewed baseline ${registry.reviewed_main}: observed ${observed}`)
+      }
+      report.repository_preflight.push({ registry_id: registry.registry_id, audit_main: registry.audit_main, reviewed_main: registry.reviewed_main, observed_main: observed, status: 'PASS' })
+    } catch (error) {
+      failures.push(`${registry.registry_id}: ${error.message}`)
+      report.repository_preflight.push({ registry_id: registry.registry_id, audit_main: registry.audit_main, reviewed_main: registry.reviewed_main, status: 'FAIL', error: error.message })
+    }
+  }
+  if (failures.length) throw new Error(`repository preflight failed: ${failures.join(' | ')}`)
+}
+
+async function verifyExactRoute(registry, route) {
+  const [live, expected] = await Promise.all([production(registry, route), reviewed(registry, route)])
+  assertSame(live, expected, `${registry.registry_id} ${route}`)
+  return live
+}
+
+async function verifyNative(registry) {
+  const values = new Map()
+  for (const route of registry.native_routes) values.set(route, await verifyExactRoute(registry, route))
+  return values
+}
+
+async function verifySeries(registry) {
+  const [liveDescriptor, expectedDescriptor, liveIndex, expectedIndex] = await Promise.all([
+    production(registry, '/data/series/registry.json', 'Series descriptor'),
+    reviewed(registry, '/data/series/registry.json', 'Series descriptor'),
+    production(registry, '/data/series/index.json', 'Series index'),
+    reviewed(registry, '/data/series/index.json', 'Series index'),
+  ])
+  assertSame(liveDescriptor, expectedDescriptor, `${registry.registry_id} Series descriptor`)
+  assertSame(liveIndex, expectedIndex, `${registry.registry_id} Series index`)
+  assert(liveDescriptor?.canonical_only === true, 'Series descriptor canonical_only is not true')
+  assert(liveIndex?.canonical_only === true, 'Series index canonical_only is not true')
+
+  const relationshipCount = Number(liveDescriptor?.record_counts?.relationships ?? 0)
+  assert(relationshipCount === registry.expected_relationships, `relationship count expected ${registry.expected_relationships}, observed ${relationshipCount}`)
+
+  let relationships = []
+  if (registry.expected_relationships > 0) {
+    assert(liveDescriptor?.routes?.relationships === '/data/series/relationships.json', 'unexpected relationships route')
+    const [live, expected] = await Promise.all([
+      production(registry, '/data/series/relationships.json', 'Series relationships'),
+      reviewed(registry, '/data/series/relationships.json', 'Series relationships'),
+    ])
+    assertSame(live, expected, `${registry.registry_id} Series relationships`)
+    assert(Array.isArray(live) && live.length === registry.expected_relationships, 'relationship transport count mismatch')
+    for (const relationship of live) {
+      assert(relationship?.source?.registry_id === registry.registry_id, 'relationship source escaped registry boundary')
+      assert(relationship?.target?.registry_id === registry.registry_id, 'cross-registry relationship observed')
+    }
+    relationships = live
+  }
+
+  const rows = Array.isArray(expectedIndex?.records) ? expectedIndex.records : []
+  assert(rows.length === expectedIndex.record_count, 'reviewed Series index record_count mismatch')
+  const envelopeResults = await mapLimit(rows, concurrency, async (row) => {
+    const machinePath = new URL(row.machine_url).pathname
+    const [liveEnvelope, expectedEnvelope] = await Promise.all([
+      production(registry, machinePath, `Series envelope ${row.global_record_key}`),
+      reviewed(registry, machinePath, `Series envelope ${row.global_record_key}`),
+    ])
+    assertSame(liveEnvelope, expectedEnvelope, `${registry.registry_id} Series envelope ${row.global_record_key}`)
+    assert(liveEnvelope.global_record_key === row.global_record_key, `Series envelope global key mismatch ${row.global_record_key}`)
+    assert(Array.isArray(liveEnvelope.relationships) && liveEnvelope.relationships.length === 0, `record-envelope relationships must remain empty ${row.global_record_key}`)
+
+    let nativePath = null
+    if (typeof expectedEnvelope?.urls?.native_machine === 'string') {
+      nativePath = new URL(expectedEnvelope.urls.native_machine, registry.origin).pathname
+      const [liveNative, expectedNative] = await Promise.all([
+        production(registry, nativePath, `native dossier ${row.global_record_key}`),
+        reviewed(registry, nativePath, `native dossier ${row.global_record_key}`),
+      ])
+      assertSame(liveNative, expectedNative, `${registry.registry_id} native dossier ${row.global_record_key}`)
+    }
+    return nativePath
+  })
+
+  return {
+    descriptor: liveDescriptor,
+    index: liveIndex,
+    relationships,
+    envelope_count: rows.length,
+    native_dossier_count: envelopeResults.filter(Boolean).length,
+  }
+}
+
+function verifyRevision(registry, native, series) {
+  const version = native.get('/version.json')
+  const manifest = native.get('/data/manifest.json') ?? native.get('/data/machine/manifest.json')
+  switch (registry.registry_id) {
+    case 'historical-exchange-index':
+      assert(version?.build?.commit === registry.reviewed_main, `HEI native build.commit expected ${registry.reviewed_main}, observed ${version?.build?.commit}`)
+      assert(series.descriptor?.verification?.build?.commit === registry.reviewed_main, 'HEI Series descriptor build commit mismatch')
+      assert(series.index?.verification?.build?.commit === registry.reviewed_main, 'HEI Series index build commit mismatch')
+      break
+    case 'minted-and-gone':
+      assert(series.descriptor?.verification?.build_commit === registry.reviewed_main, 'MAG descriptor build_commit mismatch')
+      assert(series.index?.build_commit === registry.reviewed_main, 'MAG index build_commit mismatch')
+      break
+    case 'stable-or-gone':
+      assert(series.descriptor?.verification?.build?.commit === registry.reviewed_main, 'SOG descriptor build commit mismatch')
+      assert(typeof series.descriptor?.verification?.build?.canonical_data_hash === 'string', 'SOG canonical_data_hash missing')
+      if (manifest?.build?.canonical_data_hash) assert(series.descriptor.verification.build.canonical_data_hash === manifest.build.canonical_data_hash, 'SOG Series/native canonical_data_hash mismatch')
+      break
+    case 'crypto-yield-archive':
+      assert(manifest?.build?.commit === registry.reviewed_main, 'CYA native manifest build commit mismatch')
+      assert(series.descriptor?.verification?.build?.commit === registry.reviewed_main, 'CYA descriptor build commit mismatch')
+      assertSame(series.descriptor.verification.build, manifest.build, 'CYA Series/native build object')
+      break
+    case 'bridge-incident-registry':
+      assert(!series.descriptor?.verification?.build_commit, 'BIR must not invent build_commit')
+      assert(!series.descriptor?.verification?.data_revision, 'BIR must not invent data_revision')
+      break
+    case 'cryptocurrency-wallet-lifecycle-registry':
+      assert(!('build_commit' in (series.descriptor?.verification ?? {})), 'WLR must not invent build_commit')
+      assert(series.descriptor?.verification?.last_verified_at === manifest?.last_verified_at, 'WLR last_verified_at mismatch')
+      break
+    case 'ai-tools-history-archive':
+      assert(version?.build_commit === registry.reviewed_main, 'AI Tools native build_commit mismatch')
+      assert(series.descriptor?.verification?.build_commit === registry.reviewed_main, 'AI Tools descriptor build_commit mismatch')
+      assert(series.index?.build_commit === registry.reviewed_main, 'AI Tools index build_commit mismatch')
+      break
+    case 'api-deprecation-archive': {
+      const revision = version?.data_revision
+      assert(typeof revision === 'string' && revision.length > 0, 'API Deprecation data_revision missing')
+      assert(manifest?.data_revision === revision, 'API Deprecation native manifest data_revision mismatch')
+      assert(series.descriptor?.verification?.data_revision === revision, 'API Deprecation Series descriptor data_revision mismatch')
+      assert(series.index?.data_revision === revision || series.index?.verification?.data_revision === revision, 'API Deprecation Series index data_revision mismatch')
+      break
+    }
+    default:
+      throw new Error(`missing revision verifier for ${registry.registry_id}`)
+  }
+}
+
+const liveDescriptors = new Map()
+const observedRelationshipCounts = new Map()
+
+async function verifyRegistry(registry) {
+  const row = { registry_id: registry.registry_id, repository: registry.repository, audit_main: registry.audit_main, reviewed_main: registry.reviewed_main, origin: registry.origin, verification_mode: registry.verification_mode, status: 'RUNNING' }
+  const started = Date.now()
+  report.registries.push(row)
+  try {
+    const native = await verifyNative(registry)
+    const series = await verifySeries(registry)
+    liveDescriptors.set(registry.registry_id, series.descriptor)
+    observedRelationshipCounts.set(registry.registry_id, series.relationships.length)
+    verifyRevision(registry, native, series)
+    row.status = 'PASS'
+    row.series_record_count = series.index.record_count
+    row.series_envelope_count = series.envelope_count
+    row.native_dossier_count = series.native_dossier_count
+    row.relationship_count = series.relationships.length
+  } catch (error) {
+    row.status = 'FAIL'
+    row.error = error.message
+    try {
+      if (!liveDescriptors.has(registry.registry_id)) liveDescriptors.set(registry.registry_id, await production(registry, '/data/series/registry.json', 'Series descriptor for central check'))
+    } catch {}
+  }
+  row.duration_ms = Date.now() - started
+}
+
+async function verifyCentral() {
+  const result = { status: 'RUNNING', origin: 'https://hei.badjoke-lab.com', route: '/data/series/registries.json' }
+  report.central_descriptor = result
+  try {
+    const central = await fetchJson(productionUrl('https://hei.badjoke-lab.com', '/data/series/registries.json'), 'HEI central registry index')
+    assert(central?.series_schema_version === '1.0.0', 'central Series schema mismatch')
+    assert(central?.object_type === 'registry_index', 'central object type mismatch')
+    assert(central?.semantic_owner === 'badjoke-lab-ledger-series', 'central semantic owner mismatch')
+    assert(central?.registry_count === 8 && Array.isArray(central?.registries) && central.registries.length === 8, 'central registry count mismatch')
+    const centralById = new Map(central.registries.map((entry) => [entry?.registry?.id, entry]))
+    for (const registry of registries) {
+      const liveDescriptor = liveDescriptors.get(registry.registry_id)
+      assert(liveDescriptor, `${registry.registry_id}: live descriptor unavailable`)
+      const centralEntry = centralById.get(registry.registry_id)
+      assert(centralEntry, `${registry.registry_id}: missing from central index`)
+      const expected = normalizeDescriptor(`${registry.origin.replace(/\/$/, '')}/data/series/registry.json`, liveDescriptor)
+      assertSame(centralEntry, expected, `${registry.registry_id} central descriptor`)
+    }
+    result.status = 'PASS'
+    result.collector_run = central?.snapshot?.collector_run ?? null
+    result.collected_at = central?.snapshot?.collected_at ?? null
+  } catch (error) {
+    result.status = 'FAIL'
+    result.error = error.message
+  }
+}
+
+function finalizeRelationships() {
+  const expectedByRegistry = Object.fromEntries(registries.map((registry) => [registry.registry_id, registry.expected_relationships]))
+  const observedByRegistry = Object.fromEntries(registries.map((registry) => [registry.registry_id, observedRelationshipCounts.get(registry.registry_id) ?? null]))
+  const allKnown = observedRelationshipCounts.size === registries.length
+  const observedTotal = [...observedRelationshipCounts.values()].reduce((sum, count) => sum + count, 0)
+  report.stage5_relationships = {
+    expected_by_registry: expectedByRegistry,
+    observed_by_registry: observedByRegistry,
+    expected_total: authority.frozen_stage5_relationship_counts.total,
+    observed_total: allKnown ? observedTotal : null,
+    expected_cross_registry: authority.frozen_stage5_relationship_counts.cross_registry,
+    observed_cross_registry: 0,
+    status: allKnown && observedTotal === authority.frozen_stage5_relationship_counts.total ? 'PASS' : 'FAIL',
+  }
+}
+
+try {
+  await preflight()
+} catch (error) {
+  report.overall = 'FAIL'
+  report.preflight_error = error.message
+  report.finished_at = new Date().toISOString()
+  writeReport()
+  console.error(error.message)
+  process.exit(1)
+}
+
+for (const registry of registries) await verifyRegistry(registry)
+await verifyCentral()
+finalizeRelationships()
+
+report.overall = report.registries.every((row) => row.status === 'PASS') && report.central_descriptor?.status === 'PASS' && report.stage5_relationships?.status === 'PASS' ? 'PASS' : 'FAIL'
+report.finished_at = new Date().toISOString()
+writeReport()
+
+console.log(JSON.stringify({
+  overall: report.overall,
+  registries: report.registries.map((row) => ({ registry_id: row.registry_id, status: row.status, error: row.error ?? null })),
+  central_descriptor: report.central_descriptor,
+  stage5_relationships: report.stage5_relationships,
+  result_path: path.relative(root, resultPath),
+}, null, 2))
+
+if (report.overall !== 'PASS') process.exit(1)


### PR DESCRIPTION
## Scope

Implements only the read-only Stage 6 execution authority merged in #805.

Changes are limited to:
- `scripts/verify-ledger-series-phase9-stage6-production-equality.mjs`
- `.github/workflows/ledger-series-phase9-stage6-production-equality.yml`
- `docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_2026-08-22.md`

## Baseline review

Seven vertical repositories remain exactly at their audited/reviewed Stage 6 baselines. HEI advanced after the audit through coordination PRs #804/#805 and canonical record PR #806. #806 changed only `records/exchanges/mantra-finance.json`; its exact head `f275c835...` completed all 18 applicable checks successfully and merged as `10b9546f...`. The pre-execution review records `10b9546f...` as the separately reviewed HEI execution baseline.

## Verifier

The verifier is read-only and bounded to exactly eight reviewed origins. It:
- re-reads repository mains and fails closed on unexpected drift;
- compares live native JSON to the exact reviewed GitHub revision;
- compares live Series descriptors, indexes, every envelope, referenced native dossier, and reviewed relationship transports;
- preserves per-registry revision semantics instead of inventing a universal revision field;
- verifies Stage 5 relationship counts remain 21/17/1/0/44/161/0/0 = 244 and rejects cross-registry relationships;
- compares the live HEI central registry index against the eight live descriptors and fails closed on a stale snapshot.

The workflow runs syntax/boundary checks on PRs. The network equality job is `workflow_dispatch` only and requires `main`, so it cannot execute before this PR is reviewed and merged.

No vertical repository mutation, production mutation, deployment/config change, central descriptor resync, automatic repair, Search/Compare/Stats/UI/localization change, or Stage 7/8 work is authorized or performed.

Coordinates with #780.