### PR TITLE
Add post-D-1000 BX76 One Trading successor lifecycle

### DIFF
--- a/config/lineage-later-dispositions.json
+++ b/config/lineage-later-dispositions.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "reviewed_at": "2026-08-23",
+  "reviewed_at": "2026-08-25",
   "scope": "post_a3_predecessor_successor_edges",
   "dispositions": [
     {
@@ -26,6 +26,30 @@
       "rationale": "Klickl is the reviewed successor brand to IDCM. The reciprocal predecessor/successor pair records the same one-to-one rebrand continuity from the successor side.",
       "event_ids": ["hei_ev_010135"],
       "evidence_ids": ["hei_src_012605", "hei_src_012606", "hei_src_012608"]
+    },
+    {
+      "entity_id": "hei_ex_000585",
+      "entity_name": "Bitpanda Pro",
+      "field": "successor_id",
+      "target_id": "hei_ex_001171",
+      "target_name": "One Trading",
+      "disposition": "keep_bidirectional",
+      "continuity_status": "official_brand_rebrand",
+      "rationale": "Reviewed Bitpanda and One Trading material establishes that Bitpanda Pro was spun out and rebranded as One Trading on 2023-06-28 with customer and account continuity. The reciprocal successor/predecessor pair is the intended canonical lineage.",
+      "event_ids": ["hei_ev_010044", "hei_ev_010154"],
+      "evidence_ids": ["hei_src_011113", "hei_src_011115", "hei_src_012647", "hei_src_012648"]
+    },
+    {
+      "entity_id": "hei_ex_001171",
+      "entity_name": "One Trading",
+      "field": "predecessor_id",
+      "target_id": "hei_ex_000585",
+      "target_name": "Bitpanda Pro",
+      "disposition": "keep_bidirectional",
+      "continuity_status": "official_brand_rebrand",
+      "rationale": "One Trading is the reviewed active successor identity to Bitpanda Pro. Current 2026 first-party exchange terms establish a continuing Dutch-operated venue, while predecessor and successor materials establish the exact rebrand continuity.",
+      "event_ids": ["hei_ev_010044", "hei_ev_010154"],
+      "evidence_ids": ["hei_src_011113", "hei_src_011115", "hei_src_012647", "hei_src_012648", "hei_src_012649"]
     }
   ]
 }

--- a/docs/audits/HEI_POST_D1000_GROWTH_BX76_2026-08-25.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX76_2026-08-25.md
@@ -1,0 +1,46 @@
+# HEI Post-D-1000 Growth — BX76
+
+Date: 2026-08-25  
+Status: REVIEWED IMPLEMENTATION  
+Project: Historical Exchange Index (HEI)
+
+## Scope
+
+BX76 resolves the already-documented Bitpanda Pro -> One Trading rebrand boundary by adding the continuing One Trading identity and converting the previously null successor reference into an explicit reviewed lineage edge.
+
+## Canonical changes
+
+- add `hei_ex_001171` One Trading;
+- `type: cex`;
+- `status: active`;
+- `launch_date: 2023-06-28` as the exact successor-identity transition marker;
+- `country_or_origin: Netherlands`;
+- `predecessor_id: hei_ex_000585`;
+- add event `hei_ev_010154` for the 2023-06-28 One Trading identity launch through the Bitpanda Pro spin-out/rebrand;
+- add evidence `hei_src_012647` through `hei_src_012650`;
+- update Bitpanda Pro `successor_id` to `hei_ex_001171` and refresh its verification date;
+- extend `config/lineage-later-dispositions.json` with the reciprocal reviewed lineage dispositions.
+
+## Evidence review
+
+Existing first-party Bitpanda and One Trading material already establishes the exact 2023-06-28 spin-out/rebrand and customer-account continuity. Fresh 2026 first-party One Trading material establishes a continuing exchange identity: current terms effective from 2026-06-15 identify One Trading Exchange B.V., its Amsterdam registered address, AFM supervision, MiFID investment-firm/OTF authorization and MiCA authorization to operate a crypto-asset trading platform and provide custody. Current site navigation exposes Trade, Exchange, account-opening and login entry points.
+
+## Classification boundary
+
+The 2023 transition is modeled as a rebrand/successor transition rather than an acquisition, shutdown or unrelated duplicate. The One Trading entity is active; older One Trading Markets S.r.l. service termination material is not treated as closure of the continuing One Trading Exchange B.V. venue because current 2026 first-party terms and trading entry points establish ongoing exchange operations.
+
+The frozen A3 lineage disposition file is unchanged. Post-A3 lineage authority remains `config/lineage-later-dispositions.json`.
+
+## Delta
+
+```text
+Entities: +1
+Events:   +1
+Evidence: +4
+Existing entities updated: 1
+Lineage dispositions added: 2
+```
+
+## Safety boundaries
+
+BX76 does not change Cloudflare configuration, monitoring mutation policy, localization breadth, L-2 HOLD, schema, or Ledger Series Phase 9 production state.

