### PR TITLE
BX81: add GetBTC inactive lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX81_2026-08-28.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX81_2026-08-28.md
@@ -1,0 +1,56 @@
+# HEI post-D-1000 growth audit — BX81 — 2026-08-28
+
+## Scope
+
+Lane A canonical growth only. Adds GetBTC as a reviewed historical inactive centralized exchange record.
+
+Base main: `0445e828a829e86d095fe697731b6aca33d3729f`.
+
+## Canonical reconciliation
+
+Repository search found GetBTC only in backlog/scan material and verified-unadded candidate files; no canonical `records/exchanges/getbtc.json` existed on the BX81 base main.
+
+## Evidence review
+
+1. 2017-07-05 operator announcement — the `ExchangeGetBTC` Bitcointalk account opened a GetBTC.org exchange announcement thread and described the exchange/support endpoint.
+2. 2019-07-16 disruption/relaunch marker — Cryptowisser records that GetBTC's own website displayed a message that the project was trying to be reborn.
+3. 2020-11-01 follow-up — Cryptowisser records that the website was still unavailable. HEI does not turn this observation into an exact shutdown date.
+4. Current status — CoinMarketCap currently marks GetBTC as inactive and retains getbtc.org as its historical website.
+
+## Modeling decision
+
+- entity status: `inactive`
+- death reason: `unknown`
+- death date: `null`
+- launch date: `2017-07-05`, based on the dated operator announcement rather than an asserted first-trade timestamp
+- country/origin: `Global`; conflicting historical directory jurisdiction labels are not promoted without a durable reviewed operating-jurisdiction artifact
+- official URL status: `unknown`; historical unavailability is documented, but this pass does not overclaim current domain ownership/safety state
+- no scam, insolvency, regulatory, or voluntary-shutdown inference
+
+## ID allocation
+
+From current main after BX80:
+
+- entity: `hei_ex_001178`
+- events: `hei_ev_010206`–`hei_ev_010207`
+- evidence: `hei_src_012711`–`hei_src_012713`
+
+`hei_src_012710` is already consumed by the merged BX80 GBX repair and is not reused.
+
+## Source-count check
+
+- `hei_ev_010206`: 1 directly linked evidence
+- `hei_ev_010207`: 1 directly linked evidence
+
+## Delta
+
+- +1 entity
+- +2 events
+- +3 evidence
+- +0 lineage edges
+
+## Boundaries
+
+No schema, validator, monitoring, localization, Phase 9 production, or machine-readable contract changes are included.
+
+If main advances before merge, BX81 must be replayed/re-IDed from the then-current main instead of merging stale IDs.

--- a/docs/backlog/consumed/hei_unadded-bx81-getbtc.md
+++ b/docs/backlog/consumed/hei_unadded-bx81-getbtc.md
@@ -1,0 +1,19 @@
+# Consumed backlog item — BX81 GetBTC
+
+Date: 2026-08-28
+
+Source backlog: `docs/backlog/pending-batches/hei_pending_review_0951-1000.md` and earlier 0801–0850 scan.
+
+Consumed candidate:
+- `hei_unadded_0996 GetBTC`
+
+Disposition: promoted to canonical as `records/exchanges/getbtc.json` after terminal-state research.
+
+Why promotion is now justified:
+- the operator's 2017 public announcement establishes the exchange identity and launch-era presence;
+- a dated 2019 record preserves GetBTC's own project-rebirth notice;
+- later review evidence documents continued website unavailability without supplying a defensible exact shutdown date;
+- CoinMarketCap currently marks GetBTC inactive;
+- HEI can therefore represent the lifecycle honestly as `inactive` / `unknown` with `death_date: null` rather than inventing a shutdown cause/date.
+
+Model boundary: no scam, insolvency, regulatory action, or voluntary-shutdown cause is inferred. Jurisdiction remains Global because reviewed sources do not support a single durable operating jurisdiction with sufficient confidence.

