### PR TITLE
Correct Phase 9 Stage 6 production equality verifier

### DIFF
--- a/.github/workflows/ledger-series-phase9-stage6-production-equality.yml
+++ b/.github/workflows/ledger-series-phase9-stage6-production-equality.yml
@@ -5,8 +5,14 @@ on:
     paths:
       - "scripts/verify-ledger-series-phase9-stage6-production-equality.mjs"
       - ".github/workflows/ledger-series-phase9-stage6-production-equality.yml"
-      - "docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_2026-08-22.md"
-  workflow_dispatch:
+      - "docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_SUPERSEDING_2026-08-22.md"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/verify-ledger-series-phase9-stage6-production-equality.mjs"
+      - ".github/workflows/ledger-series-phase9-stage6-production-equality.yml"
+      - "docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_SUPERSEDING_2026-08-22.md"
 
 permissions:
   contents: read
@@ -18,16 +24,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
-
-      - name: Verify Stage 6 script syntax
+      - name: Verify corrected Stage 6 script syntax
         run: node --check scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
-
-      - name: Verify authority boundary
+      - name: Verify authority boundary remains read-only
         run: |
           node - <<'NODE'
           const fs = require('node:fs');
@@ -35,41 +38,90 @@ jobs:
           if (authority.authority_id !== 'hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2') throw new Error('unexpected authority id');
           if (authority.network_read_only_verification_authorized_after_merge !== true) throw new Error('network verification not authorized');
           if (authority.production_mutation_authorized !== false || authority.vertical_repository_mutation_authorized !== false || authority.central_descriptor_resync_authorized !== false) throw new Error('mutation boundary weakened');
-          if (authority.reviewed_repository_baselines?.length !== 8) throw new Error('expected exactly eight reviewed registries');
-          console.log('Stage 6 authority boundary PASS');
+          if (authority.reviewed_repository_baselines?.length !== 8) throw new Error('expected exactly eight authority registries');
+          console.log('Corrected Stage 6 authority boundary PASS');
           NODE
 
   verify-production-equality:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Phase 9 Stage 6 corrected verifier one-shot')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Checkout exact main execution revision
+      - name: Checkout HEI exact execution revision
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Checkout reviewed MAG execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/mintedandgone
+          ref: f917d5e25eedc7b2c48091c7343b7fa9cd203428
+          path: .stage6/repos/mag
+          persist-credentials: false
+      - name: Checkout reviewed SOG execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/stable-or-gone
+          ref: 9a4f853cca85efff1c7ae4303b07c7af224e65bd
+          path: .stage6/repos/sog
+          persist-credentials: false
+      - name: Checkout reviewed CYA execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/crypto-yield-archive
+          ref: de0f7cab8b519f745d153add3a04b16394ecb8b1
+          path: .stage6/repos/cya
+          persist-credentials: false
+      - name: Checkout reviewed BIR execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/bridge-incident-registry
+          ref: ef2767ee5fb55339e530d90fcdf3eff88becbc41
+          path: .stage6/repos/bir
+          persist-credentials: false
+      - name: Checkout reviewed WLR execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/cryptocurrency-wallet-lifecycle-registry
+          ref: 919a759a4f3077ffecac5464cbb61eae41cd1f0e
+          path: .stage6/repos/wlr
+          persist-credentials: false
+      - name: Checkout reviewed AI execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/ai-tools-history-archive
+          ref: 76ef103329813f0174db121117c932bff53fbf8e
+          path: .stage6/repos/ai
+          persist-credentials: false
+      - name: Checkout reviewed API execution baseline
+        uses: actions/checkout@v4
+        with:
+          repository: badjoke-lab/api-deprecation-archive
+          ref: 641a6d4243d30f95f48436455d2cbc12a8aded53
+          path: .stage6/repos/api
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
-
-      - name: Verify Stage 6 script syntax
+      - name: Verify corrected script syntax
         run: node --check scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
-
-      - name: Run bounded read-only eight-registry equality verification
+      - name: Run one authorized read-only eight-registry equality verification
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          STAGE6_REPO_ROOT: .stage6/repos
           STAGE6_RESULT_PATH: .stage6/phase9-stage6-production-equality-result.json
           STAGE6_TIMEOUT_MS: "20000"
-          STAGE6_CONCURRENCY: "12"
+          STAGE6_CONCURRENCY: "10"
         run: node scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
-
       - name: Upload Stage 6 result
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ledger-series-phase9-stage6-production-equality-result
+          name: ledger-series-phase9-stage6-production-equality-result-${{ github.sha }}
           path: .stage6/phase9-stage6-production-equality-result.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/ledger-series-phase9-stage6-production-equality.yml
+++ b/.github/workflows/ledger-series-phase9-stage6-production-equality.yml
@@ -28,7 +28,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Verify corrected Stage 6 script syntax
+      - name: Apply reviewed post-EXMO HEI execution baseline in workspace
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const file = 'scripts/verify-ledger-series-phase9-stage6-production-equality.mjs';
+          let source = fs.readFileSync(file, 'utf8');
+          const oldBaseline = "repository: 'badjoke-lab/historical-exchange-index', repo_main: '7ec374c1dfd92fc1f53b6148a54904372c83d9ee', production_revision: '242e60a59147440207f5823c9af86fb65e85da54', local: root,";
+          const newBaseline = "repository: 'badjoke-lab/historical-exchange-index', repo_main: '3972c817694a51badfa0c183dcc58e1c4dfaba66', production_revision: '3972c817694a51badfa0c183dcc58e1c4dfaba66', local: root,";
+          const oldRetry = "HEI_PUBLIC_ORIGIN: hei.origin, EXPECTED_COMMIT: hei.production_revision, SMOKE_MAX_ATTEMPTS: '3', SMOKE_RETRY_DELAY_MS: '5000',";
+          const newRetry = "HEI_PUBLIC_ORIGIN: hei.origin, EXPECTED_COMMIT: hei.production_revision, SMOKE_MAX_ATTEMPTS: '40', SMOKE_RETRY_DELAY_MS: '15000',";
+          if (!source.includes(oldBaseline)) throw new Error('expected pre-EXMO HEI Stage 6 baseline marker missing');
+          if (!source.includes(oldRetry)) throw new Error('expected HEI short retry marker missing');
+          source = source.replace(oldBaseline, newBaseline).replace(oldRetry, newRetry);
+          fs.writeFileSync(file, source);
+          console.log('Applied reviewed HEI baseline 3972c817... with bounded 10-minute read-only deployment convergence window.');
+          NODE
+      - name: Verify corrected Stage 6 runtime script syntax
         run: node --check scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
       - name: Verify authority boundary remains read-only
         run: |
@@ -107,7 +123,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Verify corrected script syntax
+      - name: Apply reviewed post-EXMO HEI execution baseline in workspace
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const file = 'scripts/verify-ledger-series-phase9-stage6-production-equality.mjs';
+          let source = fs.readFileSync(file, 'utf8');
+          const oldBaseline = "repository: 'badjoke-lab/historical-exchange-index', repo_main: '7ec374c1dfd92fc1f53b6148a54904372c83d9ee', production_revision: '242e60a59147440207f5823c9af86fb65e85da54', local: root,";
+          const newBaseline = "repository: 'badjoke-lab/historical-exchange-index', repo_main: '3972c817694a51badfa0c183dcc58e1c4dfaba66', production_revision: '3972c817694a51badfa0c183dcc58e1c4dfaba66', local: root,";
+          const oldRetry = "HEI_PUBLIC_ORIGIN: hei.origin, EXPECTED_COMMIT: hei.production_revision, SMOKE_MAX_ATTEMPTS: '3', SMOKE_RETRY_DELAY_MS: '5000',";
+          const newRetry = "HEI_PUBLIC_ORIGIN: hei.origin, EXPECTED_COMMIT: hei.production_revision, SMOKE_MAX_ATTEMPTS: '40', SMOKE_RETRY_DELAY_MS: '15000',";
+          if (!source.includes(oldBaseline)) throw new Error('expected pre-EXMO HEI Stage 6 baseline marker missing');
+          if (!source.includes(oldRetry)) throw new Error('expected HEI short retry marker missing');
+          source = source.replace(oldBaseline, newBaseline).replace(oldRetry, newRetry);
+          fs.writeFileSync(file, source);
+          console.log('Applied reviewed HEI baseline 3972c817... with bounded 10-minute read-only deployment convergence window.');
+          NODE
+      - name: Verify corrected runtime script syntax
         run: node --check scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
       - name: Run one authorized read-only eight-registry equality verification
         env:

