### PR TITLE
Add post-D-1000 BX69 HCoin inactive lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX69_2026-08-23.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX69_2026-08-23.md
@@ -1,0 +1,56 @@
+# HEI Post-D-1000 Growth Audit — BX69 HCoin
+
+Date: 2026-08-23  
+Status: REVIEWED / PR PENDING  
+Project: Historical Exchange Index (HEI)
+
+## Scope
+
+BX69 resolves the previously deferred HCoin exchange as a conservative inactive historical CEX record.
+
+## Identity and overlap
+
+- No existing reviewed `HCoin` canonical record was found on current main before allocation.
+- HCoin is modeled independently from similarly named venues.
+- Historical endpoints include `hcoin.com`, `hcoin86.com`, and `hcoin86.io`; the record uses `hcoin86.com` as the historical official-domain anchor because contemporaneous 2019 trading announcements link that endpoint.
+
+## Status decision
+
+HCoin is classified `inactive`, not `dead`.
+
+The evidence supports active exchange functionality in 2019 and an independently observed website-unreachable marker on 2021-11-11. No reviewed operator shutdown notice or exact terminal date has been recovered, so BX69 leaves `death_date` and `death_reason` null.
+
+## Launch boundary
+
+Historical exchange directories consistently place the platform in 2018 but disagree on the exact August day. BX69 therefore leaves `launch_date` null rather than inventing a normalized exact day.
+
+## Seychelles boundary
+
+Historical exchange directories place HCoin in Seychelles. A joint Seychelles Financial Services Authority / Registrar of Companies notice dated 2024-10-25 states that the businesses listed in its Annex 1 were not registered or incorporated in Seychelles; HCOIN is included with legal name unknown.
+
+Accordingly, `country_or_origin: Seychelles` is retained only as historical directory placement. The record explicitly does not claim Seychelles incorporation, VASP registration, licensing, or regulatory approval.
+
+## Lifecycle
+
+- `hei_ev_010140` — 2021-11-11 observed website availability loss, modeled as `event_type: other`, effect `inactive`.
+
+The event is not an operator-announced shutdown event and does not establish an exact death date.
+
+## Evidence
+
+- `hei_src_012617` — CoinCarp historical exchange profile.
+- `hei_src_012618` — contemporaneous Winchain Official announcement documenting HCoin deposit/trading/withdrawal operation in December 2019.
+- `hei_src_012619` — Cryptowisser 2021-11-11 website-unreachable / inactive marker.
+- `hei_src_012620` — Seychelles FSA / Registrar of Companies 2024 caution notice.
+
+## Delta
+
+```text
+Entities: +1
+Events:   +1
+Evidence: +4
+```
+
+## Boundaries
+
+BX69 does not change monitoring, Cloudflare, localization breadth, schema, Language Selection, L-2 HOLD, or Ledger Series Phase 9 implementation.

--- a/docs/backlog/consumed/hei_unadded-bx69-hcoin.md
+++ b/docs/backlog/consumed/hei_unadded-bx69-hcoin.md
@@ -1,0 +1,40 @@
+# Consumed backlog — BX69 HCoin
+
+Date: 2026-08-23
+
+## Candidate
+
+HCoin
+
+## Resolution
+
+Promoted to reviewed canonical bundle as a conservative inactive centralized exchange.
+
+```text
+entity_id: hei_ex_001165
+status: inactive
+death_reason: null
+launch_date: null
+death_date: null
+```
+
+## Evidence decision
+
+The old backlog row was previously deferred because it did not establish a reliable current or terminal state. BX69 adds stronger reviewed context:
+
+- contemporaneous 2019 evidence of deposits, trading and withdrawals on HCoin;
+- a 2021-11-11 independently observed website-unreachable marker;
+- current historical directory entries showing no active tracked market state;
+- a 2024 Seychelles regulator/registrar notice that prevents historical Seychelles placement from being misrepresented as incorporation or licensing.
+
+## Conservative boundaries
+
+No exact launch date is asserted because secondary sources disagree on the exact August 2018 day. No exact shutdown date or cause is asserted because no reviewed operator shutdown notice has been recovered. The 2021 observation is modeled as `other` with inactive effect, not `shutdown_effective`.
+
+## Canonical delta
+
+```text
++1 entity
++1 event
++4 evidence
+```

