### PR TITLE
Add IZAKA-YA cross-registry record links

### DIFF
--- a/src/app/exchange/[slug]/layout.tsx
+++ b/src/app/exchange/[slug]/layout.tsx
@@ -8,6 +8,12 @@ type DossierLayoutProps = {
   params: Promise<{ slug: string }>
 }
 
+const izakayaRelatedRecords = [
+  { href: 'https://cya.badjoke-lab.com/platform/izaka-ya/', name: 'Crypto Yield Archive — IZAKA-YA', note: 'Lending / yield platform record for the IZAKA-YA service.' },
+  { href: 'https://www.stableorgone.com/stablecoin/jpyr/', name: 'Stable or Gone — JPYR', note: 'Stable-asset record for JPYR and its reviewed backing / redemption uncertainty.' },
+  { href: 'https://wlr.badjoke-lab.com/wallet/izaka-ya-wallet/', name: 'Wallet Lifecycle Registry — IZAKA-YA Wallet', note: 'Wallet and custody lifecycle record for the IZAKA-YA wallet service.' },
+]
+
 export default async function DossierLayout({ children, params }: DossierLayoutProps) {
   const { slug } = await params
   const detail = buildDetailView(slug)
@@ -20,6 +26,22 @@ export default async function DossierLayout({ children, params }: DossierLayoutP
         <h1>{title}</h1>
       </section>
       {detail ? <ExchangeMaterialConcerns entity={detail.entity} events={detail.events} evidence={detail.evidence} /> : null}
+      {slug === 'izaka-ya' ? (
+        <section className="panel longform-panel">
+          <div className="section">
+            <h4>Related registry records</h4>
+            <p className="muted">These are separate public records concerning the same IZAKA-YA / JPYR product ecosystem. The links do not assert common legal ownership, issuer status, custody, or safety.</p>
+            <div className="fact-grid">
+              {izakayaRelatedRecords.map((record) => (
+                <div className="fact" key={record.href}>
+                  <div className="k">Ledger Series</div>
+                  <div className="v"><a className="subtle-link" href={record.href} target="_blank" rel="noreferrer">{record.name}</a><br/><span className="muted">{record.note}</span></div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
       {children}
     </div>
   )


### PR DESCRIPTION
Adds neutral human-facing links from the canonical HEI IZAKA-YA dossier to the existing CYA IZAKA-YA, SOG JPYR and WLR IZAKA-YA Wallet records. The links identify related public records only and do not assert common ownership, issuer status, custody, or safety. No HEI canonical entity/event/evidence or typed relationship semantics are changed.