--- a/docs/backlog/consumed/hei_unadded-bx76-one-trading.md
+++ b/docs/backlog/consumed/hei_unadded-bx76-one-trading.md
@@ -1,0 +1,30 @@
+# BX76 consumed candidate — One Trading
+
+Status: consumed by reviewed implementation  
+Date: 2026-08-25
+
+## Resolution
+
+The prior D-1000 duplicate warning around One Trading was valid for thin routine growth: One Trading could not be added as an unrelated exchange because canonical Bitpanda Pro already documented the same rebrand continuity. BX76 resolves that ambiguity through explicit lineage rather than bypassing the overlap gate.
+
+Reviewed result:
+
+```text
+Bitpanda Pro hei_ex_000585 rebranded -> One Trading hei_ex_001171 active
+```
+
+The predecessor record already carried the exact 2023-06-28 spin-out/rebrand event. Fresh current first-party One Trading material now supports the successor as a separately reviewable continuing venue operated by One Trading Exchange B.V. in the Netherlands.
+
+## Durable IDs
+
+```text
+Entity:   hei_ex_001171
+Event:    hei_ev_010154
+Evidence: hei_src_012647..hei_src_012650
+```
+
+Candidate labels and historical backlog rows are discovery inputs only; the durable authority is the merged canonical record and reviewed lineage disposition.
+
+## Boundary
+
+Do not recreate One Trading as an unrelated duplicate of Bitpanda Pro. Future One Trading lifecycle updates belong to `hei_ex_001171`; historical Bitpanda Global Exchange / Bitpanda Pro events remain on `hei_ex_000585`.

--- a/records/exchanges/bitpanda-pro.json
+++ b/records/exchanges/bitpanda-pro.json
@@ -16,10 +16,10 @@
     "official_url_status": "repurposed",
     "archived_url": "https://web.archive.org/web/*/https://exchange.bitpanda.com/",
     "predecessor_id": null,
-    "successor_id": null,
+    "successor_id": "hei_ex_001171",
     "confidence": "high",
