### PR TITLE
BX95: add Folgory inactive record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX95_2026-08-31.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX95_2026-08-31.md
@@ -1,0 +1,9 @@
+# HEI post-D1000 growth — BX95
+
+Candidate: `hei_unadded_0793` Folgory.
+
+Decision: promote as historical centralized exchange with `status: inactive`, `death_reason: unknown`, and `death_date: null`.
+
+Evidence boundary: CoinMarketCap preserves the historical exchange identity, Seychelles origin, May 2019 launch month, and currently untracked listing. CoinCodex states the exchange is no longer operational. Cryptowisser lists Folgory in its exchange graveyard, but its specific 2021-07-13 death date and scam label are not promoted without stronger primary or regulatory evidence.
+
+No lifecycle event is added because no exact shutdown announcement/effective date or independently supported terminal cause was recovered.

--- a/docs/backlog/consumed/hei_unadded_0793-folgory.md
+++ b/docs/backlog/consumed/hei_unadded_0793-folgory.md
@@ -1,0 +1,3 @@
+# Consumed candidate — hei_unadded_0793 Folgory
+
+Canonical promotion prepared in BX95 after current-state reconstruction. Modeled as an inactive centralized exchange with unknown terminal cause and no exact death date. Secondary graveyard labels are not promoted to `scam_rug` or an exact shutdown date without stronger evidence.

--- a/records/exchanges/folgory.json
+++ b/records/exchanges/folgory.json
@@ -1,0 +1,72 @@
+{
+  "entity": {
+    "id": "hei_ex_001189",
+    "slug": "folgory",
+    "canonical_name": "Folgory",
+    "aliases": ["Folgory Exchange"],
+    "type": "cex",
+    "status": "inactive",
+    "death_reason": "unknown",
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Seychelles",
+    "summary": "Centralized cryptocurrency exchange launched in 2019 and formerly operating at folgory.com. Current exchange directories no longer track active markets or explicitly classify the venue as no longer operational. HEI does not infer an exact shutdown date or terminal cause from secondary graveyard labels.",
+    "official_url_original": "https://folgory.com/",
+    "official_domain_original": "folgory.com",
+    "official_url_status": "dead_domain",
+    "archived_url": "https://web.archive.org/web/*/https://folgory.com/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "medium",
+    "last_verified_at": "2026-08-31",
+    "notes": "CoinMarketCap identifies Folgory as a centralized exchange launched in May 2019 and based in Seychelles, but currently marks the listing untracked with no market data. CoinCodex states the exchange is no longer operational. Cryptowisser places Folgory in its exchange graveyard and labels a 2021-07-13 death date and scam cause; HEI does not promote that date or cause because stronger primary or regulatory evidence establishing the exact terminal event was not recovered in this review pass."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_012750",
+      "exchange_id": "hei_ex_001189",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Folgory exchange listing and untracked status",
+      "url": "https://coinmarketcap.com/exchanges/folgory/",
+      "publisher": "CoinMarketCap",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coinmarketcap.com/exchanges/folgory/",
+      "accessed_at": "2026-08-31",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "CoinMarketCap identifies Folgory as a centralized exchange launched in May 2019, based in Seychelles, and historically operating at folgory.com. The current listing is untracked and shows no market data."
+    },
+    {
+      "id": "hei_src_012751",
+      "exchange_id": "hei_ex_001189",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Folgory exchange no longer operational",
+      "url": "https://coincodex.com/exchange/folgory/",
+      "publisher": "CoinCodex",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://coincodex.com/exchange/folgory/",
+      "accessed_at": "2026-08-31",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "CoinCodex explicitly warns that Folgory is no longer operational. HEI uses this to support inactive status only, not an exact shutdown date or cause."
+    },
+    {
+      "id": "hei_src_012752",
+      "exchange_id": "hei_ex_001189",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Folgory exchange graveyard entry",
+      "url": "https://www.cryptowisser.com/exchange-graveyard/",
+      "publisher": "Cryptowisser",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.cryptowisser.com/exchange-graveyard/",
+      "accessed_at": "2026-08-31",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Cryptowisser lists Folgory in its exchange graveyard. Its specific 2021-07-13 death date and scam label are treated as secondary assertions and are not promoted to canonical death_date or death_reason without stronger evidence."
+    }
+  ]
+}


### PR DESCRIPTION
Adds reviewed Folgory canonical record for `hei_unadded_0793`.

- inactive CEX
- Seychelles origin per CoinMarketCap historical listing
- no exact death date
- terminal cause remains unknown
- Cryptowisser scam/date labels are not promoted without stronger evidence
- no lifecycle event added without exact terminal-event support

Includes BX95 audit and consumed-candidate marker.

Closes #930