--- a/records/exchanges/hcoin.json
+++ b/records/exchanges/hcoin.json
@@ -1,0 +1,105 @@
+{
+  "entity": {
+    "id": "hei_ex_001165",
+    "slug": "hcoin",
+    "canonical_name": "HCoin",
+    "aliases": [
+      "HCoin Exchange",
+      "HCOIN"
+    ],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Seychelles",
+    "summary": "Historical centralized cryptocurrency exchange associated with the hcoin.com and hcoin86.com domains. Independent tracking later recorded the exchange website as unreachable and current market directories show no active tracked markets.",
+    "official_url_original": "https://www.hcoin86.com/",
+    "official_domain_original": "hcoin86.com",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://www.hcoin86.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-23",
+    "notes": "Historical exchange directories place HCoin in Seychelles and date the platform to 2018, while contemporaneous project announcements document deposits, trading and withdrawals through hcoin86.com in 2019. HEI does not assert an exact launch date because secondary sources disagree on the day. Cryptowisser recorded the site as unreachable on 2021-11-11 and marked the venue inactive/dead; HEI conservatively uses `inactive` and leaves death_date and death_reason null. A 2024 joint notice from the Seychelles Financial Services Authority and Registrar of Companies listed HCOIN among businesses claiming Seychelles affiliation and stated the listed businesses were not registered or incorporated in Seychelles. Therefore `country_or_origin: Seychelles` reflects historical directory placement only and must not be read as a legal-incorporation, registration, or licensing claim."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010140",
+      "exchange_id": "hei_ex_001165",
+      "event_type": "other",
+      "event_date": "2021-11-11",
+      "title": "HCoin website was recorded as unreachable",
+      "description": "Independent exchange tracking reported that the HCoin website could not be reached and moved the venue to its inactive/dead exchange tracking set.",
+      "confidence": "medium",
+      "impact_level": "high",
+      "event_status_effect": "inactive",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "This is an observed availability-loss marker, not an asserted operator-announced shutdown date. HEI does not derive an exact death_date or death_reason from this observation alone."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012617",
+      "exchange_id": "hei_ex_001165",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "HCoin exchange profile",
+      "url": "https://www.coincarp.com/exchange/hcoin/",
+      "publisher": "CoinCarp",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.coincarp.com/exchange/hcoin/",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "CoinCarp preserves HCoin as a centralized exchange associated with Seychelles and the hcoin86.io / hcoin.com domains, with a 2018 launch-era history. HEI does not adopt its exact launch day as canonical."
+    },
+    {
+      "id": "hei_src_012618",
+      "exchange_id": "hei_ex_001165",
+      "event_id": null,
+      "source_type": "community_reference",
+      "title": "Winchain Weekly Report — December 9 to December 13, 2019",
+      "url": "https://medium.com/@winchainofficial/winchain-weekly-report-2dfa09458b2f",
+      "publisher": "Winchain Official",
+      "published_at": "2019-12-19",
+      "archived_url": "https://web.archive.org/web/*/https://medium.com/@winchainofficial/winchain-weekly-report-2dfa09458b2f",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "A contemporaneous project announcement documents WIN deposits, trading and withdrawals on HCoin and links the hcoin86.com exchange endpoint, supporting active exchange operation in December 2019."
+    },
+    {
+      "id": "hei_src_012619",
+      "exchange_id": "hei_ex_001165",
+      "event_id": "hei_ev_010140",
+      "source_type": "news_article",
+      "title": "HCoin Exchange review and inactive status",
+      "url": "https://www.cryptowisser.com/exchange/hcoin-exchange/",
+      "publisher": "Cryptowisser",
+      "published_at": "2021-11-11",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/hcoin-exchange/",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Cryptowisser records that it could not access the HCoin website on 2021-11-11, found no preceding maintenance or migration notice, and marked the venue inactive/dead. HEI uses this only as an availability-loss and inactivity signal."
+    },
+    {
+      "id": "hei_src_012620",
+      "exchange_id": "hei_ex_001165",
+      "event_id": null,
+      "source_type": "regulatory_notice",
+      "title": "Caution regarding virtual asset service providers claiming to be affiliated with Seychelles",
+      "url": "https://fsaseychelles.sc/media/regupdates/Press_Release_-_Caution_re_VASPs_claiming_to_be_affiliated_with_Seychelles.pdf",
+      "publisher": "Seychelles Financial Services Authority and Registrar of Companies",
+      "published_at": "2024-10-25",
+      "archived_url": "https://web.archive.org/web/*/https://fsaseychelles.sc/media/regupdates/Press_Release_-_Caution_re_VASPs_claiming_to_be_affiliated_with_Seychelles.pdf",
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "The joint notice states that businesses in Annex 1 were not registered or incorporated in Seychelles and lists HCOIN with legal name unknown and claimed activity as an exchange platform and/or payment provider. This prevents HEI from treating historical Seychelles directory placement as proof of legal registration or licensing."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Continues HEI Lane A after merged BX68 by resolving the previously deferred HCoin exchange conservatively.

### Record
- adds `HCoin` as `hei_ex_001165`;
- `type: cex`;
- historical `country_or_origin: Seychelles`, explicitly not treated as proof of legal registration or licensing;
- `status: inactive`;
- leaves `death_reason`, `death_date`, and `launch_date` null.

### Lifecycle
- `hei_ev_010140`: HCoin website observed unreachable on 2021-11-11, modeled as `event_type: other` with `event_status_effect: inactive`.

No operator-announced shutdown or exact death date is inferred.

### Evidence
Adds four reviewed evidence records (`hei_src_012617` through `hei_src_012620`) from CoinCarp, a contemporaneous Winchain project announcement, Cryptowisser, and the Seychelles Financial Services Authority / Registrar of Companies.

### Regulatory boundary
The 2024 Seychelles joint notice states that businesses in Annex 1 were not registered or incorporated in Seychelles and lists HCOIN with legal name unknown. The record therefore preserves historical Seychelles directory placement without turning it into an incorporation, registration, or licensing claim.

### Delta
`+1 entity / +1 event / +4 evidence`.

### Boundaries
- closes #838;
- preserves L-2 HOLD;
- no monitoring, Cloudflare, localization expansion, schema or Ledger Series Phase 9 mutation.

Closes #838