--- a/docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_SUPERSEDING_2026-08-22.md
+++ b/docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_SUPERSEDING_2026-08-22.md
@@ -1,6 +1,6 @@
 # Ledger Series Phase 9 Stage 6 — superseding pre-execution baseline review
 
-Date: 2026-08-22 JST  
+Date: 2026-08-23 JST  
 Coordination issue: #780  
 Execution authority: `hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2`
 
@@ -14,7 +14,7 @@ This review supersedes that execution implementation. It does **not** expand Sta
 
 | Registry | Re-reviewed repository main | Stage 6 production revision rule |
 | --- | --- | --- |
-| HEI | `7ec374c1dfd92fc1f53b6148a54904372c83d9ee` | latest reviewed runtime-affecting commit `242e60a59147440207f5823c9af86fb65e85da54`; corrected verifier merge itself is coordination-only |
+| HEI | `3972c817694a51badfa0c183dcc58e1c4dfaba66` | exact reviewed post-EXMO runtime revision `3972c817694a51badfa0c183dcc58e1c4dfaba66`; corrected verifier merge itself is coordination-only |
 | MAG | `f917d5e25eedc7b2c48091c7343b7fa9cd203428` | exact reviewed runtime build `73dafdf78a2ca60e9329a4c6844315cafb8e55c0` |
 | SOG | `9a4f853cca85efff1c7ae4303b07c7af224e65bd` | exact reviewed runtime build `a3cf1e51a00b70d867a6579ea9602343016ad58a` plus canonical data hash |
 | CYA | `de0f7cab8b519f745d153add3a04b16394ecb8b1` | exact reviewed runtime build `66b9ae8ac1fc8487d30f649f489f892b047f30e5`; current platform count derived from reviewed `data/platforms*.json`, never hard-coded |
@@ -25,7 +25,9 @@ This review supersedes that execution implementation. It does **not** expand Sta
 
 ## Drift review
 
-- HEI after the MANTRA canonical review advanced only through the Stage 6 verifier work and project-network manifest/integrity work. `7ec374c1...` differs from runtime-affecting `242e60a5...` only by the project-network integrity workflow.
+- HEI advanced after the earlier review through PR #812, `Correct EXMO wind-down lifecycle status`, merged as `3972c817694a51badfa0c183dcc58e1c4dfaba66`. The PR changes only `records/exchanges/exmo.json`: EXMO moves from `active` to `limited`, two reviewed lifecycle events are added, and two primary-source evidence rows are added. `death_reason` and `death_date` remain null.
+- PR #812 exact head `7eacf5c0a2b4d4f903a2902a860c76a4f7b3aaa9` passed all 19 observed PR workflows, including CI, Records validation, Machine/public consistency, Ledger Series Phase 9 Adapter, Project network integrity, Count semantics, metadata, URL safety, localization, and quality gates.
+- The post-EXMO HEI build reports 1038 primary records, 1047 events, 3892 evidence rows and 21 reviewed Stage 5 relationships. The Stage 6 execution baseline therefore adopts merge `3972c817...` rather than the earlier `242e60a5...` runtime revision.
 - MAG, CYA, and WLR advanced only through project-network display/integrity work; no canonical or Series corpus changed.
 - SOG advanced through project-network/deployment workflow work and the MNEE June 2026 implementation **authority** merge; the reviewed drift did not itself publish new canonical MNEE data.
 - BIR did contain a real canonical change: PR #355 added the reviewed AFX Trade July 2026 bridge incident. Its exact head `77e57cd2b6bfb738540daa052905abaf0878c14a` passed Check, SEO, V1 Release Readiness, and representative screenshot gates before merge as `fe41d1adc79d18039f41cfbcd21451c8695a7e23`. Later BIR changes were project-network/review-only changes; current reviewed main is `ef2767ee...`.
@@ -45,6 +47,8 @@ The corrected HEI verifier does the following in one execution window:
 
 The workflow performs no build, deploy, repository write, descriptor resync, Cloudflare change, or production mutation. It checks out reviewed repositories read-only and performs HTTP GET verification only.
 
+Because PR #812 merged immediately before this corrected execution, the workflow applies two exact, reviewed workspace-only substitutions before running the verifier: HEI `repo_main` / `production_revision` are advanced to `3972c817...`, and the HEI native deployment convergence check is widened from 3×5 seconds to at most 40×15 seconds. The substitution fails closed if the expected pre-EXMO markers are absent. This does not mutate the repository or production and prevents the previously observed deployment-race false failure.
+
 ## One-shot execution rule
 
-The network job is allowed only on the main-branch push whose commit message begins `Phase 9 Stage 6 corrected verifier one-shot`. Pull requests run syntax and authority-boundary checks only. If that one-shot run fails for any missing route, timeout, malformed JSON, revision mismatch, native/Series mismatch, relationship mismatch, or stale central descriptor, Stage 6 is **FAIL** and stops. No automatic remediation or resync is authorized.
+The network job is allowed only on the main-branch push whose commit message begins `Phase 9 Stage 6 corrected verifier one-shot`. Pull requests run the same workspace-only baseline substitution, script syntax validation, and authority-boundary checks, but do not perform network equality execution. If that one-shot run fails for any missing route, timeout, malformed JSON, revision mismatch, native/Series mismatch, relationship mismatch, or stale central descriptor, Stage 6 is **FAIL** and stops. No automatic remediation or resync is authorized.

--- a/docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_SUPERSEDING_2026-08-22.md
+++ b/docs/audits/HEI_LEDGER_SERIES_PHASE9_STAGE6_PRE_EXECUTION_BASELINE_REVIEW_SUPERSEDING_2026-08-22.md
@@ -1,0 +1,50 @@
+# Ledger Series Phase 9 Stage 6 — superseding pre-execution baseline review
+
+Date: 2026-08-22 JST  
+Coordination issue: #780  
+Execution authority: `hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2`
+
+## Why this review supersedes the first Stage 6 pre-execution review
+
+PR #807 correctly kept Stage 6 read-only, but its verifier assumed that reviewed GitHub commits directly track every deployed `public/version.json` and `public/data/series/*` object. That assumption is false for registries that generate public machine-readable output during build. A correct production deployment could therefore be reported as HTTP 404 against `raw.githubusercontent.com` even when production itself is valid.
+
+This review supersedes that execution implementation. It does **not** expand Stage 6 authority. Production mutation, vertical-repository mutation, Cloudflare/DNS changes, canonical descriptor resync, and any remediation remain unauthorized.
+
+## Re-reviewed repository mains before corrected execution
+
+| Registry | Re-reviewed repository main | Stage 6 production revision rule |
+| --- | --- | --- |
+| HEI | `7ec374c1dfd92fc1f53b6148a54904372c83d9ee` | latest reviewed runtime-affecting commit `242e60a59147440207f5823c9af86fb65e85da54`; corrected verifier merge itself is coordination-only |
+| MAG | `f917d5e25eedc7b2c48091c7343b7fa9cd203428` | exact reviewed runtime build `73dafdf78a2ca60e9329a4c6844315cafb8e55c0` |
+| SOG | `9a4f853cca85efff1c7ae4303b07c7af224e65bd` | exact reviewed runtime build `a3cf1e51a00b70d867a6579ea9602343016ad58a` plus canonical data hash |
+| CYA | `de0f7cab8b519f745d153add3a04b16394ecb8b1` | exact reviewed runtime build `66b9ae8ac1fc8487d30f649f489f892b047f30e5`; current platform count derived from reviewed `data/platforms*.json`, never hard-coded |
+| BIR | `ef2767ee5fb55339e530d90fcdf3eff88becbc41` | no invented commit; existing canonical-content verifier regenerates public JSON from the reviewed checkout and compares live content exactly |
+| WLR | `919a759a4f3077ffecac5464cbb61eae41cd1f0e` | no invented commit; reviewed canonical `data/{entities,products,events,evidence}.json` must equal live canonical JSON and wallet/product adapters must preserve the reviewed projection |
+| AI Tools | `76ef103329813f0174db121117c932bff53fbf8e` | exact reviewed `build_commit` across native and Series |
+| API Deprecation | `641a6d4243d30f95f48436455d2cbc12a8aded53` | deterministic reviewed `data_revision` across native machine and Series |
+
+## Drift review
+
+- HEI after the MANTRA canonical review advanced only through the Stage 6 verifier work and project-network manifest/integrity work. `7ec374c1...` differs from runtime-affecting `242e60a5...` only by the project-network integrity workflow.
+- MAG, CYA, and WLR advanced only through project-network display/integrity work; no canonical or Series corpus changed.
+- SOG advanced through project-network/deployment workflow work and the MNEE June 2026 implementation **authority** merge; the reviewed drift did not itself publish new canonical MNEE data.
+- BIR did contain a real canonical change: PR #355 added the reviewed AFX Trade July 2026 bridge incident. Its exact head `77e57cd2b6bfb738540daa052905abaf0878c14a` passed Check, SEO, V1 Release Readiness, and representative screenshot gates before merge as `fe41d1adc79d18039f41cfbcd21451c8695a7e23`. Later BIR changes were project-network/review-only changes; current reviewed main is `ef2767ee...`.
+- AI Tools and API Deprecation did not advance from the authority audit baselines.
+
+## Corrected verifier boundary
+
+The corrected HEI verifier does the following in one execution window:
+
+1. re-reads all eight GitHub `main` refs and fails if any vertical repo has advanced beyond the re-reviewed execution baseline;
+2. runs existing reviewed per-registry production checkers from exact read-only checkouts, preserving each registry's native revision semantics;
+3. compares every live Series envelope with its live native dossier using only the projection defined by that registry's existing adapter generator;
+4. derives CYA current primary count from the reviewed canonical corpus rather than a fixed number;
+5. requires WLR live canonical aggregate JSON to equal the reviewed canonical JSON exactly;
+6. requires Stage 5 relationship total `244` with zero cross-registry relationships, while existing Stage 5 verifiers retain finite-allowlist enforcement where already implemented;
+7. compares HEI's live central eight-registry descriptor index against the eight accepted live descriptors using the same Stage 4 descriptor normalization.
+
+The workflow performs no build, deploy, repository write, descriptor resync, Cloudflare change, or production mutation. It checks out reviewed repositories read-only and performs HTTP GET verification only.
+
+## One-shot execution rule
+
+The network job is allowed only on the main-branch push whose commit message begins `Phase 9 Stage 6 corrected verifier one-shot`. Pull requests run syntax and authority-boundary checks only. If that one-shot run fails for any missing route, timeout, malformed JSON, revision mismatch, native/Series mismatch, relationship mismatch, or stale central descriptor, Stage 6 is **FAIL** and stops. No automatic remediation or resync is authorized.

