### PR TITLE
BX88: add ExMarkets inactive record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX88_2026-08-29.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX88_2026-08-29.md
@@ -1,0 +1,45 @@
+# HEI post-D1000 growth audit — BX88 ExMarkets inactive reconstruction
+
+Date: 2026-08-29
+Base main: `9fe7da0c712650a3aeb6d1f2941952bc5b3ca81d`
+
+## Candidate
+
+- backlog row: `hei_unadded_0717 ExMarkets`
+- prior disposition: `needs_research`
+- fresh canonical/code search found no existing ExMarkets exchange entity
+
+## Evidence
+
+1. The European Commission EU Digital Finance Platform lists ExMarkets with launch year 2017, location Vilnius, Lithuania, and an exmarkets.com trading URL.
+2. A preserved copy of ExMarkets Terms of Service defines ExMarkets as Chain Framework Ltd., B.V.I. and describes the trading service.
+3. The branded ExMarkets Kayako support center remains reachable.
+4. Current exchange-directory monitoring classifies ExMarkets as discontinued/inactive and records the main exmarkets.com site as offline.
+
+## Modeling
+
+- entity: `hei_ex_001184`
+- type: `cex`
+- status: `inactive`
+- death_reason: `unknown`
+- launch_date: `null`
+- death_date: `null`
+- country_or_origin: `Lithuania`
+- official_url_status: `dead_domain`
+- events: none
+- evidence: `hei_src_012733`–`hei_src_012736`
+
+## Boundary decisions
+
+The Commission source supports a Lithuanian location/origin and a 2017 launch year, but not an exact launch day; HEI therefore does not fabricate a date. The preserved Terms of Service supports the BVI operating legal entity, so the record notes the Lithuania/BVI distinction rather than forcing both concepts into one jurisdiction field.
+
+The main exchange domain being offline is sufficient, together with current exchange-directory status, to support `inactive`, but it is not sufficient to prove an exact shutdown date or a terminal cause. The residual support center also means HEI should not infer that all operator infrastructure disappeared on the first observed domain-offline date. No dated shutdown event is created.
+
+## Delta
+
+- +1 entity
+- +0 events
+- +4 evidence
+- +0 lineage edges
+
+No schema, validator, monitoring, localization, or Phase 9 production changes are included.

--- a/docs/backlog/consumed/hei_unadded_0717-exmarkets.md
+++ b/docs/backlog/consumed/hei_unadded_0717-exmarkets.md
@@ -1,0 +1,14 @@
+# BX88 — ExMarkets candidate reconciliation
+
+Date: 2026-08-29
+
+Reviewed backlog row:
+- `hei_unadded_0717 ExMarkets`
+
+Result: promoted to a reviewed canonical exchange record after current-state and historical-identity reconstruction.
+
+Canonical target:
+- `records/exchanges/exmarkets.json`
+- entity `hei_ex_001184`
+
+Reviewed evidence supports an inactive exchange with the main domain offline while residual branded support infrastructure remains reachable. HEI records `inactive` with `death_reason: unknown`, `death_date: null`, and no dated shutdown event because no reviewed first-party terminal notice establishes an exact closure date or cause.

