### PR TITLE
Fix BX85 FameEX consumed candidate IDs

### DIFF
--- a/docs/backlog/consumed/hei_unadded-bx85-fameex-reconciled.md
+++ b/docs/backlog/consumed/hei_unadded-bx85-fameex-reconciled.md
@@ -3,9 +3,9 @@
 Date: 2026-08-29
 
 Reviewed stale backlog rows:
-- `hei_unadded_0880 FameEX`
-- `hei_unadded_0881 FameEX`
-- `hei_unadded_0882 FameEX Derivatives`
+- `hei_unadded_0728 FameEX`
+- `hei_unadded_0729 FameEX`
+- `hei_unadded_0730 FameEX Derivatives`
 
 Result: consumed as existing canonical entity, not new records.
 
@@ -14,3 +14,5 @@ Canonical target:
 - entity `hei_ex_000750`
 
 Fresh first-party evidence confirms the operator as FAMEEX INTERNATIONAL PTY LTD, registered in Australia since 2020, and confirms current exchange operations through 2026-08-26. BX85 repairs the existing record instead of creating duplicate spot/derivatives entities.
+
+Correction note: the original BX85 marker mistakenly listed `hei_unadded_0880`–`0882`; the verified D-750 scan shows the actual FameEX rows are `hei_unadded_0728`–`0730`.


### PR DESCRIPTION
Corrects the BX85 consumed-backlog marker after a post-merge verification found the listed candidate IDs were wrong.

Verified D-750 scan rows:
- `hei_unadded_0728 FameEX`
- `hei_unadded_0729 FameEX`
- `hei_unadded_0730 FameEX Derivatives`

The previous marker incorrectly listed `0880`–`0882`.

Documentation-only correction; no canonical entity/event/evidence changes.