--- a/scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
+++ b/scripts/verify-ledger-series-phase9-stage6-production-equality.mjs
@@ -1,92 +1,379 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 
 const root = process.cwd()
 const authority = JSON.parse(fs.readFileSync(path.join(root, 'config', 'ledger-series-phase9-stage6-production-equality-authority.json'), 'utf8'))
-const timeoutMs = Math.max(1000, Number(process.env.STAGE6_TIMEOUT_MS ?? 20000))
-const concurrency = Math.max(1, Number(process.env.STAGE6_CONCURRENCY ?? 12))
+const repoRoot = process.env.STAGE6_REPO_ROOT || path.join(root, '.stage6', 'repos')
 const resultPath = process.env.STAGE6_RESULT_PATH || path.join(root, '.stage6', 'phase9-stage6-production-equality-result.json')
-const githubToken = process.env.GITHUB_TOKEN?.trim() || null
-const githubSha = process.env.GITHUB_SHA?.trim() || null
-const cacheNonce = `${Date.now()}`
+const timeoutMs = Math.max(1000, Number(process.env.STAGE6_TIMEOUT_MS || 20000))
+const concurrency = Math.max(1, Number(process.env.STAGE6_CONCURRENCY || 10))
+const githubSha = (process.env.GITHUB_SHA || '').trim()
+const githubToken = (process.env.GITHUB_TOKEN || '').trim()
+const nonce = Date.now()
 
-const executionMainOverride = {
-  'historical-exchange-index': '10b9546f386ce9e99c0169871e4277cb1891ab3a',
+const REVIEW = {
+  'historical-exchange-index': {
+    repository: 'badjoke-lab/historical-exchange-index', repo_main: '7ec374c1dfd92fc1f53b6148a54904372c83d9ee', production_revision: '242e60a59147440207f5823c9af86fb65e85da54', local: root,
+  },
+  'minted-and-gone': {
+    repository: 'badjoke-lab/mintedandgone', repo_main: 'f917d5e25eedc7b2c48091c7343b7fa9cd203428', production_revision: '73dafdf78a2ca60e9329a4c6844315cafb8e55c0', local: path.join(repoRoot, 'mag'),
+  },
+  'stable-or-gone': {
+    repository: 'badjoke-lab/stable-or-gone', repo_main: '9a4f853cca85efff1c7ae4303b07c7af224e65bd', production_revision: 'a3cf1e51a00b70d867a6579ea9602343016ad58a', local: path.join(repoRoot, 'sog'),
+  },
+  'crypto-yield-archive': {
+    repository: 'badjoke-lab/crypto-yield-archive', repo_main: 'de0f7cab8b519f745d153add3a04b16394ecb8b1', production_revision: '66b9ae8ac1fc8487d30f649f489f892b047f30e5', local: path.join(repoRoot, 'cya'),
+  },
+  'bridge-incident-registry': {
+    repository: 'badjoke-lab/bridge-incident-registry', repo_main: 'ef2767ee5fb55339e530d90fcdf3eff88becbc41', production_revision: null, local: path.join(repoRoot, 'bir'),
+  },
+  'cryptocurrency-wallet-lifecycle-registry': {
+    repository: 'badjoke-lab/cryptocurrency-wallet-lifecycle-registry', repo_main: '919a759a4f3077ffecac5464cbb61eae41cd1f0e', production_revision: null, local: path.join(repoRoot, 'wlr'),
+  },
+  'ai-tools-history-archive': {
+    repository: 'badjoke-lab/ai-tools-history-archive', repo_main: '76ef103329813f0174db121117c932bff53fbf8e', production_revision: '76ef103329813f0174db121117c932bff53fbf8e', local: path.join(repoRoot, 'ai'),
+  },
+  'api-deprecation-archive': {
+    repository: 'badjoke-lab/api-deprecation-archive', repo_main: '641a6d4243d30f95f48436455d2cbc12a8aded53', production_revision: null, local: path.join(repoRoot, 'api'),
+  },
 }
 
-function assert(condition, message) {
-  if (!condition) throw new Error(message)
+const expectedRelationships = {
+  'historical-exchange-index': 21,
+  'minted-and-gone': 17,
+  'stable-or-gone': 1,
+  'crypto-yield-archive': 0,
+  'bridge-incident-registry': 44,
+  'cryptocurrency-wallet-lifecycle-registry': 161,
+  'ai-tools-history-archive': 0,
+  'api-deprecation-archive': 0,
 }
 
+function assert(condition, message) { if (!condition) throw new Error(message) }
 function stable(value) {
   if (Array.isArray(value)) return value.map(stable)
   if (value && typeof value === 'object') return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]))
   return value
 }
+function same(a, b) { return JSON.stringify(stable(a)) === JSON.stringify(stable(b)) }
+function assertSame(a, b, label) { if (!same(a, b)) throw new Error(`${label}: mismatch`) }
+function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')) }
+function endpointKey(endpoint) { return `${endpoint?.registry_id}:${endpoint?.native_record_type}:${endpoint?.native_record_id}` }
+function relationshipId(type, source, target) { return `series_rel_${createHash('sha256').update(`${type}\n${source}\n${target}`, 'utf8').digest('hex')}` }
+function urlPath(value) { return new URL(value).pathname }
 
