### PR TITLE
Fix IZAKA-YA closeout content SHA

### DIFF
--- a/.github/workflows/izakaya-production-closeout.yml
+++ b/.github/workflows/izakaya-production-closeout.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Verify IZAKA-YA human and machine publication
         shell: bash
         env:
-          EXPECTED_COMMIT: ${{ github.sha }}
+          EXPECTED_CONTENT_COMMIT: bfc068c116aa39fb0747ef576c3e215db2a6a7c1
         run: |
           set -euo pipefail
           ok=0
@@ -37,7 +37,7 @@ jobs:
               && grep -Fq 'Stable or Gone — JPYR' <<<"$html" \
               && grep -Fq 'Wallet Lifecycle Registry — IZAKA-YA Wallet' <<<"$html" \
               && jq -e '.entity.id == "hei_ex_001154" and .entity.slug == "izaka-ya"' <<<"$record" >/dev/null 2>&1 \
-              && jq -e --arg sha "$EXPECTED_COMMIT" '.build.commit == $sha' <<<"$version" >/dev/null 2>&1; then
+              && jq -e --arg sha "$EXPECTED_CONTENT_COMMIT" '.build.commit == $sha' <<<"$version" >/dev/null 2>&1; then
               ok=1
               break
             fi
@@ -50,4 +50,4 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: 866, body: `HEI IZAKA-YA production closeout passed at exact main \`${context.sha}\`. Human page, machine record, and all three cross-registry links are live. Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`});
+            await github.rest.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: 866, body: `HEI IZAKA-YA production closeout passed for deployed content \`bfc068c116aa39fb0747ef576c3e215db2a6a7c1\`. Human page, machine record, and all three cross-registry links are live. Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`});


### PR DESCRIPTION
The closeout must verify the deployed public-content commit, not a later workflow-only commit. Pin the production content check to the already-merged cross-registry publication commit `bfc068c116aa39fb0747ef576c3e215db2a6a7c1`, while still requiring the live human page, machine record, and all three cross-registry links.