### PR TITLE
Add post-D-1000 BX68 Hubi inactive lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX68_2026-08-23.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX68_2026-08-23.md
@@ -1,0 +1,39 @@
+# HEI post-D-1000 growth — BX68
+
+Date: 2026-08-23
+Scope: Lane A reviewed canonical growth during L-2 HOLD
+
+## Addition
+
+Hubi is added as a conservative inactive historical centralized exchange record.
+
+Canonical delta:
+
+```text
+Entities: +1
+Events:   +1
+Evidence: +4
+```
+
+## Reviewed facts
+
+- First-party Hubi material shows active exchange operations through March 2020.
+- Cryptowisser recorded `hubi.com` as unreachable on 2021-06-10 and moved Hubi into inactive/dead tracking.
+- CoinMarketCap currently lists Hubi without tracked volume.
+- Coin360 identifies the historical Hubi exchange as Hong Kong based.
+
+## Conservative boundaries
+
+BX68 does not infer:
+
+- an operator-announced shutdown;
+- a shutdown cause;
+- an exact death date;
+- a precise launch date;
+- any lineage relationship with Huobi/HTX.
+
+The 2021-06-10 event is an observed availability-loss marker only. Entity status is `inactive`, with `death_reason` and `death_date` left null.
+
+## Validation rule
+
+Merge only after the complete current pull-request workflow matrix passes on the exact final head. Do not weaken record, lineage, count, URL, localization, machine/public, or project-network checks to make the batch pass.

--- a/docs/backlog/consumed/hei_unadded-bx68-hubi.md
+++ b/docs/backlog/consumed/hei_unadded-bx68-hubi.md
@@ -1,0 +1,27 @@
+# Consumed candidate — BX68 Hubi
+
+Date: 2026-08-23
+
+BX68 revisits the previously deferred Hubi exchange identity after stronger historical status evidence became available.
+
+## Canonical result
+
+- Hubi -> `hei_ex_001164`
+- type: `cex`
+- current historical status: `inactive`
+- death reason: unresolved / null
+- exact terminal date: unresolved / null
+
+## Evidence boundary
+
+First-party Hubi material documents active deposit, trading and withdrawal operations through March 2020. Independent exchange tracking recorded `hubi.com` as unreachable on 2021-06-10, and CoinMarketCap now carries Hubi as an untracked listing.
+
+HEI deliberately does not convert the site-disappearance observation into an operator-announced shutdown, an exact death date, or a shutdown cause. A dated `other` event records only the observed loss of public exchange availability.
+
+## Identity boundary
+
+Hubi is not Huobi/HTX. Similar naming is not treated as lineage or duplicate evidence.
+
+## Launch-date boundary
+
+Secondary sources conflict between an earlier organizational foundation and a 2018 Hubi brand/platform start. No precise canonical launch date is asserted.

--- a/records/exchanges/hubi.json
+++ b/records/exchanges/hubi.json
@@ -99,7 +99,7 @@
       "archived_url": "https://web.archive.org/web/*/https://coin360.com/exchange/hubi",
       "accessed_at": "2026-08-23",
       "reliability": "medium",
-      "claim_scope": "country_or_origin",
+      "claim_scope": "entity",
       "notes": "Coin360 identifies Hubi as a centralized exchange located in Hong Kong and links the historical hubi.com domain. HEI does not rely on its stated 2018 establishment year because other secondary sources describe an earlier organizational foundation."
     }
   ]

