### PR TITLE
Add post-D-1000 BX70 CoinExchange.io shutdown lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX70_2026-08-23.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX70_2026-08-23.md
@@ -1,0 +1,62 @@
+# HEI Post-D-1000 Growth Audit — BX70
+
+Date: 2026-08-23  
+Status: REVIEWED IMPLEMENTATION  
+Project: Historical Exchange Index (HEI)
+
+## Scope
+
+BX70 resolves the previously deferred CoinExchange.io lifecycle contradiction with contemporaneous shutdown evidence.
+
+## Canonical addition
+
+- `hei_ex_001166` — CoinExchange.io
+- type: `cex`
+- status: `dead`
+- death reason: `voluntary_shutdown`
+- death date: `2019-10-15`
+- launch date: null
+- country/origin: `Unknown`
+
+## Lifecycle interpretation
+
+CoinExchange.io announced on 2019-10-01 that its board had decided to close the exchange because continued operation was no longer economically viable. The contemporaneous announcement language explicitly denied a security breach or other incident as the cause.
+
+The operator schedule set 2019-10-15 for suspension of trading and deposits. The website and withdrawals remained available during a later withdrawal-only run-off period. HEI therefore uses the end of trading as the terminal exchange date while preserving the later asset-return window in notes rather than treating withdrawal availability as continued exchange operation.
+
+Events:
+
+- `hei_ev_010141` — shutdown announced, 2019-10-01
+- `hei_ev_010142` — shutdown effective / trading ended, 2019-10-15
+
+## Evidence discipline
+
+The original `coinexchange.io/news/post/85/` announcement is no longer directly retrievable in this review. BX70 therefore does not mislabel a secondary copy as a first-party source.
+
+The record uses four transparent historical sources:
+
+- a contemporaneous BitcoinTalk reproduction of the operator notice;
+- Crypto Watch / Impress contemporaneous coverage;
+- CryptoNinjas contemporaneous coverage;
+- Cryptowisser historical inactive/closure tracking.
+
+No hack, exploit, insolvency, regulatory action, or security-breach event is created.
+
+## Delta
+
+- entities: +1
+- events: +2
+- evidence: +4
+
+## Boundaries
+
+BX70 preserves:
+
+- L-2 HOLD;
+- existing localization scope;
+- monitoring boundaries;
+- Cloudflare configuration;
+- canonical schema;
+- Ledger Series Phase 9 scope.
+
+No horizontal Phase 9 files are modified.

--- a/docs/backlog/consumed/hei_unadded-bx70-coinexchange-io.md
+++ b/docs/backlog/consumed/hei_unadded-bx70-coinexchange-io.md
@@ -1,0 +1,20 @@
+# Consumed backlog note — BX70 CoinExchange.io
+
+Date: 2026-08-23
+
+CoinExchange.io was previously deferred during D-1000 growth because the old candidate state conflicted with later closure context.
+
+BX70 resolves that conflict with reviewed contemporaneous evidence and promotes the historical exchange as:
+
+- `hei_ex_001166`
+- `CoinExchange.io`
+- `cex`
+- `dead`
+- `voluntary_shutdown`
+- terminal exchange-trading date `2019-10-15`
+
+The original operator announcement URL is not directly retrievable in the present review. The promotion therefore relies transparently on contemporaneous reproductions and coverage and does not fabricate a first-party archive capture.
+
+Withdrawal-only availability after trading ended is preserved as run-off and does not keep the exchange active.
+
+Historical candidate IDs are not treated as durable canonical identity. The consumed decision is keyed to the reviewed CoinExchange.io identity and canonical record above.