-    "last_verified_at": "2026-07-03",
-    "notes": "HEI treats Bitpanda Global Exchange and Bitpanda Pro as one continuous exchange identity. The terminal marker is the 2023-06-28 spin-out and rebrand to One Trading. One Trading is not yet a canonical HEI entity, so successor_id remains null. The original Bitpanda exchange URL is classified as repurposed because the professional exchange now operates under the One Trading identity."
+    "last_verified_at": "2026-08-25",
+    "notes": "HEI treats Bitpanda Global Exchange and Bitpanda Pro as one continuous exchange identity. The terminal marker is the 2023-06-28 spin-out and rebrand to One Trading. One Trading is now separately reviewed as canonical successor hei_ex_001171, so this record links to that continuing identity through successor_id. The original Bitpanda exchange URL is classified as repurposed because the professional exchange now operates under the One Trading identity."
   },
   "events": [
     {

--- a/records/exchanges/one-trading.json
+++ b/records/exchanges/one-trading.json
@@ -1,0 +1,104 @@
+{
+  "entity": {
+    "id": "hei_ex_001171",
+    "slug": "one-trading",
+    "canonical_name": "One Trading",
+    "aliases": [
+      "One Trading Exchange"
+    ],
+    "type": "cex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2023-06-28",
+    "death_date": null,
+    "country_or_origin": "Netherlands",
+    "summary": "Dutch-operated centralized crypto trading venue created when Bitpanda Pro was spun out and rebranded as One Trading on 2023-06-28. Current first-party terms identify One Trading Exchange B.V. as an AFM-supervised investment firm and MiCA crypto-asset service provider operating a crypto-asset trading platform.",
+    "official_url_original": "https://www.onetrading.com/",
+    "official_domain_original": "onetrading.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://www.onetrading.com/",
+    "predecessor_id": "hei_ex_000585",
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-25",
+    "notes": "One Trading is the reviewed successor identity to Bitpanda Pro. The 2023-06-28 date is the exact public identity transition marker established by the existing Bitpanda Pro rebrand record and corroborating reporting; it does not imply a break in underlying customer-account continuity. Current 2026 first-party terms and site entry points demonstrate an active exchange identity operated by One Trading Exchange B.V. in the Netherlands. HEI models One Trading separately from the terminal Bitpanda Pro brand and links the pair bidirectionally rather than treating the current venue as a duplicate alias."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010154",
+      "exchange_id": "hei_ex_001171",
+      "event_type": "launched",
+      "event_date": "2023-06-28",
+      "title": "One Trading identity launched through the Bitpanda Pro spin-out and rebrand",
+      "description": "Bitpanda Pro separated from Bitpanda and adopted the One Trading identity while preserving customer and account continuity on the successor platform.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "active",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "HEI uses the exact rebrand/spin-out date as the launch marker for the One Trading successor identity. This is an identity transition, not a claim that the underlying exchange service started from zero on that date."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012647",
+      "exchange_id": "hei_ex_001171",
+      "event_id": "hei_ev_010154",
+      "source_type": "official_statement",
+      "title": "Why is Bitpanda Pro evolving to become One Trading?",
+      "url": "https://support.bitpanda.com/hc/en-us/articles/9374684386332-Why-is-Bitpanda-Pro-evolving-to-become-One-Trading",
+      "publisher": "Bitpanda",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://support.bitpanda.com/hc/en-us/articles/9374684386332-Why-is-Bitpanda-Pro-evolving-to-become-One-Trading",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party predecessor material documents the spin-out and rebrand from Bitpanda Pro to One Trading and explains customer/account continuity across the transition."
+    },
+    {
+      "id": "hei_src_012648",
+      "exchange_id": "hei_ex_001171",
+      "event_id": "hei_ev_010154",
+      "source_type": "news_article",
+      "title": "Bitpanda’s crypto exchange separates from Bitpanda and secures $33 million",
+      "url": "https://techcrunch.com/2023/06/28/bitpandas-crypto-exchange-separates-from-bitpanda-and-secures-33-million/",
+      "publisher": "TechCrunch",
+      "published_at": "2023-06-28",
+      "archived_url": "https://web.archive.org/web/*/https://techcrunch.com/2023/06/28/bitpandas-crypto-exchange-separates-from-bitpanda-and-secures-33-million/",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Independent contemporaneous reporting dates the Bitpanda Pro separation and One Trading identity to 2023-06-28."
+    },
+    {
+      "id": "hei_src_012649",
+      "exchange_id": "hei_ex_001171",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "One Trading Terms of Service",
+      "url": "https://www.onetrading.com/terms",
+      "publisher": "One Trading",
+      "published_at": "2026-06-15",
+      "archived_url": "https://web.archive.org/web/*/https://www.onetrading.com/terms",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party terms identify One Trading Exchange B.V., show terms effective from 2026-06-15, give its Amsterdam registered address, and state AFM supervision plus authorization to operate a crypto-asset trading platform under MiCA."
+    },
+    {
+      "id": "hei_src_012650",
+      "exchange_id": "hei_ex_001171",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "One Trading About",
+      "url": "https://www.onetrading.com/about",
+      "publisher": "One Trading",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.onetrading.com/about",
+      "accessed_at": "2026-08-25",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Current first-party corporate page supports the continuing One Trading identity; the wider current site exposes Trade, Exchange, account opening and login entry points under the same operator brand."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Continues HEI Lane A after merged BX75 by resolving the already-documented Bitpanda Pro -> One Trading successor boundary through explicit reviewed lineage.

### Record
- adds `One Trading` as `hei_ex_001171`;
- `type: cex`;
- `status: active`;
- launch/identity-transition date `2023-06-28`;
- `country_or_origin: Netherlands`;
- `predecessor_id: hei_ex_000585`.

### Lifecycle
- `hei_ev_010154`: One Trading identity launched through the Bitpanda Pro spin-out/rebrand on 2023-06-28.

### Evidence
Adds four reviewed evidence records (`hei_src_012647` through `hei_src_012650`) covering predecessor-side first-party rebrand continuity, independent contemporaneous dating, and current 2026 One Trading first-party operator/status evidence.

### Existing canonical update
- updates Bitpanda Pro `successor_id` from null to `hei_ex_001171`;
- refreshes its verification date and notes;
- does not alter its established terminal rebrand status/date.

### Lineage authority
Extends `config/lineage-later-dispositions.json` with reciprocal Bitpanda Pro / One Trading reviewed dispositions. Frozen A3 lineage dispositions remain unchanged.

### Delta
`+1 entity / +1 event / +4 evidence`, plus one existing entity update and two reviewed lineage dispositions.

### Boundaries
- closes #878;
- preserves L-2 HOLD;
- no monitoring, Cloudflare, localization expansion, schema or Ledger Series Phase 9 mutation.

Closes #878