### PR TITLE
BX83: add Geco.one regulatory shutdown lifecycle record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX83_2026-08-28.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX83_2026-08-28.md
@@ -1,0 +1,50 @@
+# HEI post-D1000 growth audit — BX83 Geco.one
+
+Date: 2026-08-28
+Base main: `4ca488be19c0593e5565e4c660517f68e5a52ce3`
+
+## Decision
+
+Promote Geco.one from the pending-thin backlog as a historical centralized exchange with a first-party-confirmed regulatory shutdown lifecycle.
+
+## Duplicate / identity review
+
+Fresh repository search found no existing canonical Geco.one exchange record. The candidate is treated as the former retail crypto-margin exchange, not as a new entity for the current white-label software business using the same domain.
+
+## Reviewed evidence
+
+1. Geco.one first-party cryptocurrency page: identifies Geco.one as a crypto margin exchange launched in August 2020; identifies Analemma Technologies, s.r.o. as the operator registered in Slovakia; states the trading platform is closing because of implementation of new MiCA regulations; gives 2025-06-23 for deposit blocking and 2025-07-14 for the withdrawal deadline and server disconnection/login termination.
+2. Geco.one current root site: markets a white-label crypto and futures trading-platform service to business customers. This supports `official_url_status: repurposed`; it does not establish continued operation of the historical retail exchange.
+3. BitDegree exchange page: currently marks Geco.one inactive/untracked. This is secondary status corroboration only.
+
+## Modeling
+
+- entity: `hei_ex_001180`
+- status: `dead`
+- death_reason: `regulation`
+- death_date: `2025-07-14`
+- launch_date: `null`
+- launch month retained only in notes/evidence: August 2020
+- country_or_origin: `Slovakia`
+- official_url_status: `repurposed`
+- event: `hei_ev_010208` (`shutdown_effective`, 2025-07-14)
+- evidence: `hei_src_012717`–`hei_src_012719`
+
+The closure notice does not expose a publication date in the reviewed page, so HEI does not invent a separate `shutdown_announced` event date. The dated terminal action is recorded as `shutdown_effective`.
+
+## Safety boundaries
+
+- No exact launch day is inferred from an August 2020 statement.
+- The surviving Geco.one white-label business is not used to classify the former retail exchange as active.
+- MiCA/regulation is used as death_reason only because the first-party closure notice explicitly attributes the shutdown to that regulatory implementation.
+- No insolvency, hack, scam, or customer-loss inference is made.
+- No schema, validator, monitoring, or Phase 9 production mutation is included.
+
+## Canonical delta
+
+- +1 entity
+- +1 event
+- +3 evidence
+- +0 lineage edges
+
+If main advances before merge, replay and re-ID this batch from then-current main.

--- a/docs/backlog/consumed/hei_unadded-bx83-geco-one.md
+++ b/docs/backlog/consumed/hei_unadded-bx83-geco-one.md
@@ -1,0 +1,10 @@
+# Consumed backlog candidate — BX83 Geco.one
+
+- Source backlog candidate: `hei_unadded_0995 Geco one`
+- Canonical slug: `geco-one`
+- Canonical entity: `hei_ex_001180`
+- Decision: promoted after fresh first-party shutdown research
+- Status: `dead`
+- Death reason: `regulation`
+- Death date: `2025-07-14`
+- Key correction versus stale backlog: the former thin candidate now has explicit first-party closure evidence, including the MiCA attribution and terminal platform-disconnection date.

