### PR TITLE
Add IZAKA-YA production closeout check

### DIFF
--- a/.github/workflows/izakaya-production-closeout.yml
+++ b/.github/workflows/izakaya-production-closeout.yml
@@ -1,0 +1,53 @@
+name: IZAKA-YA production closeout
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'records/**'
+      - '.github/workflows/izakaya-production-closeout.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hei-izakaya-production-closeout
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Verify IZAKA-YA human and machine publication
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          ok=0
+          for attempt in $(seq 1 40); do
+            html="$(curl -fsS --max-time 20 -H 'Cache-Control: no-cache' 'https://hei.badjoke-lab.com/exchange/izaka-ya/?publication_closeout='"${attempt}" 2>/dev/null || true)"
+            record="$(curl -fsS --max-time 20 -H 'Cache-Control: no-cache' 'https://hei.badjoke-lab.com/data/exchanges/izaka-ya.json?publication_closeout='"${attempt}" 2>/dev/null || true)"
+            version="$(curl -fsS --max-time 20 -H 'Cache-Control: no-cache' 'https://hei.badjoke-lab.com/version.json?publication_closeout='"${attempt}" 2>/dev/null || true)"
+            if grep -Fq 'Crypto Yield Archive — IZAKA-YA' <<<"$html" \
+              && grep -Fq 'Stable or Gone — JPYR' <<<"$html" \
+              && grep -Fq 'Wallet Lifecycle Registry — IZAKA-YA Wallet' <<<"$html" \
+              && jq -e '.entity.id == "hei_ex_001154" and .entity.slug == "izaka-ya"' <<<"$record" >/dev/null 2>&1 \
+              && jq -e --arg sha "$EXPECTED_COMMIT" '.build.commit == $sha' <<<"$version" >/dev/null 2>&1; then
+              ok=1
+              break
+            fi
+            sleep 15
+          done
+          test "$ok" = 1
+
+      - name: Report closeout
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: 866, body: `HEI IZAKA-YA production closeout passed at exact main \`${context.sha}\`. Human page, machine record, and all three cross-registry links are live. Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`});


### PR DESCRIPTION
Adds a publication-only production verification for the canonical IZAKA-YA case. It requires exact-main version parity, the live HEI machine record, and all three cross-registry links on the human page. It reports success to #866 and does not invoke legacy corpus audits.