### PR TITLE
Add post-D-1000 BX75 DeversiFi rebrand lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX75_2026-08-25.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX75_2026-08-25.md
@@ -1,0 +1,43 @@
+# HEI Post-D-1000 Growth — BX75 DeversiFi
+
+Date: 2026-08-25  
+Status: REVIEWED / PR PENDING  
+Project: Historical Exchange Index (HEI)
+
+## Scope
+
+Resolve the deferred historical DeversiFi exchange identity without forcing current rhino.fi into HEI as a pure exchange entity.
+
+## Identity and overlap
+
+Repository checks found no current canonical `records/exchanges/deversifi.json`. DeversiFi is distinct from unrelated current venues and from the current broader rhino.fi product scope.
+
+## Classification
+
+- entity: `hei_ex_001170`
+- type: `dex`
+- status: `rebranded`
+- death reason: `rebrand`
+- launch: `2020-06-03`
+- rebrand/death marker: `2022-07-13`
+- origin: `Global`
+
+The historical protocol is treated as a decentralized exchange identity rather than as a jurisdiction-defined centralized operator.
+
+## Lifecycle evidence
+
+First-party rhino.fi material published on 2021-06-03 states that DeversiFi was unveiled exactly one year earlier on 2020-06-03 and records $300m traded in its first year. The 2022-07-13 first-party rebrand notice states that DeversiFi became rhino.fi. A 2024 first-party retrospective explicitly describes DeversiFi as an orderbook DEX launched in June 2020 and says the project later pivoted to rhino.fi while deprioritizing the DEX.
+
+## Successor boundary
+
+No `successor_id` is created in BX75. Current rhino.fi has evolved into a broader multi-chain/stablecoin and infrastructure product, and its current retail offering is separately in wind-down. A forced exchange-to-exchange successor edge would overstate continuity of HEI scope. The historical rebrand itself is retained in the lifecycle notes and evidence.
+
+## Delta
+
+- entities: +1
+- events: +2
+- evidence: +3
+
+## Safety boundaries
+
+BX75 does not change Cloudflare, monitoring, localization scope, L-2 HOLD, canonical schema, or Ledger Series Phase 9 state.

--- a/docs/backlog/consumed/hei_unadded-bx75-deversifi.md
+++ b/docs/backlog/consumed/hei_unadded-bx75-deversifi.md
@@ -1,0 +1,14 @@
+# Consumed candidate — BX75 DeversiFi
+
+Candidate: DeversiFi  
+Disposition: promoted to reviewed canonical record  
+Entity: `hei_ex_001170`
+
+Reviewed result:
+- historical Ethereum layer-2 order-book DEX;
+- launch marker 2020-06-03 from first-party retrospective;
+- rebranded to rhino.fi on 2022-07-13;
+- classified `rebranded` with `death_reason: rebrand`;
+- current rhino.fi is not added as a canonical exchange successor in this batch because its present product scope is broader than the historical DEX.
+
+Evidence is preserved in `records/exchanges/deversifi.json` and the BX75 audit.