--- a/records/exchanges/geco-one.json
+++ b/records/exchanges/geco-one.json
@@ -1,0 +1,87 @@
+{
+  "entity": {
+    "id": "hei_ex_001180",
+    "slug": "geco-one",
+    "canonical_name": "Geco.one",
+    "aliases": ["Geco One", "Geco.one Exchange"],
+    "type": "cex",
+    "status": "dead",
+    "death_reason": "regulation",
+    "launch_date": null,
+    "death_date": "2025-07-14",
+    "country_or_origin": "Slovakia",
+    "summary": "Crypto margin exchange whose operator announced closure of the trading platform in 2025 due to implementation of MiCA regulations. Deposits were scheduled to stop on June 23 and the platform to be disconnected on July 14, 2025. The geco.one domain now promotes a white-label trading-platform business rather than the former retail exchange.",
+    "official_url_original": "https://www.geco.one/",
+    "official_domain_original": "geco.one",
+    "official_url_status": "repurposed",
+    "archived_url": "https://web.archive.org/web/*/https://www.geco.one/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-28",
+    "notes": "Geco.one's first-party exchange page identifies the platform as launched in August 2020 and operated by Analemma Technologies, s.r.o., registered in Slovakia. HEI leaves launch_date null because the source supports only a month, not an exact calendar day. The same first-party page states that the trading platform would close because of new MiCA regulations, with deposits blocked from 2025-06-23, withdrawals available until 2025-07-14, and server disconnection/login termination on 2025-07-14. The current root domain markets a white-label crypto and futures platform; HEI treats that as domain/business repurposing, not continued operation of the historical retail exchange."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010208",
+      "exchange_id": "hei_ex_001180",
+      "event_type": "shutdown_effective",
+      "event_date": "2025-07-14",
+      "title": "Geco.one trading platform reached its announced shutdown date",
+      "description": "Geco.one told users that deposits would be blocked from June 23, withdrawals would remain possible until July 14, and on July 14, 2025 the trading platform would be disconnected from its servers and login would no longer be possible. The operator attributed the closure to implementation of new MiCA regulations.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "dead",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "HEI uses 2025-07-14 as death_date because the first-party closure notice explicitly identifies that date for server disconnection and loss of login access."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012717",
+      "exchange_id": "hei_ex_001180",
+      "event_id": "hei_ev_010208",
+      "source_type": "official_statement",
+      "title": "Geco.one trading-platform closure notice and exchange FAQ",
+      "url": "https://www.geco.one/cryptocurrencies",
+      "publisher": "Geco.one",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.geco.one/cryptocurrencies",
+      "accessed_at": "2026-08-28",
+      "reliability": "high",
+      "claim_scope": "death_reason",
+      "notes": "First-party page states that the trading platform is closing because of implementation of new MiCA regulations, gives the June 23 deposit-block date and July 14 withdrawal/server-disconnection deadline, and separately identifies the historical exchange as launched in August 2020 and operated by Analemma Technologies, s.r.o. registered in Slovakia."
+    },
+    {
+      "id": "hei_src_012718",
+      "exchange_id": "hei_ex_001180",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Geco.one current white-label trading-platform site",
+      "url": "https://www.geco.one/",
+      "publisher": "Geco.one",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.geco.one/",
+      "accessed_at": "2026-08-28",
+      "reliability": "high",
+      "claim_scope": "url_history",
+      "notes": "Current first-party root site markets a white-label crypto and futures trading-platform solution to brokers, fintech startups, and trading firms. HEI uses this to classify the historical exchange domain as repurposed rather than as evidence that the former retail exchange remains active."
+    },
+    {
+      "id": "hei_src_012719",
+      "exchange_id": "hei_ex_001180",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Geco.one exchange status page",
+      "url": "https://www.bitdegree.org/top-crypto-exchanges/geco-one",
+      "publisher": "BitDegree",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.bitdegree.org/top-crypto-exchanges/geco-one",
+      "accessed_at": "2026-08-28",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current exchange directory page marks Geco.one inactive/untracked. This is secondary confirmation only; HEI's terminal date and regulatory cause come from Geco.one's first-party closure notice."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #898.

## Lane A scope
Adds Geco.one as a reviewed historical centralized exchange with a first-party-confirmed regulatory shutdown lifecycle.

### Canonical delta
- +1 entity (`hei_ex_001180`)
- +1 event (`hei_ev_010208`)
- +3 evidence (`hei_src_012717`–`hei_src_012719`)
- +0 lineage edges

### Modeling
- status: `dead`
- death_reason: `regulation`
- death_date: `2025-07-14`
- launch_date: `null`; first-party material supports August 2020 only
- country_or_origin: `Slovakia` based on the first-party operator statement
- official_url_status: `repurposed` because the root domain now markets a white-label trading-platform business

### Lifecycle boundary
The closure page gives exact operational dates but no publication date for the notice. Therefore HEI records only the exact `shutdown_effective` date and does not invent a separate `shutdown_announced` date.

### Safety
- no false exact launch date
- no conflation of the surviving white-label business with continued operation of the former retail exchange
- no insolvency/hack/scam inference
- no schema/validator changes

Base main: `4ca488be19c0593e5565e4c660517f68e5a52ce3`.
If main advances before merge, replay/re-ID from current main.