### PR TITLE
BX92: add FatBTC inactive record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX92_2026-08-30.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX92_2026-08-30.md
@@ -1,0 +1,29 @@
+# HEI post-D1000 growth audit — BX92 FatBTC — 2026-08-30
+
+## Candidate
+
+- backlog: `hei_unadded_0737 Fatbtc`
+- canonical duplicate search: no existing FatBTC canonical record found on current main before branch creation
+- branch base: `521d65342af01ec63fe21e0e33f320005f0c6efa`
+
+## Result
+
+Add one reviewed historical centralized-exchange entity for FatBTC.
+
+- entity: `hei_ex_001188`
+- status: `inactive`
+- death_reason: `unknown`
+- launch_date: `null`
+- death_date: `null`
+- country_or_origin: `Global`
+- official_url_status: `dead_domain`
+- events: none
+- evidence: `hei_src_012747`–`hei_src_012749`
+
+## Evidence boundary
+
+Current CoinMarketCap and BitDegree listings classify FatBTC as inactive/untracked. Cryptowisser records an unsuccessful website access check on 2024-09-18 and moved the exchange to its graveyard. Historical exchange-directory material preserves FatBTC exchange activity into 2021. Secondary material that describes a shutdown around 2022 is approximate.
+
+HEI does **not** promote 2024-09-18 or an approximate 2022 date to `death_date`, and does not infer a terminal cause. Geographic descriptions conflict between Seychelles, Hong Kong and China, so no jurisdiction is guessed.
+
+No schema, validator, enum, allowlist or quality-gate changes are required for this addition.

--- a/docs/backlog/consumed/hei_unadded_0737-fatbtc.md
+++ b/docs/backlog/consumed/hei_unadded_0737-fatbtc.md
@@ -1,0 +1,9 @@
+# Consumed backlog candidate — hei_unadded_0737 Fatbtc
+
+- canonical slug: `fatbtc`
+- canonical entity: `hei_ex_001188`
+- Lane A batch: BX92
+- disposition: added as reviewed inactive historical CEX record
+- issue: #922
+
+Boundary: no exact shutdown date or terminal cause inferred; conflicting geographic descriptions remain unresolved as `Global`.

--- a/records/exchanges/fatbtc.json
+++ b/records/exchanges/fatbtc.json
@@ -1,0 +1,72 @@
+{
+  "entity": {
+    "id": "hei_ex_001188",
+    "slug": "fatbtc",
+    "canonical_name": "FatBTC",
+    "aliases": ["Fatbtc", "Fat BTC"],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Global",
+    "summary": "Centralized cryptocurrency exchange formerly operating at fatbtc.com. Current exchange directories classify FatBTC as inactive or untracked, while later access checks found the original site unavailable. HEI does not infer a precise shutdown date or terminal cause from those observations.",
+    "official_url_original": "https://www.fatbtc.com/",
+    "official_domain_original": "fatbtc.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://www.fatbtc.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-30",
+    "notes": "FatBTC is consistently described as a centralized cryptocurrency exchange founded in 2014, but available sources conflict on geographic origin or registration, including Seychelles, Hong Kong and China; country_or_origin therefore remains Global. CoinMarketCap currently marks FatBTC inactive, BitDegree marks it inactive/untracked, and Cryptowisser records an unsuccessful access check on 2024-09-18 before placing it in its exchange graveyard. HEI treats 2024-09-18 as an observation date only, not as the exact shutdown date. Secondary documentation suggesting a shutdown around 2022 is approximate and is not promoted to death_date."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012747",
+      "exchange_id": "hei_ex_001188",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Fatbtc exchange listing and inactive status",
+      "url": "https://coinmarketcap.com/exchanges/fatbtc/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/fatbtc/",
+      "accessed_at": "2026-08-30",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "CoinMarketCap currently identifies Fatbtc as an inactive exchange and links the historical fatbtc.com domain. HEI uses this for inactive status corroboration only, not for an exact shutdown date or cause."
+    },
+    {
+      "id": "hei_src_012748",
+      "exchange_id": "hei_ex_001188",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "FatBTC exchange graveyard update",
+      "url": "https://www.cryptowisser.com/exchange/fatbtc/",
+      "publisher": "Cryptowisser",
+      "published_at": "2024-09-18",
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange/fatbtc/",
+      "accessed_at": "2026-08-30",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Cryptowisser records that it was unable to access the FatBTC website on 2024-09-18 and moved the exchange to its graveyard, while noting no preceding maintenance or migration message. HEI treats this as first-observed unavailability, not a precise shutdown date."
+    },
+    {
+      "id": "hei_src_012749",
+      "exchange_id": "hei_ex_001188",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "FatBTC historical exchange activity and 2021 announcements",
+      "url": "https://www.coinlore.com/exchange/fatbtc",
+      "publisher": "CoinLore",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.coinlore.com/exchange/fatbtc",
+      "accessed_at": "2026-08-30",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "CoinLore preserves historical FatBTC exchange activity and announcements from 2021, including scheduled maintenance and subsequent service resumption. This supports the historical exchange identity and continued operation into 2021, but not a terminal date or cause."
+    }
+  ]
+}


### PR DESCRIPTION
Adds reviewed canonical coverage for backlog candidate `hei_unadded_0737 Fatbtc`.

Modeling:
- entity `hei_ex_001188`
- type `cex`
- status `inactive`
- death_reason `unknown`
- launch_date `null`
- death_date `null`
- country_or_origin `Global`
- official_url_status `dead_domain`
- events `[]`
- evidence `hei_src_012747`–`hei_src_012749`

Boundary: current directory evidence supports inactive status and historical operation, but available shutdown timing is approximate or first-observed only. Geographic descriptions conflict between Seychelles, Hong Kong and China, so HEI does not guess a jurisdiction. No scam, insolvency or exact shutdown date is inferred.

Includes audit and consumed marker. No schema or validator changes.

Closes #922.