--- a/records/exchanges/deversifi.json
+++ b/records/exchanges/deversifi.json
@@ -1,0 +1,101 @@
+{
+  "entity": {
+    "id": "hei_ex_001170",
+    "slug": "deversifi",
+    "canonical_name": "DeversiFi",
+    "aliases": ["DeversiFi Exchange"],
+    "type": "dex",
+    "status": "rebranded",
+    "death_reason": "rebrand",
+    "launch_date": "2020-06-03",
+    "death_date": "2022-07-13",
+    "country_or_origin": "Global",
+    "summary": "Ethereum layer-2 order-book decentralized exchange launched in June 2020. On 2022-07-13 DeversiFi became rhino.fi as the project expanded from a pure-play exchange into a broader multi-chain DeFi platform.",
+    "official_url_original": "https://deversifi.com/",
+    "official_domain_original": "deversifi.com",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://deversifi.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-25",
+    "notes": "First-party rhino.fi retrospectives establish that DeversiFi was unveiled on 2020-06-03 as an Ethereum layer-2 exchange and later describe it explicitly as an orderbook DEX. On 2022-07-13 the project announced that DeversiFi became rhino.fi and shifted toward a broader multi-chain DeFi gateway. HEI classifies the historical DeversiFi exchange identity as rebranded rather than dead. No successor_id is assigned in this batch because current rhino.fi has evolved beyond a pure exchange into broader bridging, stablecoin and infrastructure products; forcing a canonical exchange lineage edge would overstate scope continuity."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010152",
+      "exchange_id": "hei_ex_001170",
+      "event_type": "launched",
+      "event_date": "2020-06-03",
+      "title": "DeversiFi launched as an Ethereum layer-2 exchange",
+      "description": "DeversiFi was unveiled on 2020-06-03 as an Ethereum layer-2 protocol focused on gas-free, scalable trading.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "The date comes from a first-party one-year retrospective published on 2021-06-03."
+    },
+    {
+      "id": "hei_ev_010153",
+      "exchange_id": "hei_ex_001170",
+      "event_type": "rebranded",
+      "event_date": "2022-07-13",
+      "title": "DeversiFi became rhino.fi",
+      "description": "DeversiFi announced that it had become rhino.fi, changing the project identity while expanding from a pure-play layer-2 exchange into a broader multi-chain DeFi platform.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "rebranded",
+      "source_count": 1,
+      "sort_order": 2,
+      "notes": "This is a rebrand and product-scope transition, not an insolvency, exploit or service-failure event."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012644",
+      "exchange_id": "hei_ex_001170",
+      "event_id": "hei_ev_010152",
+      "source_type": "official_blog",
+      "title": "1 year helping DeFi scale",
+      "url": "https://rhino.fi/blog/one-year-helping-defi-scale/",
+      "publisher": "DeversiFi / rhino.fi",
+      "published_at": "2021-06-03",
+      "archived_url": "https://web.archive.org/web/*/https://rhino.fi/blog/one-year-helping-defi-scale/",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "launch_date",
+      "notes": "First-party retrospective states that DeversiFi was unveiled on 2020-06-03 and records $300 million traded in its first year."
+    },
+    {
+      "id": "hei_src_012645",
+      "exchange_id": "hei_ex_001170",
+      "event_id": "hei_ev_010153",
+      "source_type": "official_blog",
+      "title": "Introducing rhino.fi: A Frictionless Gateway to Multi-chain DeFi",
+      "url": "https://rhino.fi/blog/introducing-rhino-fi-the-first-frictionless-gateway-to-multi-chain-defi/",
+      "publisher": "rhino.fi",
+      "published_at": "2022-07-13",
+      "archived_url": "https://web.archive.org/web/*/https://rhino.fi/blog/introducing-rhino-fi-the-first-frictionless-gateway-to-multi-chain-defi/",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party announcement states: today DeversiFi becomes rhino.fi, and explains the move from layer-2 trading toward a broader multi-chain DeFi platform."
+    },
+    {
+      "id": "hei_src_012646",
+      "exchange_id": "hei_ex_001170",
+      "event_id": null,
+      "source_type": "official_blog",
+      "title": "Plan for DVF purchase",
+      "url": "https://rhino.fi/blog/plan-for-dvf-purchase",
+      "publisher": "rhino.fi",
+      "published_at": "2024-08-07",
+      "archived_url": "https://web.archive.org/web/*/https://rhino.fi/blog/plan-for-dvf-purchase",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "First-party retrospective describes DeversiFi as an orderbook DEX that began in June 2020 and says the project later pivoted to rhino.fi while deprioritizing the DEX, supporting the historical exchange-to-broader-platform scope transition."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Continues HEI Lane A after merged BX74 by resolving the deferred historical DeversiFi exchange identity.

### Record
- adds `DeversiFi` as `hei_ex_001170`;
- `type: dex`;
- `status: rebranded`;
- `death_reason: rebrand`;
- launch date `2020-06-03`;
- rebrand/death marker `2022-07-13`;
- `country_or_origin: Global`.

### Lifecycle
- `hei_ev_010152`: DeversiFi launched as an Ethereum layer-2 exchange on 2020-06-03;
- `hei_ev_010153`: DeversiFi became rhino.fi on 2022-07-13.

### Evidence
Adds three first-party reviewed evidence records (`hei_src_012644` through `hei_src_012646`) covering launch, exact rebrand date, and the later retrospective confirming DeversiFi began as an orderbook DEX and rhino.fi subsequently deprioritized the DEX.

### Classification boundary
No canonical rhino.fi successor is created in this batch because current rhino.fi has evolved beyond the historical pure-play exchange into broader multi-chain/stablecoin infrastructure. The historical rebrand is preserved without forcing a misleading exchange-to-exchange lineage edge.

### Delta
`+1 entity / +2 events / +3 evidence`.

### Boundaries
- closes #876;
- preserves L-2 HOLD;
- no monitoring, Cloudflare, localization expansion, schema or Ledger Series Phase 9 mutation.

Closes #876