### PR TITLE
BX87: add Exbitron shutdown-transition record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX87_2026-08-29.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX87_2026-08-29.md
@@ -1,0 +1,49 @@
+# HEI post-D1000 growth audit — BX87 Exbitron shutdown transition
+
+Date: 2026-08-29
+Base main: `833c458d7c9cd75871592f40434b1b7f9266bc63`
+
+## Candidate
+
+- backlog row: `hei_unadded_0710 Exbitron`
+- prior disposition: `needs_research`
+- fresh canonical/code search found no existing Exbitron exchange entity
+
+## First-party evidence
+
+1. Exbitron's current application page states that Exbitron is shutting down permanently, tells users to withdraw all funds, and warns that assets will no longer be accessible after closure. Login and withdrawal access remain available.
+2. The same first-party shutdown narrative says Exbitron started in 2020, but gives no exact launch date.
+3. Exbitron's historical press kit identifies the service as a centralized cryptocurrency exchange and states in its FAQ that the exchange is based in Germany.
+4. The shutdown narrative retrospectively mentions a serious exploit, bear-market pressure, service-provider/infrastructure/compliance costs, and unsuccessful investment/takeover/partnership efforts. These statements do not provide an exact exploit date or a sufficiently bounded terminal cause.
+
+## Corroboration
+
+Nexa Forum lists a June 10, 2026 topic titled `Important Notice: Exbitron is Shutting Down Permanently`. This is community corroboration only. HEI does not use that date as the first-party announcement date and therefore does not create a dated shutdown event from it.
+
+## Modeling
+
+- entity: `hei_ex_001183`
+- type: `cex`
+- status: `limited`
+- death_reason: `null`
+- launch_date: `null`
+- death_date: `null`
+- country_or_origin: `Germany`
+- official_url_status: `live_verified`
+- events: none
+- evidence: `hei_src_012730`–`hei_src_012732`
+
+## State boundary
+
+The permanent-shutdown intention is clear, but the shutdown has not yet been modeled as completed because the current first-party application still exposes account/login and withdrawal access. `limited` therefore represents the observed transitional state more accurately than `dead`.
+
+No exact launch date is invented from the year-only 2020 statement. No exploit event is created without an exact date. No `shutdown_announced` event is created because the first-party publication date is not established. No death reason is assigned from the retrospective narrative.
+
+## Delta
+
+- +1 entity
+- +0 events
+- +3 evidence
+- +0 lineage edges
+
+No schema, validator, monitoring, localization, or Phase 9 production changes are included.

--- a/docs/backlog/consumed/hei_unadded_0710-exbitron.md
+++ b/docs/backlog/consumed/hei_unadded_0710-exbitron.md
@@ -1,0 +1,14 @@
+# BX87 — Exbitron candidate reconciliation
+
+Date: 2026-08-29
+
+Reviewed backlog row:
+- `hei_unadded_0710 Exbitron`
+
+Result: promoted to a reviewed canonical exchange record after first-party current-state reconstruction.
+
+Canonical target:
+- `records/exchanges/exbitron.json`
+- entity `hei_ex_001183`
+
+Current first-party evidence supports a permanent-shutdown transition with withdrawals still available. HEI therefore records `limited`, not `dead`, with `death_date: null` and no dated shutdown event until an exact first-party event date or completed terminal state is established.

--- a/records/exchanges/exbitron.json
+++ b/records/exchanges/exbitron.json
@@ -1,0 +1,72 @@
+{
+  "entity": {
+    "id": "hei_ex_001183",
+    "slug": "exbitron",
+    "canonical_name": "Exbitron",
+    "aliases": [],
+    "type": "cex",
+    "status": "limited",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Germany",
+    "summary": "Centralized cryptocurrency exchange launched in 2020 that is now in a permanent-shutdown transition while retaining account access for users to withdraw remaining funds.",
+    "official_url_original": "https://app.exbitron.com/",
+    "official_domain_original": "exbitron.com",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://app.exbitron.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-08-29",
+    "notes": "Exbitron's current first-party site states that the exchange is shutting down permanently and instructs users to withdraw all funds, while login and withdrawal access remain available. HEI therefore records a limited transitional state rather than dead. The site states that Exbitron started in 2020, but no exact launch day is established. A historical first-party press-kit FAQ describes the exchange as based in Germany; this is used as country_or_origin without inferring a specific legal entity or regulatory status. The shutdown page retrospectively mentions an exploit and later financial/operational pressures, but HEI does not infer an exploit date or assign a terminal cause from that narrative."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012730",
+      "exchange_id": "hei_ex_001183",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Exbitron permanent shutdown notice",
+      "url": "https://app.exbitron.com/",
+      "publisher": "Exbitron",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.exbitron.com/",
+      "accessed_at": "2026-08-29",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party page states that Exbitron is shutting down permanently, instructs users to withdraw all funds, and warns that assets will no longer be accessible after closure. Login and withdrawal access remain exposed, supporting a limited transition rather than a completed shutdown. The page also says the exchange started in 2020 without giving an exact launch date."
+    },
+    {
+      "id": "hei_src_012731",
+      "exchange_id": "hei_ex_001183",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Exbitron press kit",
+      "url": "https://app.exbitron.com/press-kit/",
+      "publisher": "Exbitron",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://app.exbitron.com/press-kit/",
+      "accessed_at": "2026-08-29",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "Historical first-party press material identifies Exbitron as a centralized cryptocurrency exchange and its FAQ describes the exchange as based in Germany. It does not establish a durable legal-entity identity or an exact launch day."
+    },
+    {
+      "id": "hei_src_012732",
+      "exchange_id": "hei_ex_001183",
+      "event_id": null,
+      "source_type": "community_reference",
+      "title": "Important Notice: Exbitron is Shutting Down Permanently",
+      "url": "https://forum.nexa.org/c/general/4",
+      "publisher": "Nexa Forum",
+      "published_at": "2026-06-10",
+      "archived_url": "https://web.archive.org/web/*/https://forum.nexa.org/c/general/4",
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Community corroboration showing a June 10, 2026 topic titled 'Important Notice: Exbitron is Shutting Down Permanently'. This date is not treated as the first-party announcement date and no lifecycle event date is inferred from it."
+    }
+  ]
+}


### PR DESCRIPTION
Adds reviewed canonical coverage for Exbitron from backlog candidate `hei_unadded_0710`.

Modeling:
- entity `hei_ex_001183`
- type `cex`
- status `limited`
- death_reason `null`
- launch_date `null`
- death_date `null`
- country_or_origin `Germany`
- official_url_status `live_verified`
- events `[]`
- evidence `hei_src_012730`–`hei_src_012732`

Boundary: Exbitron's current first-party site says it is shutting down permanently and asks users to withdraw all funds, but login/withdrawal access remains available. This batch therefore does not mark the exchange dead. No dated shutdown event or exploit event is inferred without a first-party exact date.

Includes audit and consumed marker. No schema or validator changes.