--- a/records/exchanges/coinexchange-io.json
+++ b/records/exchanges/coinexchange-io.json
@@ -1,0 +1,119 @@
+{
+  "entity": {
+    "id": "hei_ex_001166",
+    "slug": "coinexchange-io",
+    "canonical_name": "CoinExchange.io",
+    "aliases": [
+      "CoinExchange",
+      "Coin Exchange"
+    ],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "voluntary_shutdown",
+    "launch_date": null,
+    "death_date": "2019-10-15",
+    "country_or_origin": "Unknown",
+    "summary": "Historical altcoin-focused centralized cryptocurrency exchange that announced an orderly business closure in October 2019, ended trading and deposits on 2019-10-15, and kept withdrawals available temporarily during wind-down.",
+    "official_url_original": "https://www.coinexchange.io/",
+    "official_domain_original": "coinexchange.io",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://www.coinexchange.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-23",
+    "notes": "CoinExchange.io announced on 2019-10-01 that its board had decided to close the exchange because operating the service was no longer economically viable; contemporaneous reproductions of the operator notice explicitly state there had been no security breach or other incident. Trading and deposits were scheduled to stop on 2019-10-15. The website and withdrawals remained available during a withdrawal-only run-off period into December 2019, which HEI does not treat as continued exchange trading. The original operator news URL is no longer directly retrievable in this review, so the shutdown is supported transparently by contemporaneous reproductions and coverage rather than mislabeled as a currently accessible first-party page. No precise launch date or jurisdiction is asserted because reviewed evidence is insufficient for those fields."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010141",
+      "exchange_id": "hei_ex_001166",
+      "event_type": "shutdown_announced",
+      "event_date": "2019-10-01",
+      "title": "CoinExchange.io announced an orderly business closure",
+      "description": "CoinExchange.io announced that its board had decided to close the exchange because continued operation was no longer economically viable, while explicitly denying a security breach or other incident as the cause.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "none",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "The original operator announcement URL is no longer directly retrievable here. Two contemporaneous sources reproduce or report the announcement and its closure rationale."
+    },
+    {
+      "id": "hei_ev_010142",
+      "exchange_id": "hei_ex_001166",
+      "event_type": "shutdown_effective",
+      "event_date": "2019-10-15",
+      "title": "CoinExchange.io ended trading and deposits",
+      "description": "Trading and deposits were scheduled to stop on 2019-10-15 as the exchange entered its terminal withdrawal-only run-off period.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "dead",
+      "source_count": 2,
+      "sort_order": 2,
+      "notes": "Withdrawals and the website remained available temporarily after trading ended. HEI uses the end of exchange trading as the terminal exchange date while preserving the subsequent asset-return run-off in notes."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012621",
+      "exchange_id": "hei_ex_001166",
+      "event_id": "hei_ev_010141",
+      "source_type": "community_reference",
+      "title": "Coinexchange.io is Closing Down. Official announcement.",
+      "url": "https://bitcointalk.org/index.php?topic=5189124.0",
+      "publisher": "BitcoinTalk",
+      "published_at": "2019-10-01",
+      "archived_url": "https://web.archive.org/web/*/https://bitcointalk.org/index.php?topic=5189124.0",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Contemporaneous forum post reproduces the CoinExchange.io operator notice, including the board decision to close, the economic rationale, the explicit statement that there was no security breach or other incident, and the scheduled shutdown dates. This is not labeled first-party evidence because the original operator page is not directly retrievable in this review."
+    },
+    {
+      "id": "hei_src_012622",
+      "exchange_id": "hei_ex_001166",
+      "event_id": "hei_ev_010141",
+      "source_type": "news_article",
+      "title": "CoinExchange decided to close, with trading and deposits stopping October 15",
+      "url": "https://crypto.watch.impress.co.jp/docs/news/1210468.html",
+      "publisher": "Crypto Watch / Impress",
+      "published_at": "2019-10-02",
+      "archived_url": "https://web.archive.org/web/*/https://crypto.watch.impress.co.jp/docs/news/1210468.html",
+      "accessed_at": "2026-08-23",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Contemporaneous Japanese coverage reports the October 1 closure announcement, the business/economic rationale, the October 15 trading/deposit stop, and the December withdrawal/site deadline."
+    },
+    {
+      "id": "hei_src_012623",
+      "exchange_id": "hei_ex_001166",
+      "event_id": "hei_ev_010142",
+      "source_type": "news_article",
+      "title": "Crypto exchange CoinExchange.io is closing down",
+      "url": "https://www.cryptoninjas.net/2019/10/01/crypto-exchange-coinexchange-io-is-closing-down/",
+      "publisher": "CryptoNinjas",
+      "published_at": "2019-10-01",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptoninjas.net/2019/10/01/crypto-exchange-coinexchange-io-is-closing-down/",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Contemporaneous report states that trading and deposits would be suspended starting October 15, 2019 and that withdrawals/site access would remain temporarily available afterward."
+    },
+    {
+      "id": "hei_src_012624",
+      "exchange_id": "hei_ex_001166",
+      "event_id": "hei_ev_010142",
+      "source_type": "database_reference",
+      "title": "CoinExchange.io inactive exchange review",
+      "url": "https://www.cryptowisser.com/exchange/coinexchange-io/",
+      "publisher": "Cryptowisser",
+      "published_at": "2019-10-15",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/coinexchange-io/",
+      "accessed_at": "2026-08-23",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Historical exchange review marks CoinExchange.io inactive and records October 15, 2019 as the closure/trading-stop date pursuant to the October 1 board decision."
+    }
+  ]
+}


### PR DESCRIPTION
## Closed without merge

CI correctly detected that CoinExchange.io already exists canonically as `hei_ex_000112`.

Current-main re-audit confirms the existing canonical record already has the intended lifecycle state:
- `status: dead`
- `death_reason: voluntary_shutdown`
- `death_date: 2019-10-15`
- historical launch `2016-03-01`
- `country_or_origin: Australia`
- business-driven closure notes

The proposed `hei_ex_001166` would therefore duplicate an existing canonical entity. No duplicate allowlist or validator weakening is appropriate.

Closes no canonical gap; PR closed without merge. See #841.