-function same(left, right) {
-  return JSON.stringify(stable(left)) === JSON.stringify(stable(right))
+assert(authority.authority_id === 'hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2', 'unexpected Stage 6 authority')
+assert(authority.network_read_only_verification_authorized_after_merge === true, 'Stage 6 network verification is not authorized')
+assert(authority.production_mutation_authorized === false && authority.vertical_repository_mutation_authorized === false && authority.central_descriptor_resync_authorized === false, 'Stage 6 mutation boundary weakened')
+assert(authority.reviewed_repository_baselines?.length === 8, 'Stage 6 authority must cover eight registries')
+assert(Object.keys(REVIEW).length === 8, 'superseding execution review must cover eight registries')
+assert(Object.values(expectedRelationships).reduce((a, b) => a + b, 0) === 244, 'Stage 5 relationship total must remain 244')
+
+const byId = new Map(authority.reviewed_repository_baselines.map((x) => [x.registry_id, x]))
+for (const [id, review] of Object.entries(REVIEW)) {
+  const frozen = byId.get(id)
+  assert(frozen, `${id}: missing frozen authority baseline`)
+  assert(frozen.repository === review.repository, `${id}: repository changed from authority`)
+  review.origin = frozen.origin
+  review.verification_mode = frozen.verification_mode
 }
 
-function assertSame(actual, expected, label) {
-  if (!same(actual, expected)) throw new Error(`${label}: live/reviewed mismatch`)
+const report = {
+  schema_version: '1.1.0', phase: 9, stage: 6,
+  authority_id: authority.authority_id,
+  execution_kind: 'read_only_cross_registry_production_equality_corrected',
+  started_at: new Date().toISOString(), workflow_sha: githubSha || null,
+  repository_preflight: [], checker_results: [], registries: [], central_descriptor: null,
+  stage5_relationships: null, overall: 'RUNNING',
+}
+function writeReport() {
+  fs.mkdirSync(path.dirname(resultPath), { recursive: true })
+  fs.writeFileSync(resultPath, `${JSON.stringify(report, null, 2)}\n`)
 }
 
-function normalizeRoute(route) {
-  return route.startsWith('/') ? route : `/${route}`
+async function fetchText(url, label) {
+  const headers = { accept: '*/*', 'cache-control': 'no-cache', 'user-agent': 'HEI-Ledger-Series-Stage6-corrected/1.0' }
+  if (url.startsWith('https://api.github.com/') && githubToken) headers.authorization = `Bearer ${githubToken}`
+  const res = await fetch(url, { headers, redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) })
+  const text = await res.text()
+  if (!res.ok) throw new Error(`${label}: HTTP ${res.status}`)
+  return text
+}
+async function fetchJsonUrl(url, label) {
+  const text = await fetchText(url, label)
+  try { return JSON.parse(text) } catch (error) { throw new Error(`${label}: malformed JSON: ${error.message}`) }
+}
+async function live(review, route, label = route) {
+  const origin = review.origin.replace(/\/$/, '')
+  const sep = route.includes('?') ? '&' : '?'
+  return fetchJsonUrl(`${origin}${route}${sep}stage6=${nonce}`, `${label} @ ${origin}`)
 }
 
-function rawPath(prefix, route) {
-  const relative = normalizeRoute(route).replace(/^\//, '')
-  return prefix ? `${prefix.replace(/\/$/, '')}/${relative}` : relative
-}
-
-function rawUrl(repository, sha, sourcePath) {
-  return `https://raw.githubusercontent.com/${repository}/${sha}/${sourcePath.split('/').map(encodeURIComponent).join('/')}`
-}
-
-function productionUrl(origin, route) {
-  const normalizedOrigin = origin.replace(/\/$/, '')
-  const normalizedRoute = normalizeRoute(route)
-  const separator = normalizedRoute.includes('?') ? '&' : '?'
-  return `${normalizedOrigin}${normalizedRoute}${separator}stage6_verify=${cacheNonce}`
-}
-
-const cache = new Map()
-
-async function fetchJson(url, label, githubApi = false) {
-  if (cache.has(url)) return cache.get(url)
-  const headers = {
-    accept: 'application/json',
-    'cache-control': 'no-cache',
-    'user-agent': 'HEI-Ledger-Series-Stage6-verifier/1.0',
+async function preflight() {
+  for (const [id, review] of Object.entries(REVIEW)) {
+    const branch = await fetchJsonUrl(`https://api.github.com/repos/${review.repository}/branches/main`, `${id} GitHub main`)
+    const observed = branch?.commit?.sha
+    if (id === 'historical-exchange-index') {
+      assert(githubSha && observed === githubSha, `HEI main moved: workflow ${githubSha || 'missing'}, observed ${observed}`)
+    } else {
+      assert(observed === review.repo_main, `${id} main moved beyond reviewed execution baseline: expected ${review.repo_main}, observed ${observed}`)
+    }
+    report.repository_preflight.push({ registry_id: id, authority_audit_main: byId.get(id).reviewed_main, reviewed_execution_main: review.repo_main, observed_main: observed, production_revision: review.production_revision, status: 'PASS' })
   }
-  if (githubApi && githubToken) headers.authorization = `Bearer ${githubToken}`
-  const response = await fetch(url, { headers, redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) })
-  const text = await response.text()
-  if (!response.ok) throw new Error(`${label}: HTTP ${response.status}`)
-  let parsed
-  try {
-    parsed = JSON.parse(text)
-  } catch (error) {
-    throw new Error(`${label}: malformed JSON (${error.message})`)
-  }
-  cache.set(url, parsed)
-  return parsed
 }
 
-async function mapLimit(items, limit, worker) {
-  const output = new Array(items.length)
-  let next = 0
-  async function runner() {
-    while (true) {
-      const index = next++
-      if (index >= items.length) return
-      output[index] = await worker(items[index], index)
+function checker(label, id, script, args = [], extraEnv = {}, maxMs = 210000) {
+  const cwd = REVIEW[id].local
+  assert(fs.existsSync(path.join(cwd, script)), `${label}: checker missing at reviewed checkout ${script}`)
+  const env = { ...process.env, ...extraEnv }
+  const proc = spawnSync(process.execPath, [script, ...args], { cwd, env, encoding: 'utf8', timeout: maxMs, maxBuffer: 8 * 1024 * 1024 })
+  const item = { label, registry_id: id, script, status: proc.status === 0 ? 'PASS' : 'FAIL', exit_code: proc.status, stdout_tail: (proc.stdout || '').trim().slice(-3500), stderr_tail: (proc.stderr || '').trim().slice(-3500) }
+  report.checker_results.push(item)
+  if (proc.error) throw new Error(`${label}: ${proc.error.message}`)
+  if (proc.status !== 0) throw new Error(`${label}: existing reviewed checker failed: ${item.stderr_tail || item.stdout_tail || `exit ${proc.status}`}`)
+}
+
+function runReviewedCheckers() {
+  const hei = REVIEW['historical-exchange-index']
+  checker('HEI native exact reviewed deployment', 'historical-exchange-index', 'scripts/check-record-level-machine-readable-production.mjs', [], {
+    HEI_PUBLIC_ORIGIN: hei.origin, EXPECTED_COMMIT: hei.production_revision, SMOKE_MAX_ATTEMPTS: '3', SMOKE_RETRY_DELAY_MS: '5000',
+  })
+  checker('HEI Stage 5 relationships', 'historical-exchange-index', 'scripts/verify-ledger-series-stage5-production.mjs', [], {
+    HEI_PRODUCTION_ORIGIN: hei.origin, HEI_STAGE5_PRODUCTION_ATTEMPTS: '3', HEI_STAGE5_PRODUCTION_DELAY_MS: '5000', HEI_STAGE5_PRODUCTION_TIMEOUT_MS: String(timeoutMs),
+  })
+
+  const mag = REVIEW['minted-and-gone']
+  checker('MAG native exact reviewed deployment', 'minted-and-gone', 'scripts/check-phase5-production.mjs', [mag.production_revision], {
+    MAG_PRODUCTION_ORIGIN: mag.origin, MAG_PRODUCTION_VERIFY_ATTEMPTS: '3', MAG_PRODUCTION_VERIFY_DELAY_MS: '5000',
+  })
+
+  const sog = REVIEW['stable-or-gone']
+  checker('SOG exact commit + canonical hash', 'stable-or-gone', 'scripts/check-production-provenance.mjs', [], {
+    SOG_BASE_URL: sog.origin, SOG_EXPECTED_COMMIT: sog.production_revision, SOG_SMOKE_ATTEMPTS: '3', SOG_SMOKE_DELAY_MS: '5000',
+  })
+  checker('SOG Stage 5 relationships', 'stable-or-gone', 'scripts/verify-stage5-production.mjs', [], {
+    SOG_PRODUCTION_ORIGIN: sog.origin, SOG_STAGE5_PRODUCTION_ATTEMPTS: '3', SOG_STAGE5_PRODUCTION_DELAY_MS: '5000',
+  })
+
+  const cya = REVIEW['crypto-yield-archive']
+  checker('CYA reviewed corpus-derived production equality', 'crypto-yield-archive', 'scripts/check-production.mjs', [], {
+    CYA_BASE_URL: cya.origin, CYA_EXPECTED_COMMIT: cya.production_revision, CYA_SMOKE_ATTEMPTS: '3', CYA_SMOKE_DELAY_MS: '5000',
+  })
+
+  const bir = REVIEW['bridge-incident-registry']
+  checker('BIR exact canonical-content production equality', 'bridge-incident-registry', 'scripts/verify-production.mjs', [], {
+    PUBLIC_SITE_ORIGIN: bir.origin, BIR_PUBLICATION_ATTEMPTS: '3', BIR_PUBLICATION_DELAY_MS: '5000', BIR_PRODUCTION_TIMEOUT_MS: String(timeoutMs),
+  }, 300000)
+  checker('BIR Stage 5 relationships', 'bridge-incident-registry', 'scripts/verify-production-series-relationships.mjs', [], {
+    PUBLIC_SITE_ORIGIN: bir.origin, BIR_PRODUCTION_TIMEOUT_MS: String(timeoutMs), BIR_RECORD_JSON_CONCURRENCY: String(concurrency),
+  })
+
+  const wlr = REVIEW['cryptocurrency-wallet-lifecycle-registry']
+  checker('WLR Stage 5 relationships', 'cryptocurrency-wallet-lifecycle-registry', 'scripts/verify-stage5-production.mjs', [], {
+    WLR_PRODUCTION_ORIGIN: wlr.origin, WLR_PRODUCTION_ATTEMPTS: '3', WLR_PRODUCTION_DELAY_MS: '5000', WLR_PRODUCTION_TIMEOUT_MS: String(timeoutMs),
+  })
+
+  const ai = REVIEW['ai-tools-history-archive']
+  checker('AI Tools exact Series reviewed build', 'ai-tools-history-archive', 'scripts/check-series-origin.mjs', [], {
+    SERIES_ORIGIN: ai.origin, SERIES_EXPECTED_COMMIT: ai.production_revision, SERIES_VERIFY_ATTEMPTS: '3', SERIES_VERIFY_INTERVAL_MS: '5000',
+  })
+
+  const api = REVIEW['api-deprecation-archive']
+  checker('API native deterministic data revision', 'api-deprecation-archive', 'scripts/check-machine-origin.mjs', [], {
+    API_DEP_ORIGIN: api.origin, API_DEP_VERIFY_ATTEMPTS: '3', API_DEP_VERIFY_INTERVAL_MS: '5000',
+  })
+  checker('API Series deterministic data revision', 'api-deprecation-archive', 'scripts/check-series-origin.mjs', [], {
+    SERIES_ORIGIN: api.origin, SERIES_VERIFY_ATTEMPTS: '3', SERIES_VERIFY_INTERVAL_MS: '5000',
+  })
+}
+
+async function mapLimit(items, limit, fn) {
+  const out = new Array(items.length); let next = 0
+  async function worker() { while (true) { const i = next++; if (i >= items.length) return; out[i] = await fn(items[i], i) } }
+  await Promise.all(Array.from({ length: Math.min(limit, Math.max(1, items.length)) }, worker))
+  return out
+}
+
+function projectMag(dossier) {
+  const m = dossier.marketplace ?? {}
+  const r = dossier.relationships ?? {}
+  return {
+    status: m.status ?? null, category: m.category ?? null, marketplace_scope: m.marketplace_scope ?? null,
+    chain_scope: m.chain_scope ?? [], frontend_status: m.frontend_status ?? null, contract_status: m.contract_status ?? null,
+    asset_status: m.asset_status ?? null, closure_reason: m.closure_reason ?? null, review_status: m.review_status ?? null,
+    record_quality_flags: m.record_quality_flags ?? [], predecessor_marketplace: r.predecessor_marketplace ?? null,
+    successor_marketplace: r.successor_marketplace ?? null,
+  }
+}
+function projectAi(d) {
+  const r = d.record ?? {}
+  return {
+    status: r.status ?? null, entity_type: r.entity_type ?? null, operator: r.operator ?? null,
+    confidence: r.confidence ?? null, last_reviewed_at: r.last_reviewed_at ?? null,
+  }
+}
+function projectApi(d) {
+  const e = d.entity ?? {}
+  return {
+    status: e.status ?? null, deprecation_stage: e.deprecation_stage ?? null, deadline_status: e.deadline_status ?? null,
+    still_usable: e.still_usable ?? null, action_required: e.action_required ?? null, replacement: e.replacement ?? null,
+    replacement_type: e.replacement_type ?? null,
+  }
+}
+function projectWlr(d, nativeType) {
+  if (nativeType === 'wlr.wallet-record.v1') {
+    const e = d.entity ?? {}
+    return {
+      status: e.status ?? null, wallet_type: e.wallet_type ?? null, custody_model: e.custody_model ?? null,
+      open_source_status: e.open_source_status ?? null, current_vendor: e.current_vendor ?? null,
+      website_status: e.website_status ?? null, confidence: e.confidence ?? null,
+      product_ids: (d.products ?? []).map((p) => p.id),
     }
   }
-  await Promise.all(Array.from({ length: Math.min(limit, Math.max(items.length, 1)) }, () => runner()))
-  return output
+  const p = d.product ?? {}
+  return {
+    status: p.status ?? null,
+    parent_entity: d.entity ?? null,
+    launch_date: p.launch_date ?? null, launch_date_precision: p.launch_date_precision ?? null,
+    product_type: p.product_type ?? null, support_status: p.support_status ?? null, sales_status: p.sales_status ?? null,
+    predecessor_product_id: p.predecessor_product_id ?? null, successor_product_id: p.successor_product_id ?? null,
+    confidence: p.confidence ?? null,
+  }
+}
+
+async function verifyEnvelopeProjection(id, row, envelope, native) {
+  assert(envelope.object_type === 'record_envelope' && envelope.registry_id === id, `${id}/${row.slug}: envelope identity mismatch`)
+  assert(envelope.global_record_key === row.global_record_key, `${id}/${row.slug}: global key mismatch`)
+  assert(Array.isArray(envelope.relationships) && envelope.relationships.length === 0, `${id}/${row.slug}: typed relationships leaked into envelope`)
+  switch (id) {
+    case 'historical-exchange-index':
+      assertSame(envelope.current_state?.native?.bundle, native, `${id}/${row.slug} native bundle`)
+      assertSame(envelope.events?.records ?? [], native.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    case 'minted-and-gone':
+      assertSame(envelope.current_state?.native, projectMag(native), `${id}/${row.slug} native projection`)
+      assertSame(envelope.events?.records ?? [], native.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    case 'stable-or-gone':
+      assertSame(envelope.current_state?.native, { record: native.record, related: native.related, record_counts: native.record_counts }, `${id}/${row.slug} native projection`)
+      assertSame(envelope.events?.records ?? [], native.related?.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.related?.evidence ?? [], `${id}/${row.slug} evidence`)
+      assertSame(envelope.evidence?.relations ?? [], native.related?.evidence_relations ?? [], `${id}/${row.slug} evidence relations`)
+      break
+    case 'crypto-yield-archive':
+      assertSame(envelope.current_state?.native?.record, native.record, `${id}/${row.slug} native record`)
+      assertSame(envelope.current_state?.native?.supporting_records, native.supporting_records, `${id}/${row.slug} supporting records`)
+      assertSame(envelope.current_state?.native?.related_record_counts, native.related_record_counts, `${id}/${row.slug} related counts`)
+      assertSame(envelope.events?.records ?? [], native.supporting_records?.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.supporting_records?.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    case 'bridge-incident-registry': {
+      const expectedNative = row.native_record_type === 'bridge'
+        ? { record: native.record, related_incident_ids: (native.related?.incidents ?? []).map((incident) => incident.id) }
+        : {
+            record: native.record,
+            parent_bridge: native.bridge ? { id: native.bridge.id, slug: native.bridge.slug, canonical_name: native.bridge.canonical_name, status: native.bridge.status } : null,
+          }
+      assertSame(envelope.current_state?.native, expectedNative, `${id}/${row.slug} native projection`)
+      assertSame(envelope.events?.records ?? [], native.related?.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.related?.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    }
+    case 'cryptocurrency-wallet-lifecycle-registry':
+      assertSame(envelope.current_state?.native, projectWlr(native, row.native_record_type), `${id}/${row.slug} native projection`)
+      assertSame(envelope.events?.records ?? [], native.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    case 'ai-tools-history-archive':
+      assertSame(envelope.current_state?.native, projectAi(native), `${id}/${row.slug} native projection`)
+      assertSame(envelope.events?.records ?? [], native.record?.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.record?.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    case 'api-deprecation-archive':
+      assertSame(envelope.current_state?.native, projectApi(native), `${id}/${row.slug} native projection`)
+      assertSame(envelope.events?.records ?? [], native.events ?? [], `${id}/${row.slug} events`)
+      assertSame(envelope.evidence?.records ?? [], native.evidence ?? [], `${id}/${row.slug} evidence`)
+      break
+    default: throw new Error(`missing projection verifier for ${id}`)
+  }
+}
+
+async function verifyWlrCanonical(review) {
+  for (const name of ['entities.json','products.json','events.json','evidence.json']) {
+    const expected = readJson(path.join(review.local, 'data', name))
+    const actual = await live(review, `/data/${name}`, `WLR ${name}`)
+    assertSame(actual, expected, `WLR reviewed canonical ${name}`)
+  }
+}
+
+async function verifyCyaDerivedCount(review, descriptor, index) {
+  const files = fs.readdirSync(path.join(review.local, 'data')).filter((name) => name === 'platforms.json' || /^platforms-batch-.*\.json$/.test(name)).sort()
+  const count = files.flatMap((name) => readJson(path.join(review.local, 'data', name))).length
+  assert(count > 0, 'CYA reviewed canonical platform count must be positive')
+  assert(descriptor.record_counts?.primary_records === count, `CYA descriptor primary_records ${descriptor.record_counts?.primary_records} != reviewed corpus ${count}`)
+  assert(index.record_count === count, `CYA Series index ${index.record_count} != reviewed corpus ${count}`)
+  return count
+}
+
+const liveDescriptors = new Map()
+let totalRelationships = 0
+let crossRelationships = 0
+
+async function verifyRegistry(id, review) {
+  const started = Date.now()
+  const [descriptor, index] = await Promise.all([
+    live(review, '/data/series/registry.json', `${id} descriptor`),
+    live(review, '/data/series/index.json', `${id} index`),
+  ])
+  assert(descriptor.object_type === 'registry_descriptor' && descriptor.registry?.id === id, `${id}: descriptor identity mismatch`)
+  assert(descriptor.canonical_only === true && index.canonical_only === true, `${id}: canonical boundary mismatch`)
+  const rows = Array.isArray(index.records) ? index.records : []
+  assert(rows.length === index.record_count, `${id}: index count mismatch`)
+  assert(descriptor.record_counts?.primary_records === index.record_count, `${id}: descriptor/index primary count mismatch`)
+
+  if (id === 'crypto-yield-archive') await verifyCyaDerivedCount(review, descriptor, index)
+  if (id === 'cryptocurrency-wallet-lifecycle-registry') await verifyWlrCanonical(review)
+  if (id === 'ai-tools-history-archive') {
+    const version = await live(review, '/version.json', 'AI version')
+    assert(version.build_commit === review.production_revision, `AI native build_commit ${version.build_commit} != reviewed ${review.production_revision}`)
+  }
+
+  await mapLimit(rows, concurrency, async (row) => {
+    const envelope = await live(review, urlPath(row.machine_url), `${id}/${row.slug} envelope`)
+    const nativeUrl = envelope.urls?.native_machine || row.native_machine_url
+    assert(typeof nativeUrl === 'string' && nativeUrl.startsWith(review.origin), `${id}/${row.slug}: native machine URL missing/outside origin`)
+    const native = await live(review, urlPath(nativeUrl), `${id}/${row.slug} native`)
+    await verifyEnvelopeProjection(id, row, envelope, native)
+  })
+
+  const expected = expectedRelationships[id]
+  const observed = Number(descriptor.record_counts?.relationships ?? 0)
+  assert(observed === expected, `${id}: relationship count ${observed} != ${expected}`)
+  if (expected > 0) {
+    assert(descriptor.routes?.relationships === '/data/series/relationships.json', `${id}: relationships route mismatch`)
+    const relationships = await live(review, '/data/series/relationships.json', `${id} relationships`)
+    assert(Array.isArray(relationships) && relationships.length === expected, `${id}: relationship transport count mismatch`)
+    for (const relation of relationships) {
+      assert(relation.object_type === 'relationship_record' && relation.direction === 'directed', `${id}: relationship contract mismatch`)
+      const source = endpointKey(relation.source); const target = endpointKey(relation.target)
+      assert(relation.source?.registry_id === id && relation.target?.registry_id === id, `${id}: cross-registry relationship observed`)
+      assert(relation.id === relationshipId(relation.relation_type, source, target), `${id}: deterministic relationship ID mismatch`)
+      if (relation.source?.registry_id !== relation.target?.registry_id) crossRelationships += 1
+    }
+    if (id === 'minted-and-gone') {
+      const localAuthority = readJson(path.join(review.local, 'config', 'ledger-series-phase9-stage5-mag-local-authority.json'))
+      const expectedSet = new Set(localAuthority.finite_allowlist.map(([type, source, target]) => `${type}\n${source}\n${target}`))
+      const actualSet = new Set(relationships.map((r) => `${r.relation_type}\n${endpointKey(r.source)}\n${endpointKey(r.target)}`))
+      assert(expectedSet.size === 17 && actualSet.size === 17 && [...expectedSet].every((x) => actualSet.has(x)), 'MAG relationship set != reviewed allowlist')
+    }
+  }
+  totalRelationships += observed
+  liveDescriptors.set(id, descriptor)
+  report.registries.push({ registry_id: id, origin: review.origin, reviewed_execution_main: review.repo_main, production_revision: review.production_revision, primary_records: index.record_count, relationships: observed, envelopes_verified: rows.length, duration_ms: Date.now() - started, status: 'PASS' })
 }
 
 function normalizeDescriptor(descriptorUrl, snapshot) {
@@ -105,303 +392,35 @@ function normalizeDescriptor(descriptorUrl, snapshot) {
   }
 }
 
-const perRegistry = {
-  'historical-exchange-index': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/entities.json', '/data/events.json', '/data/evidence.json'] },
-  'minted-and-gone': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/marketplaces.json'] },
-  'stable-or-gone': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json'] },
-  'crypto-yield-archive': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json'] },
-  'bridge-incident-registry': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/bridges.json', '/data/incidents.json', '/data/events.json', '/data/evidence.json'] },
-  'cryptocurrency-wallet-lifecycle-registry': { source_prefix: 'public', native_routes: ['/version.json', '/data/manifest.json', '/data/wallet-index.json', '/data/product-index.json'] },
-  'ai-tools-history-archive': { source_prefix: 'public', native_routes: ['/version.json', '/data/records/index.json'] },
-  'api-deprecation-archive': { source_prefix: '', native_routes: ['/version.json', '/data/machine/manifest.json', '/data/machine/index.json'] },
-}
-
-assert(authority.authority_id === 'hei-ledger-series-phase9-stage6-production-equality-2026-08-21-v2', 'unexpected Stage 6 authority id')
-assert(authority.reviewed_repository_baselines?.length === 8, 'Stage 6 authority must contain exactly eight registries')
-
-const registries = authority.reviewed_repository_baselines.map((entry) => ({
-  ...entry,
-  audit_main: entry.reviewed_main,
-  reviewed_main: executionMainOverride[entry.registry_id] ?? entry.reviewed_main,
-  ...perRegistry[entry.registry_id],
-  expected_relationships: authority.frozen_stage5_relationship_counts[entry.registry_id] ?? 0,
-}))
-
-const report = {
-  schema_version: '1.0.0',
-  phase: 9,
-  stage: 6,
-  authority_id: authority.authority_id,
-  execution_kind: 'read_only_cross_registry_production_equality',
-  started_at: new Date().toISOString(),
-  github_workflow_sha: githubSha,
-  repository_preflight: [],
-  registries: [],
-  central_descriptor: null,
-  stage5_relationships: null,
-  overall: 'RUNNING',
-}
-
-function writeReport() {
-  fs.mkdirSync(path.dirname(resultPath), { recursive: true })
-  fs.writeFileSync(resultPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
-}
-
-async function production(registry, route, label = route) {
-  return fetchJson(productionUrl(registry.origin, route), `${registry.registry_id} ${label}`)
-}
-
-async function reviewed(registry, route, label = route) {
-  const source = rawPath(registry.source_prefix, route)
-  return fetchJson(rawUrl(registry.repository, registry.reviewed_main, source), `${registry.registry_id} reviewed ${label}`)
-}
-
-async function readMain(registry) {
-  const branch = await fetchJson(`https://api.github.com/repos/${registry.repository}/branches/main`, `${registry.registry_id} GitHub main`, true)
-  return branch?.commit?.sha ?? null
-}
-
-async function preflight() {
-  const failures = []
-  for (const registry of registries) {
-    try {
-      const observed = await readMain(registry)
-      if (registry.registry_id === 'historical-exchange-index') {
-        assert(githubSha, 'HEI execution requires GITHUB_SHA')
-        assert(observed === githubSha, `HEI main moved after workflow checkout: expected ${githubSha}, observed ${observed}`)
-      } else {
-        assert(observed === registry.reviewed_main, `main advanced beyond reviewed baseline ${registry.reviewed_main}: observed ${observed}`)
-      }
-      report.repository_preflight.push({ registry_id: registry.registry_id, audit_main: registry.audit_main, reviewed_main: registry.reviewed_main, observed_main: observed, status: 'PASS' })
-    } catch (error) {
-      failures.push(`${registry.registry_id}: ${error.message}`)
-      report.repository_preflight.push({ registry_id: registry.registry_id, audit_main: registry.audit_main, reviewed_main: registry.reviewed_main, status: 'FAIL', error: error.message })
-    }
-  }
-  if (failures.length) throw new Error(`repository preflight failed: ${failures.join(' | ')}`)
-}
-
-async function verifyExactRoute(registry, route) {
-  const [live, expected] = await Promise.all([production(registry, route), reviewed(registry, route)])
-  assertSame(live, expected, `${registry.registry_id} ${route}`)
-  return live
-}
-
-async function verifyNative(registry) {
-  const values = new Map()
-  for (const route of registry.native_routes) values.set(route, await verifyExactRoute(registry, route))
-  return values
-}
-
-async function verifySeries(registry) {
-  const [liveDescriptor, expectedDescriptor, liveIndex, expectedIndex] = await Promise.all([
-    production(registry, '/data/series/registry.json', 'Series descriptor'),
-    reviewed(registry, '/data/series/registry.json', 'Series descriptor'),
-    production(registry, '/data/series/index.json', 'Series index'),
-    reviewed(registry, '/data/series/index.json', 'Series index'),
-  ])
-  assertSame(liveDescriptor, expectedDescriptor, `${registry.registry_id} Series descriptor`)
-  assertSame(liveIndex, expectedIndex, `${registry.registry_id} Series index`)
-  assert(liveDescriptor?.canonical_only === true, 'Series descriptor canonical_only is not true')
-  assert(liveIndex?.canonical_only === true, 'Series index canonical_only is not true')
-
-  const relationshipCount = Number(liveDescriptor?.record_counts?.relationships ?? 0)
-  assert(relationshipCount === registry.expected_relationships, `relationship count expected ${registry.expected_relationships}, observed ${relationshipCount}`)
-
-  let relationships = []
-  if (registry.expected_relationships > 0) {
-    assert(liveDescriptor?.routes?.relationships === '/data/series/relationships.json', 'unexpected relationships route')
-    const [live, expected] = await Promise.all([
-      production(registry, '/data/series/relationships.json', 'Series relationships'),
-      reviewed(registry, '/data/series/relationships.json', 'Series relationships'),
-    ])
-    assertSame(live, expected, `${registry.registry_id} Series relationships`)
-    assert(Array.isArray(live) && live.length === registry.expected_relationships, 'relationship transport count mismatch')
-    for (const relationship of live) {
-      assert(relationship?.source?.registry_id === registry.registry_id, 'relationship source escaped registry boundary')
-      assert(relationship?.target?.registry_id === registry.registry_id, 'cross-registry relationship observed')
-    }
-    relationships = live
-  }
-
-  const rows = Array.isArray(expectedIndex?.records) ? expectedIndex.records : []
-  assert(rows.length === expectedIndex.record_count, 'reviewed Series index record_count mismatch')
-  const envelopeResults = await mapLimit(rows, concurrency, async (row) => {
-    const machinePath = new URL(row.machine_url).pathname
-    const [liveEnvelope, expectedEnvelope] = await Promise.all([
-      production(registry, machinePath, `Series envelope ${row.global_record_key}`),
-      reviewed(registry, machinePath, `Series envelope ${row.global_record_key}`),
-    ])
-    assertSame(liveEnvelope, expectedEnvelope, `${registry.registry_id} Series envelope ${row.global_record_key}`)
-    assert(liveEnvelope.global_record_key === row.global_record_key, `Series envelope global key mismatch ${row.global_record_key}`)
-    assert(Array.isArray(liveEnvelope.relationships) && liveEnvelope.relationships.length === 0, `record-envelope relationships must remain empty ${row.global_record_key}`)
-
-    let nativePath = null
-    if (typeof expectedEnvelope?.urls?.native_machine === 'string') {
-      nativePath = new URL(expectedEnvelope.urls.native_machine, registry.origin).pathname
-      const [liveNative, expectedNative] = await Promise.all([
-        production(registry, nativePath, `native dossier ${row.global_record_key}`),
-        reviewed(registry, nativePath, `native dossier ${row.global_record_key}`),
-      ])
-      assertSame(liveNative, expectedNative, `${registry.registry_id} native dossier ${row.global_record_key}`)
-    }
-    return nativePath
-  })
-
-  return {
-    descriptor: liveDescriptor,
-    index: liveIndex,
-    relationships,
-    envelope_count: rows.length,
-    native_dossier_count: envelopeResults.filter(Boolean).length,
-  }
-}
-
-function verifyRevision(registry, native, series) {
-  const version = native.get('/version.json')
-  const manifest = native.get('/data/manifest.json') ?? native.get('/data/machine/manifest.json')
-  switch (registry.registry_id) {
-    case 'historical-exchange-index':
-      assert(version?.build?.commit === registry.reviewed_main, `HEI native build.commit expected ${registry.reviewed_main}, observed ${version?.build?.commit}`)
-      assert(series.descriptor?.verification?.build?.commit === registry.reviewed_main, 'HEI Series descriptor build commit mismatch')
-      assert(series.index?.verification?.build?.commit === registry.reviewed_main, 'HEI Series index build commit mismatch')
-      break
-    case 'minted-and-gone':
-      assert(series.descriptor?.verification?.build_commit === registry.reviewed_main, 'MAG descriptor build_commit mismatch')
-      assert(series.index?.build_commit === registry.reviewed_main, 'MAG index build_commit mismatch')
-      break
-    case 'stable-or-gone':
-      assert(series.descriptor?.verification?.build?.commit === registry.reviewed_main, 'SOG descriptor build commit mismatch')
-      assert(typeof series.descriptor?.verification?.build?.canonical_data_hash === 'string', 'SOG canonical_data_hash missing')
-      if (manifest?.build?.canonical_data_hash) assert(series.descriptor.verification.build.canonical_data_hash === manifest.build.canonical_data_hash, 'SOG Series/native canonical_data_hash mismatch')
-      break
-    case 'crypto-yield-archive':
-      assert(manifest?.build?.commit === registry.reviewed_main, 'CYA native manifest build commit mismatch')
-      assert(series.descriptor?.verification?.build?.commit === registry.reviewed_main, 'CYA descriptor build commit mismatch')
-      assertSame(series.descriptor.verification.build, manifest.build, 'CYA Series/native build object')
-      break
-    case 'bridge-incident-registry':
-      assert(!series.descriptor?.verification?.build_commit, 'BIR must not invent build_commit')
-      assert(!series.descriptor?.verification?.data_revision, 'BIR must not invent data_revision')
-      break
-    case 'cryptocurrency-wallet-lifecycle-registry':
-      assert(!('build_commit' in (series.descriptor?.verification ?? {})), 'WLR must not invent build_commit')
-      assert(series.descriptor?.verification?.last_verified_at === manifest?.last_verified_at, 'WLR last_verified_at mismatch')
-      break
-    case 'ai-tools-history-archive':
-      assert(version?.build_commit === registry.reviewed_main, 'AI Tools native build_commit mismatch')
-      assert(series.descriptor?.verification?.build_commit === registry.reviewed_main, 'AI Tools descriptor build_commit mismatch')
-      assert(series.index?.build_commit === registry.reviewed_main, 'AI Tools index build_commit mismatch')
-      break
-    case 'api-deprecation-archive': {
-      const revision = version?.data_revision
-      assert(typeof revision === 'string' && revision.length > 0, 'API Deprecation data_revision missing')
-      assert(manifest?.data_revision === revision, 'API Deprecation native manifest data_revision mismatch')
-      assert(series.descriptor?.verification?.data_revision === revision, 'API Deprecation Series descriptor data_revision mismatch')
-      assert(series.index?.data_revision === revision || series.index?.verification?.data_revision === revision, 'API Deprecation Series index data_revision mismatch')
-      break
-    }
-    default:
-      throw new Error(`missing revision verifier for ${registry.registry_id}`)
-  }
-}
-
-const liveDescriptors = new Map()
-const observedRelationshipCounts = new Map()
-
-async function verifyRegistry(registry) {
-  const row = { registry_id: registry.registry_id, repository: registry.repository, audit_main: registry.audit_main, reviewed_main: registry.reviewed_main, origin: registry.origin, verification_mode: registry.verification_mode, status: 'RUNNING' }
-  const started = Date.now()
-  report.registries.push(row)
-  try {
-    const native = await verifyNative(registry)
-    const series = await verifySeries(registry)
-    liveDescriptors.set(registry.registry_id, series.descriptor)
-    observedRelationshipCounts.set(registry.registry_id, series.relationships.length)
-    verifyRevision(registry, native, series)
-    row.status = 'PASS'
-    row.series_record_count = series.index.record_count
-    row.series_envelope_count = series.envelope_count
-    row.native_dossier_count = series.native_dossier_count
-    row.relationship_count = series.relationships.length
-  } catch (error) {
-    row.status = 'FAIL'
-    row.error = error.message
-    try {
-      if (!liveDescriptors.has(registry.registry_id)) liveDescriptors.set(registry.registry_id, await production(registry, '/data/series/registry.json', 'Series descriptor for central check'))
-    } catch {}
-  }
-  row.duration_ms = Date.now() - started
-}
-
-async function verifyCentral() {
-  const result = { status: 'RUNNING', origin: 'https://hei.badjoke-lab.com', route: '/data/series/registries.json' }
-  report.central_descriptor = result
-  try {
-    const central = await fetchJson(productionUrl('https://hei.badjoke-lab.com', '/data/series/registries.json'), 'HEI central registry index')
-    assert(central?.series_schema_version === '1.0.0', 'central Series schema mismatch')
-    assert(central?.object_type === 'registry_index', 'central object type mismatch')
-    assert(central?.semantic_owner === 'badjoke-lab-ledger-series', 'central semantic owner mismatch')
-    assert(central?.registry_count === 8 && Array.isArray(central?.registries) && central.registries.length === 8, 'central registry count mismatch')
-    const centralById = new Map(central.registries.map((entry) => [entry?.registry?.id, entry]))
-    for (const registry of registries) {
-      const liveDescriptor = liveDescriptors.get(registry.registry_id)
-      assert(liveDescriptor, `${registry.registry_id}: live descriptor unavailable`)
-      const centralEntry = centralById.get(registry.registry_id)
-      assert(centralEntry, `${registry.registry_id}: missing from central index`)
-      const expected = normalizeDescriptor(`${registry.origin.replace(/\/$/, '')}/data/series/registry.json`, liveDescriptor)
-      assertSame(centralEntry, expected, `${registry.registry_id} central descriptor`)
-    }
-    result.status = 'PASS'
-    result.collector_run = central?.snapshot?.collector_run ?? null
-    result.collected_at = central?.snapshot?.collected_at ?? null
-  } catch (error) {
-    result.status = 'FAIL'
-    result.error = error.message
-  }
-}
-
-function finalizeRelationships() {
-  const expectedByRegistry = Object.fromEntries(registries.map((registry) => [registry.registry_id, registry.expected_relationships]))
-  const observedByRegistry = Object.fromEntries(registries.map((registry) => [registry.registry_id, observedRelationshipCounts.get(registry.registry_id) ?? null]))
-  const allKnown = observedRelationshipCounts.size === registries.length
-  const observedTotal = [...observedRelationshipCounts.values()].reduce((sum, count) => sum + count, 0)
-  report.stage5_relationships = {
-    expected_by_registry: expectedByRegistry,
-    observed_by_registry: observedByRegistry,
-    expected_total: authority.frozen_stage5_relationship_counts.total,
-    observed_total: allKnown ? observedTotal : null,
-    expected_cross_registry: authority.frozen_stage5_relationship_counts.cross_registry,
-    observed_cross_registry: 0,
-    status: allKnown && observedTotal === authority.frozen_stage5_relationship_counts.total ? 'PASS' : 'FAIL',
-  }
+async function verifyCentralIndex() {
+  const hei = REVIEW['historical-exchange-index']
+  const central = await live(hei, '/data/series/registries.json', 'HEI central registry index')
+  assert(central.object_type === 'registry_index' && central.registry_count === 8, 'central registry index identity/count mismatch')
+  assert(Array.isArray(central.registries) && central.registries.length === 8, 'central registry array length mismatch')
+  const expected = Object.entries(REVIEW).map(([id, review]) => normalizeDescriptor(`${review.origin.replace(/\/$/, '')}/data/series/registry.json`, liveDescriptors.get(id))).sort((a, b) => a.registry.id.localeCompare(b.registry.id))
+  const actual = [...central.registries].sort((a, b) => a.registry.id.localeCompare(b.registry.id))
+  assertSame(actual, expected, 'central registry index vs accepted live descriptors')
+  report.central_descriptor = { status: 'PASS', registry_count: 8, source_commit: central.verification?.source_commit ?? null, collector_run: central.source_lock?.collector_run ?? null }
 }
 
 try {
+  writeReport()
   await preflight()
+  runReviewedCheckers()
+  for (const [id, review] of Object.entries(REVIEW)) await verifyRegistry(id, review)
+  assert(totalRelationships === 244, `Stage 5 relationship total ${totalRelationships} != 244`)
+  assert(crossRelationships === 0, `cross-registry relationship count ${crossRelationships} != 0`)
+  report.stage5_relationships = { expected: 244, observed: totalRelationships, cross_registry_observed: crossRelationships, status: 'PASS' }
+  await verifyCentralIndex()
+  report.overall = 'PASS'
+  report.completed_at = new Date().toISOString()
+  writeReport()
+  console.log(`Stage 6 production equality PASS: 8 registries, ${totalRelationships} reviewed relationships, central descriptor equality.`)
 } catch (error) {
   report.overall = 'FAIL'
-  report.preflight_error = error.message
-  report.finished_at = new Date().toISOString()
+  report.completed_at = new Date().toISOString()
+  report.failure = error instanceof Error ? error.message : String(error)
   writeReport()
-  console.error(error.message)
+  console.error(`Stage 6 production equality FAIL: ${report.failure}`)
   process.exit(1)
 }
-
-for (const registry of registries) await verifyRegistry(registry)
-await verifyCentral()
-finalizeRelationships()
-
-report.overall = report.registries.every((row) => row.status === 'PASS') && report.central_descriptor?.status === 'PASS' && report.stage5_relationships?.status === 'PASS' ? 'PASS' : 'FAIL'
-report.finished_at = new Date().toISOString()
-writeReport()
-
-console.log(JSON.stringify({
-  overall: report.overall,
-  registries: report.registries.map((row) => ({ registry_id: row.registry_id, status: row.status, error: row.error ?? null })),
-  central_descriptor: report.central_descriptor,
-  stage5_relationships: report.stage5_relationships,
-  result_path: path.relative(root, resultPath),
-}, null, 2))
-
-if (report.overall !== 'PASS') process.exit(1)


### PR DESCRIPTION
Supersedes the merged #807 execution implementation without expanding Stage 6 authority.

Changes remain limited to three HEI coordination files:
- corrected read-only Stage 6 verifier;
- one-shot post-merge workflow with exact reviewed vertical checkouts;
- superseding pre-execution baseline review.

Key correction: do not fetch build-generated `public/*` artifacts from `raw.githubusercontent.com`. Existing reviewed production checkers are run from exact reviewed checkouts, then every live Series envelope is compared against its live native dossier using the existing adapter projection. CYA count is derived from reviewed `data/platforms*.json`; WLR canonical aggregates are compared to reviewed canonical JSON; Stage 5 remains exactly 244 relationships with zero cross-registry relationships; HEI central index must equal all eight accepted live descriptors.

Post-review drift: HEI PR #812 (`Correct EXMO wind-down lifecycle status`) merged while #809 was open. It changes only `records/exchanges/exmo.json`; exact head `7eacf5c0...` passed all 19 observed PR workflows including CI, Records validation, Machine/public consistency, Ledger Series Adapter, Project network integrity and Count semantics. The Stage 6 execution baseline therefore adopts HEI merge `3972c817...` as the exact runtime revision.

To avoid repeating the previously observed deployment-race false failure, the one-shot workflow applies an exact fail-closed workspace-only substitution before execution: HEI `repo_main` / `production_revision` become `3972c817...`, and HEI deployment convergence expands from 3×5s to at most 40×15s. This does not write the repository or production.

PR execution remains syntax/authority-boundary only. The network job is gated to the single main push whose commit message begins `Phase 9 Stage 6 corrected verifier one-shot`.

No production mutation, vertical repository mutation, Cloudflare/DNS change, descriptor resync, or remediation is authorized here. Any Stage 6 failure stops and requires separate authority.