--- a/records/exchanges/hubi.json
+++ b/records/exchanges/hubi.json
@@ -1,0 +1,106 @@
+{
+  "entity": {
+    "id": "hei_ex_001164",
+    "slug": "hubi",
+    "canonical_name": "Hubi",
+    "aliases": [
+      "Hubi Exchange",
+      "Hubi Global",
+      "Hubi Exchange Alliance"
+    ],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Hong Kong",
+    "summary": "Historical centralized cryptocurrency exchange associated with the Hubi Exchange Alliance and the hubi.com domain. First-party materials show active trading operations through March 2020; later independent exchange tracking recorded the site as unreachable and the venue is no longer actively tracked.",
+    "official_url_original": "https://www.hubi.com/",
+    "official_domain_original": "hubi.com",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://www.hubi.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-23",
+    "notes": "Hubi is a separate exchange identity from Huobi/HTX despite the similar names. Reviewed first-party Hubi posts show deposits, trading pairs and withdrawals operating in March 2020. Cryptowisser recorded hubi.com as unreachable on 2021-06-10 and marked the exchange inactive/dead, while CoinMarketCap currently presents Hubi as an untracked listing. HEI therefore uses the conservative status `inactive` and does not infer a shutdown announcement, shutdown cause or exact terminal date from disappearance alone. Secondary sources conflict on whether the underlying organization dates to 2016 or the Hubi exchange/brand to 2018, so no launch_date is asserted."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010139",
+      "exchange_id": "hei_ex_001164",
+      "event_type": "other",
+      "event_date": "2021-06-10",
+      "title": "Hubi website was recorded as unreachable",
+      "description": "Independent exchange tracking reported that hubi.com could not be reached and moved Hubi to its inactive/dead exchange tracking set.",
+      "confidence": "medium",
+      "impact_level": "high",
+      "event_status_effect": "inactive",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "This is an observed availability-loss marker, not an asserted operator-announced shutdown date. HEI does not derive a death_date or death_reason from this observation alone."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012613",
+      "exchange_id": "hei_ex_001164",
+      "event_id": null,
+      "source_type": "official_blog",
+      "title": "Token Listing: Hubi will launch ZEN, HNS on March 16",
+      "url": "https://medium.com/@HubiEX/token-listing-hubi-will-launch-zen-hns-on-march-16-48cab3432b60",
+      "publisher": "HubiExchange",
+      "published_at": "2020-03-17",
+      "archived_url": "https://web.archive.org/web/*/https://medium.com/@HubiEX/token-listing-hubi-will-launch-zen-hns-on-march-16-48cab3432b60",
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "First-party Hubi post documents deposit, trading-pair and withdrawal schedules in March 2020 and identifies the Hubi Global Operations Team, supporting active exchange operation at that time."
+    },
+    {
+      "id": "hei_src_012614",
+      "exchange_id": "hei_ex_001164",
+      "event_id": "hei_ev_010139",
+      "source_type": "news_article",
+      "title": "Hubi exchange review and inactive status",
+      "url": "https://www.cryptowisser.com/exchange/hubi/",
+      "publisher": "Cryptowisser",
+      "published_at": "2021-06-10",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/hubi/",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Cryptowisser records that hubi.com was unreachable on 2021-06-10 and says it marked the exchange inactive/dead. HEI uses this only as an availability-loss and inactivity signal, not proof of an operator-announced shutdown cause or exact terminal date."
+    },
+    {
+      "id": "hei_src_012615",
+      "exchange_id": "hei_ex_001164",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Hubi exchange listing",
+      "url": "https://coinmarketcap.com/exchanges/hubi/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/hubi/",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "CoinMarketCap currently presents Hubi as an untracked exchange listing with no tracked volume, supporting conservative inactive treatment while preserving the historical exchange identity."
+    },
+    {
+      "id": "hei_src_012616",
+      "exchange_id": "hei_ex_001164",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Hubi exchange profile",
+      "url": "https://coin360.com/exchange/hubi",
+      "publisher": "Coin360",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coin360.com/exchange/hubi",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "country_or_origin",
+      "notes": "Coin360 identifies Hubi as a centralized exchange located in Hong Kong and links the historical hubi.com domain. HEI does not rely on its stated 2018 establishment year because other secondary sources describe an earlier organizational foundation."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Continues HEI Lane A after merged BX67 by resolving the previously deferred Hubi identity conservatively.

### Record
- adds `Hubi` as `hei_ex_001164`;
- `type: cex`;
- `country_or_origin: Hong Kong`;
- `status: inactive`;
- leaves `death_reason`, `death_date` and `launch_date` null because reviewed evidence does not justify stronger claims.

### Lifecycle
- `hei_ev_010139`: observed loss of public exchange availability on 2021-06-10, modeled as `event_type: other` with `event_status_effect: inactive`.

This event records an independently observed availability-loss marker only. It is not treated as an operator-announced shutdown or exact death date.

### Evidence
Adds four evidence records (`hei_src_012613` through `hei_src_012616`) from first-party Hubi Medium material, Cryptowisser, CoinMarketCap and Coin360.

### Identity boundary
Hubi is distinct from Huobi/HTX. Similar naming does not create a duplicate or lineage relationship.

### Delta
`+1 entity / +1 event / +4 evidence`.

### Boundaries
- closes #829;
- preserves L-2 HOLD;
- no monitoring, Cloudflare, localization expansion, schema or Ledger Series Phase 9 mutation.

Closes #829