--- a/records/exchanges/getbtc.json
+++ b/records/exchanges/getbtc.json
@@ -1,0 +1,101 @@
+{
+  "entity": {
+    "id": "hei_ex_001178",
+    "slug": "getbtc",
+    "canonical_name": "GetBTC",
+    "aliases": ["GetBTC.org"],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": "unknown",
+    "launch_date": "2017-07-05",
+    "death_date": null,
+    "country_or_origin": "Global",
+    "summary": "Centralized cryptocurrency exchange announced by its operator in July 2017. By July 2019 the project was publicly described as attempting to be reborn, and current exchange databases classify GetBTC as inactive. HEI does not infer a precise shutdown date or cause from the available evidence.",
+    "official_url_original": "https://getbtc.org/",
+    "official_domain_original": "getbtc.org",
+    "official_url_status": "unknown",
+    "archived_url": "https://web.archive.org/web/*/https://getbtc.org/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-28",
+    "notes": "The operator account ExchangeGetBTC opened a Bitcointalk announcement thread for GetBTC.org on 2017-07-05 and described the exchange and support endpoint. Cryptowisser later recorded that GetBTC's own website displayed a rebirth message on 2019-07-16 and that the site was still unavailable in November 2020. CoinMarketCap currently marks GetBTC inactive. HEI therefore uses inactive / unknown with death_date null rather than asserting a specific shutdown date, insolvency, scam, regulatory cause, or voluntary closure. Historical third-party directory rows associate GetBTC with multiple jurisdictions, but no durable reviewed operating-jurisdiction artifact was found in this pass, so country_or_origin remains Global rather than guessed."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010206",
+      "exchange_id": "hei_ex_001178",
+      "event_type": "launched",
+      "event_date": "2017-07-05",
+      "title": "GetBTC operator announced the exchange",
+      "description": "The ExchangeGetBTC operator account opened a public announcement thread for GetBTC.org, described the exchange, and published its support endpoint.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "HEI uses the dated operator announcement as the launch marker because it is the earliest reviewed first-party-like public evidence in this pass; it does not prove the exact first completed trade timestamp."
+    },
+    {
+      "id": "hei_ev_010207",
+      "exchange_id": "hei_ex_001178",
+      "event_type": "other",
+      "event_date": "2019-07-16",
+      "title": "GetBTC website displayed a project rebirth notice",
+      "description": "A contemporaneous exchange-review record documented that GetBTC's own website displayed a message saying the project was attempting to be reborn.",
+      "confidence": "medium",
+      "impact_level": "medium",
+      "event_status_effect": "none",
+      "source_count": 1,
+      "sort_order": 2,
+      "notes": "This is preserved as a lifecycle disruption/relaunch-attempt marker. HEI does not convert it into a shutdown date because the underlying notice did not establish a precise terminal date or cause."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012711",
+      "exchange_id": "hei_ex_001178",
+      "event_id": "hei_ev_010206",
+      "source_type": "community_reference",
+      "title": "GetBTC.org - cryptocurrency exchange announcement thread",
+      "url": "https://bitcointalk.org/index.php?topic=2005010.0",
+      "publisher": "ExchangeGetBTC / Bitcointalk",
+      "published_at": "2017-07-05",
+      "archived_url": "https://web.archive.org/web/*/https://bitcointalk.org/index.php?topic=2005010.0",
+      "accessed_at": "2026-08-28",
+      "reliability": "medium",
+      "claim_scope": "launch_date",
+      "notes": "The thread was opened by the ExchangeGetBTC operator account and describes GetBTC.org as an exchange, including the support URL. Because it is hosted on a community forum rather than an independently verified corporate publication, HEI uses medium reliability."
+    },
+    {
+      "id": "hei_src_012712",
+      "exchange_id": "hei_ex_001178",
+      "event_id": "hei_ev_010207",
+      "source_type": "database_reference",
+      "title": "GetBTC exchange review and inactivity updates",
+      "url": "https://www.cryptowisser.com/exchange/getbtc/",
+      "publisher": "Cryptowisser",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/getbtc/",
+      "accessed_at": "2026-08-28",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Cryptowisser records a 2019-07-16 update that GetBTC's website displayed a rebirth notice and a 2020-11-01 update that the website remained unavailable. HEI uses the dated 2019 observation for the lifecycle event and does not infer a terminal date from the later observation."
+    },
+    {
+      "id": "hei_src_012713",
+      "exchange_id": "hei_ex_001178",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "GetBTC trade volume and market listings",
+      "url": "https://coinmarketcap.com/exchanges/getbtc/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/getbtc/",
+      "accessed_at": "2026-08-28",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current CoinMarketCap exchange page marks GetBTC inactive and retains getbtc.org as the historical website. This supports the current inactive classification, not a specific shutdown cause or date."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #895.

## Lane A scope
Adds GetBTC as a reviewed historical inactive centralized exchange record.

### Canonical delta
- +1 entity
- +2 events
- +3 evidence
- +0 lineage edges

### Modeling
- launch marker: 2017-07-05 operator announcement
- 2019-07-16 project-rebirth notice preserved as lifecycle disruption/relaunch-attempt evidence
- current status: `inactive`
- death_reason: `unknown`
- death_date: `null`
- jurisdiction: `Global` rather than guessing from conflicting historical directory labels
- no scam, insolvency, regulatory, or voluntary-shutdown inference

### ID basis
Allocated from exact main `0445e828a829e86d095fe697731b6aca33d3729f`:
- entity `hei_ex_001178`
- events `hei_ev_010206`–`hei_ev_010207`
- evidence `hei_src_012711`–`hei_src_012713`

`hei_src_012710` is already consumed by merged BX80 and is not reused.

### Validation boundaries
- record/audit/consumed-backlog only
- no schema or validator changes
- no monitoring promotion
- no Phase 9 production mutation
- exact event/evidence source counts preserved

If main advances before merge, replay/re-ID this branch from then-current main rather than merging stale IDs.