### PR TITLE
BX91: add EXX inactive record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX91_2026-08-29.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX91_2026-08-29.md
@@ -1,0 +1,30 @@
+# HEI Post-D1000 Growth — BX91
+
+## Candidate
+
+- Backlog ID: `hei_unadded_0725`
+- Name: EXX
+
+## Decision
+
+Promote EXX to canonical as an inactive centralized exchange.
+
+## Canonical model
+
+- entity: `hei_ex_001187`
+- status: `inactive`
+- death_reason: `unknown`
+- launch_date: `null`
+- death_date: `null`
+- country_or_origin: `Global`
+- official_url_status: `dead_domain`
+- events: none
+- evidence: `hei_src_012744`–`hei_src_012746`
+
+## Evidence boundary
+
+CoinMarketCap identifies EXX as EXX Group Limited and gives an October 2017 launch, but only at month precision. Blockspot and Cryptowisser independently classify EXX as inactive and record the main domain unavailable on 2021-11-11. That date is retained as an observation, not promoted to an exact shutdown date. Geographic descriptions vary between China, Hong Kong, and Shenzhen, so HEI leaves country/origin at Global rather than guessing. No terminal cause is inferred.
+
+## Validation intent
+
+No schema, validator, or allowlist changes. The record must pass existing canonical gates unchanged.

--- a/docs/backlog/consumed/hei_unadded_0725-exx.md
+++ b/docs/backlog/consumed/hei_unadded_0725-exx.md
@@ -1,0 +1,5 @@
+# Consumed candidate: hei_unadded_0725 EXX
+
+Promoted in BX91 to canonical record `records/exchanges/exx.json` as `hei_ex_001187`.
+
+Review boundary: inactive / unknown terminal cause / no exact death date / country_or_origin Global due inconsistent geographic descriptions.

--- a/records/exchanges/exx.json
+++ b/records/exchanges/exx.json
@@ -1,0 +1,72 @@
+{
+  "entity": {
+    "id": "hei_ex_001187",
+    "slug": "exx",
+    "canonical_name": "EXX",
+    "aliases": ["Exchange X", "Exx.com"],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Global",
+    "summary": "Centralized cryptocurrency exchange operated by EXX Group Limited and formerly available at exx.com. Current exchange-directory evidence records EXX as inactive and the main website unavailable, but does not establish an exact shutdown date or terminal cause.",
+    "official_url_original": "https://www.exx.com/",
+    "official_domain_original": "exx.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.exx.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-29",
+    "notes": "CoinMarketCap states that EXX was launched in October 2017 and operated by EXX Group Limited, while describing it as based in Hong Kong and Shenzhen. Other directories variously classify the exchange as China-based. Because the geographic descriptions are inconsistent, country_or_origin remains Global. Blockspot and Cryptowisser both classify EXX as inactive and record exx.com as unavailable on 2021-11-11; HEI treats that date as first-observed unavailability rather than a precise shutdown date. No shutdown cause is inferred."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012744",
+      "exchange_id": "hei_ex_001187",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "EXX exchange profile",
+      "url": "https://coinmarketcap.com/exchanges/exx/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/exx/",
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "CoinMarketCap identifies EXX as EXX Group Limited, launched in October 2017, and describes it as based in Hong Kong and Shenzhen. The month-level launch statement does not support an exact launch_date."
+    },
+    {
+      "id": "hei_src_012745",
+      "exchange_id": "hei_ex_001187",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "EXX discontinued exchange profile",
+      "url": "https://blockspot.io/exchange/exx/",
+      "publisher": "Blockspot",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://blockspot.io/exchange/exx/",
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Blockspot classifies EXX as inactive and records exx.com offline since 2021-11-11. HEI uses this to support inactive status and dead-domain classification only, not an exact shutdown date or cause."
+    },
+    {
+      "id": "hei_src_012746",
+      "exchange_id": "hei_ex_001187",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "EXX inactive exchange review",
+      "url": "https://www.cryptowisser.com/exchange/exx/",
+      "publisher": "Cryptowisser",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/exx/",
+      "accessed_at": "2026-08-29",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Cryptowisser flags EXX inactive and records an unsuccessful access attempt on 2021-11-11 without a preceding maintenance or migration notice. HEI treats this as corroboration of inactivity, not proof of a precise shutdown date or terminal cause."
+    }
+  ]
+}


### PR DESCRIPTION
Adds reviewed canonical coverage for backlog candidate `hei_unadded_0725 EXX`.

Modeling:
- entity `hei_ex_001187`
- type `cex`
- status `inactive`
- death_reason `unknown`
- launch_date `null`
- death_date `null`
- country_or_origin `Global`
- official_url_status `dead_domain`
- events `[]`
- evidence `hei_src_012744`–`hei_src_012746`

Boundary: month-level 2017 launch evidence is not promoted to an exact launch date; 2021-11-11 is retained only as first-observed unavailability, not a precise shutdown date. Conflicting geographic descriptions are not guessed into a jurisdiction. No shutdown cause is inferred.

Includes audit and consumed marker. No schema or validator changes.

Closes #917.