--- a/records/exchanges/exmarkets.json
+++ b/records/exchanges/exmarkets.json
@@ -1,0 +1,88 @@
+{
+  "entity": {
+    "id": "hei_ex_001184",
+    "slug": "exmarkets",
+    "canonical_name": "ExMarkets",
+    "aliases": ["ExMarkets.com"],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Lithuania",
+    "summary": "Centralized cryptocurrency exchange associated with Vilnius, Lithuania, and operated through Chain Framework Ltd. in the British Virgin Islands. The main exchange domain is no longer operational while a legacy support center remains reachable; HEI therefore records ExMarkets as inactive without inferring a precise shutdown date or cause.",
+    "official_url_original": "https://exmarkets.com/",
+    "official_domain_original": "exmarkets.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://exmarkets.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-29",
+    "notes": "The European Commission's EU Digital Finance Platform lists ExMarkets with launch year 2017 and location Vilnius, Lithuania; HEI uses Lithuania as country_or_origin but does not invent an exact launch day from year-only evidence. A preserved copy of ExMarkets Terms of Service identifies ExMarkets as Chain Framework Ltd., B.V.I., documenting the operating legal entity without overriding the separately supported Lithuanian origin/location. The current ExMarkets Kayako support center remains reachable, while current exchange-directory monitoring reports the main exmarkets.com exchange site offline. HEI therefore uses inactive / unknown with death_date null rather than treating a domain-offline observation as an exact shutdown event or terminal date.
+"
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012733",
+      "exchange_id": "hei_ex_001184",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "ExMarkets — EU Digital Finance Platform",
+      "url": "https://digital-finance-platform.ec.europa.eu/observatory/eu-fintech-map/exmarkets",
+      "publisher": "European Commission — DG FISMA",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://digital-finance-platform.ec.europa.eu/observatory/eu-fintech-map/exmarkets",
+      "accessed_at": "2026-08-29",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "The EU Digital Finance Platform lists ExMarkets with launch date 2017, location Vilnius, Lithuania, and an exmarkets.com trading URL. The year-only launch field supports historical existence and origin/location but not an exact launch date."
+    },
+    {
+      "id": "hei_src_012734",
+      "exchange_id": "hei_ex_001184",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "ExMarkets Support Center",
+      "url": "https://exm.kayako.com/",
+      "publisher": "ExMarkets",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://exm.kayako.com/",
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "url_history",
+      "notes": "The branded ExMarkets support center remains reachable and offers conversation/sign-in entry points. This shows residual support infrastructure but does not establish that the trading exchange itself remains operational."
+    },
+    {
+      "id": "hei_src_012735",
+      "exchange_id": "hei_ex_001184",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "ExMarkets exchange status",
+      "url": "https://blockspot.io/exchange/exmarkets/",
+      "publisher": "Blockspot.io",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blockspot.io/exchange/exmarkets/",
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Current exchange-directory monitoring classifies ExMarkets as inactive/discontinued and records exmarkets.com as offline. HEI uses this to support current inactive status and dead-domain classification, but does not treat the directory's first-observed offline date as a proven shutdown date."
+    },
+    {
+      "id": "hei_src_012736",
+      "exchange_id": "hei_ex_001184",
+      "event_id": null,
+      "source_type": "archive_capture",
+      "title": "ExMarkets Terms of Service preserved copy",
+      "url": "https://wikibitimg.tech002.com/attach/2020/10/742917341/WBE742917341_94436.pdf",
+      "publisher": "ExMarkets / preserved copy",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Preserved Terms of Service text defines ExMarkets as Chain Framework Ltd., B.V.I. and describes ExMarkets as a digital-currency trading platform. This supports historical operator identity and CEX classification; it is not used to infer terminal state or date."
+    }
+  ]
+}

--- a/records/exchanges/exmarkets.json
+++ b/records/exchanges/exmarkets.json
@@ -19,8 +19,7 @@
     "successor_id": null,
     "confidence": "medium",
     "last_verified_at": "2026-08-29",
-    "notes": "The European Commission's EU Digital Finance Platform lists ExMarkets with launch year 2017 and location Vilnius, Lithuania; HEI uses Lithuania as country_or_origin but does not invent an exact launch day from year-only evidence. A preserved copy of ExMarkets Terms of Service identifies ExMarkets as Chain Framework Ltd., B.V.I., documenting the operating legal entity without overriding the separately supported Lithuanian origin/location. The current ExMarkets Kayako support center remains reachable, while current exchange-directory monitoring reports the main exmarkets.com exchange site offline. HEI therefore uses inactive / unknown with death_date null rather than treating a domain-offline observation as an exact shutdown event or terminal date.
-"
+    "notes": "The European Commission's EU Digital Finance Platform lists ExMarkets with launch year 2017 and location Vilnius, Lithuania; HEI uses Lithuania as country_or_origin but does not invent an exact launch day from year-only evidence. A preserved copy of ExMarkets Terms of Service identifies ExMarkets as Chain Framework Ltd., B.V.I., documenting the operating legal entity without overriding the separately supported Lithuanian origin/location. The current ExMarkets Kayako support center remains reachable, while current exchange-directory monitoring reports the main exmarkets.com exchange site offline. HEI therefore uses inactive / unknown with death_date null rather than treating a domain-offline observation as an exact shutdown event or terminal date."
   },
   "events": [],
   "evidence": [


### PR DESCRIPTION
Adds reviewed canonical coverage for backlog candidate `hei_unadded_0717 ExMarkets`.

Modeling:
- entity `hei_ex_001184`
- type `cex`
- status `inactive`
- death_reason `unknown`
- launch_date `null`
- death_date `null`
- country_or_origin `Lithuania`
- official_url_status `dead_domain`
- events `[]`
- evidence `hei_src_012733`–`hei_src_012736`

Boundary: the European Commission EU Digital Finance Platform supports a Vilnius/Lithuania location and year-only 2017 launch; preserved ExMarkets terms identify Chain Framework Ltd., B.V.I. Current evidence supports that the main exchange domain is offline while a branded support center remains reachable. No exact shutdown date or terminal cause is inferred.

Includes audit and consumed marker. No schema or validator changes.