### PR TITLE
Add post-D-1000 BX67 Korean Hanbitco lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX67_2026-08-23.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX67_2026-08-23.md
@@ -1,0 +1,48 @@
+# HEI post-D-1000 growth audit — BX67 Hanbitco
+
+Date: 2026-08-23
+
+## Scope
+
+BX67 adds one historical South Korean exchange record after revisiting a candidate previously deferred for insufficient terminal-state evidence.
+
+## Canonical decision
+
+- Hanbitco / 한빗코 -> `hei_ex_001163`
+- type: `cex`
+- origin: South Korea
+- status: `dead`
+- death reason: `voluntary_shutdown`
+- launch: year-level 2018 marker normalized to `2018-01-01`
+- terminal exchange date: `2024-05-16`, the reviewed trading-support end date
+
+## Evidence review
+
+Reviewed evidence now resolves the prior uncertainty:
+
+1. Hanbitco's official company social profile says the company was founded in 2017 and that the exchange launched in 2018, and identifies `hanbitco.com` as the historical website.
+2. The Republic of Korea Financial Services Commission lists Hanbitco among exchanges that formally announced business closure and places the closure in May 2024.
+3. Bithumb's 2024-05-09 notice identifies Hanbitco's exchange-service termination as the reason for stopping high-value transfers to the exchange.
+4. Flybit's contemporaneous notice reproduces the Hanbitco shutdown schedule: new registrations and deposits ended 2024-05-09, trading support ended 2024-05-16, and withdrawal support continued through 2024-07-16.
+
+The post-trading withdrawal period is treated as orderly asset-return run-off, not continued exchange operation.
+
+## Identity boundary
+
+A separate current platform at `hanbitco.io` describes itself as a Europe-founded exchange launched in 2022. No reviewed evidence establishes continuity, acquisition, rebrand, or migration from the South Korean Hanbitco. BX67 therefore does not merge the identities and does not create a lineage edge.
+
+## Canonical delta
+
+- entities: +1
+- events: +2
+- evidence: +4
+
+Allocated IDs:
+
+- `hei_ex_001163`
+- `hei_ev_010137`-`hei_ev_010138`
+- `hei_src_012609`-`hei_src_012612`
+
+## Boundaries
+
+BX67 changes reviewed canonical data only. It does not change Cloudflare configuration, monitoring publication behavior, localization breadth, L-2 HOLD, schema contracts, or Ledger Series Phase 9 implementation.

--- a/docs/backlog/consumed/hei_unadded-bx67-hanbitco-korea.md
+++ b/docs/backlog/consumed/hei_unadded-bx67-hanbitco-korea.md
@@ -1,0 +1,19 @@
+# Consumed candidate — BX67 Korean Hanbitco
+
+Date: 2026-08-23
+
+The South Korean Hanbitco candidate was previously deferred because the available backlog evidence did not resolve its terminal state strongly enough. BX67 consumes that deferred identity after regulator and contemporaneous VASP evidence established a formal May 2024 service shutdown.
+
+## Canonical result
+
+- Hanbitco / 한빗코 -> `hei_ex_001163`
+- terminal state `dead`
+- `death_reason: voluntary_shutdown`
+- trading-support end `2024-05-16`
+- withdrawal run-off through `2024-07-16` retained in notes
+
+## Identity safety
+
+The active `hanbitco.io` platform is not treated as the same entity or as a successor. Its own current material describes a Europe-founded 2022 exchange, while the reviewed historical Korean company used `hanbitco.com` and ended exchange service in 2024. No lineage relationship is asserted without evidence.
+
+Permanent canonical identity is represented only by the `hei_ex_*` record; stale discovery/backlog identifiers are not promoted as canonical IDs.

