### PR TITLE
Trigger HEI production publication

### DIFF
--- a/.github/workflows/force-production-deploy.yml
+++ b/.github/workflows/force-production-deploy.yml
@@ -39,3 +39,5 @@ jobs:
               issue_number: 853,
               body: `Force production deploy finished.\n\n- Result: **${{ job.status }}**\n- Source commit: \`${context.sha}\`\n- Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             })
+
+# Merge-triggered production execution 2026-08-24.


### PR DESCRIPTION
Merge-only production trigger for the existing forced Cloudflare Pages deploy workflow. No canonical data changes.