--- a/records/exchanges/hanbitco.json
+++ b/records/exchanges/hanbitco.json
@@ -1,0 +1,120 @@
+{
+  "entity": {
+    "id": "hei_ex_001163",
+    "slug": "hanbitco",
+    "canonical_name": "Hanbitco",
+    "aliases": [
+      "HANBITCO",
+      "한빗코"
+    ],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "voluntary_shutdown",
+    "launch_date": "2018-01-01",
+    "death_date": "2024-05-16",
+    "country_or_origin": "South Korea",
+    "summary": "South Korean centralized cryptocurrency exchange operated by the Hanbitco/PlutusDS organization. The exchange launched in 2018 and ended trading support in May 2024 during an orderly service shutdown, with withdrawal support continuing afterward for a limited run-off period.",
+    "official_url_original": "https://www.hanbitco.com/",
+    "official_domain_original": "hanbitco.com",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://www.hanbitco.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "parent_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-23",
+    "notes": "Hanbitco's official company social profile says the company was founded in 2017 and that the Hanbitco exchange launched in 2018; HEI normalizes the year-level exchange launch to 2018-01-01 because no reviewed source establishes an exact launch day. South Korea's Financial Services Commission identified Hanbitco among exchanges that formally announced business closure and places the closure in May 2024. Contemporaneous Bithumb and Flybit notices citing Hanbitco's own service-end announcement give the operational schedule: new registrations and crypto deposits ended on 2024-05-09, trading support ended on 2024-05-16, and online/offline withdrawal support continued until 2024-07-16. HEI therefore uses the end of trading support as the exchange death date while preserving the later withdrawal-only run-off in notes. A separate current platform at hanbitco.io describes itself as a Europe-founded 2022 exchange; no reviewed evidence establishes it as a successor to the South Korean exchange, so HEI does not merge or link those identities."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010137",
+      "exchange_id": "hei_ex_001163",
+      "event_type": "launched",
+      "event_date": "2018-01-01",
+      "title": "Hanbitco exchange launched in South Korea",
+      "description": "Hanbitco's official company history states that the cryptocurrency exchange launched in 2018.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "Year-level launch marker normalized to 2018-01-01 because the reviewed company source does not provide an exact launch day."
+    },
+    {
+      "id": "hei_ev_010138",
+      "exchange_id": "hei_ex_001163",
+      "event_type": "shutdown_effective",
+      "event_date": "2024-05-16",
+      "title": "Hanbitco ended exchange trading support",
+      "description": "Hanbitco's shutdown schedule ended trading support on 2024-05-16 after new registrations and crypto deposits had stopped on 2024-05-09; withdrawal support remained available through 2024-07-16 as a run-off service.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "dead",
+      "source_count": 3,
+      "sort_order": 2,
+      "notes": "South Korea's Financial Services Commission independently identifies Hanbitco as a formally closed exchange and places its business closure in May 2024. The 2024-05-16 terminal date is the specific trading-support end date reproduced by contemporaneous Korean VASP notices citing Hanbitco's service-termination announcement; later withdrawal support is treated as asset-return run-off rather than continued exchange operation."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012609",
+      "exchange_id": "hei_ex_001163",
+      "event_id": "hei_ev_010137",
+      "source_type": "official_social",
+      "title": "Hanbitco company profile",
+      "url": "https://www.linkedin.com/company/plutusds",
+      "publisher": "Hanbitco / PlutusDS",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.linkedin.com/company/plutusds",
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "launch_date",
+      "notes": "Official company profile describes Hanbitco as founded in 2017 and states that the Hanbitco exchange launched in 2018, while identifying hanbitco.com as the company website."
+    },
+    {
+      "id": "hei_src_012610",
+      "exchange_id": "hei_ex_001163",
+      "event_id": "hei_ev_010138",
+      "source_type": "regulatory_notice",
+      "title": "Response to virtual-asset business closures and suspensions",
+      "url": "https://fsc.go.kr/no010101/82407",
+      "publisher": "Financial Services Commission, Republic of Korea",
+      "published_at": "2024-06-07",
+      "archived_url": "https://web.archive.org/web/*/https://fsc.go.kr/no010101/82407",
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "death_date",
+      "notes": "The Financial Services Commission lists Hanbitco among exchanges that formally announced closure and states that Hanbitco's business ended in May 2024."
+    },
+    {
+      "id": "hei_src_012611",
+      "exchange_id": "hei_ex_001163",
+      "event_id": "hei_ev_010138",
+      "source_type": "official_statement",
+      "title": "Notice on suspension of large virtual-asset withdrawals to Hanbitco following service termination",
+      "url": "https://feed.bithumb.com/notice/1644767",
+      "publisher": "Bithumb",
+      "published_at": "2024-05-09",
+      "archived_url": "https://web.archive.org/web/*/https://feed.bithumb.com/notice/1644767",
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Contemporaneous Korean VASP notice states that Hanbitco was terminating exchange service and attributes the restriction to Hanbitco's own closure announcement."
+    },
+    {
+      "id": "hei_src_012612",
+      "exchange_id": "hei_ex_001163",
+      "event_id": "hei_ev_010138",
+      "source_type": "official_statement",
+      "title": "Hanbitco exchange service termination schedule",
+      "url": "https://flybit.zendesk.com/hc/ko/articles/32239235923993--%EC%A4%91%EC%9A%94-%ED%95%9C%EB%B9%97%EC%BD%94-%EA%B1%B0%EB%9E%98%EC%86%8C-%EC%84%9C%EB%B9%84%EC%8A%A4-%EC%A2%85%EB%A3%8C%EC%97%90-%EB%94%B0%EB%A5%B8-100%EB%A7%8C-%EC%9B%90-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%83%81%EC%9E%90%EC%82%B0-%EC%B6%9C%EA%B8%88-%EC%A4%91%EB%8B%A8-%EC%95%88%EB%82%B4",
+      "publisher": "Flybit",
+      "published_at": "2024-05-09",
+      "archived_url": null,
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Contemporaneous VASP notice reproduces Hanbitco's service-end schedule: registration and crypto deposits ended 2024-05-09, trading support ended 2024-05-16, and online/offline withdrawal support continued through 2024-07-16."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Continues HEI Lane A after merged BX66 by resolving the previously deferred South Korean Hanbitco terminal lifecycle with regulator and contemporaneous exchange evidence.

### Record
- adds `Hanbitco` / `한빗코` as `hei_ex_001163`;
- `type: cex`;
- `country_or_origin: South Korea`;
- terminal `status: dead`;
- `death_reason: voluntary_shutdown`;
- year-level exchange launch normalized to `2018-01-01`;
- terminal exchange date `2024-05-16`, when trading support ended.

### Lifecycle
- `hei_ev_010137`: Hanbitco exchange launch in 2018;
- `hei_ev_010138`: trading support ended 2024-05-16 during orderly shutdown.

Withdrawal support continuing through 2024-07-16 is explicitly preserved as asset-return run-off rather than continued exchange activity.

### Evidence
Adds four reviewed evidence records (`hei_src_012609` through `hei_src_012612`) from Hanbitco's official company profile, the Republic of Korea Financial Services Commission, Bithumb, and Flybit.

### Identity boundary
A separate current platform at `hanbitco.io` describes itself as a Europe-founded 2022 exchange. No reviewed evidence establishes continuity with the South Korean exchange, so this PR neither merges the identities nor creates a lineage edge.

### Delta
`+1 entity / +2 events / +4 evidence`.

### Boundaries
- closes #826;
- preserves L-2 HOLD;
- no monitoring, Cloudflare, localization expansion, schema or Ledger Series Phase 9 mutation.

Closes #826