### PR TITLE
BX97: refresh existing Glue Hub canonical record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX97_2026-09-01.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX97_2026-09-01.md
@@ -1,0 +1,37 @@
+# HEI post-D1000 growth audit — BX97 Glue Hub canonical refresh
+
+Date: 2026-09-01
+
+## Scope
+
+Review backlog candidate `hei_unadded_0863 Glue Hub` against current main and preserve entity-first deduplication.
+
+## Current-main finding
+
+`Glue Hub` is already represented as canonical `hei_ex_000756` in `records/exchanges/glue-hub.json`. No new entity ID is allocated.
+
+## Evidence refresh
+
+Current first-party Glue material now provides stronger exchange-boundary evidence than the July 2026 record:
+
+- `https://hub.glue.net/` is live and exposes market, buy/sell, earn, transfer/pay and account/history functionality.
+- `https://docs.glue.net/learn/glue-hub` explicitly describes Glue Hub as a fully decentralized interface that aggregates protocols and routes users toward execution prices rather than acting as a custodial centralized exchange.
+- current CoinGecko Glue Hub exchange data reports an active market pair and exchange volume.
+
+## Canonical decision
+
+- entity: `hei_ex_000756`
+- type: `dex`
+- status: `active`
+- confidence: `high`
+- official URL: `https://hub.glue.net/`
+- launch_date: `null`
+- events: unchanged (`[]`)
+
+No exact first-party launch day is established. Secondary establishment-year metadata is not promoted to an exact date, and routine current activity is not converted into a lifecycle event.
+
+## Backlog handling
+
+`hei_unadded_0863` is consumed against existing `hei_ex_000756`. This prevents stale scan metadata from allocating a duplicate exchange entity.
+
+No schema, validator, allowlist or quality-gate weakening is introduced.

--- a/docs/backlog/consumed/hei_unadded_0863-glue-hub.md
+++ b/docs/backlog/consumed/hei_unadded_0863-glue-hub.md
@@ -1,0 +1,14 @@
+# Consumed backlog candidate — hei_unadded_0863 Glue Hub
+
+Reviewed: 2026-09-01
+
+- candidate: `hei_unadded_0863 Glue Hub`
+- canonical slug: `glue-hub`
+- canonical entity: `hei_ex_000756`
+- result: existing canonical entity refreshed; no duplicate ID allocated
+- type: `dex`
+- status: `active`
+
+Current first-party Glue documentation explicitly describes Glue Hub as a fully decentralized on-chain interface aggregating protocols and routing users toward execution prices while users retain custody. The live Hub exposes current market and buy/sell functionality, and current CoinGecko exchange data corroborates active market activity.
+
+This candidate is therefore consumed against the existing canonical entity rather than promoted as a new exchange record.

--- a/records/exchanges/glue-hub.json
+++ b/records/exchanges/glue-hub.json
@@ -1,1 +1,72 @@
-{"entity":{"id":"hei_ex_000756","slug":"glue-hub","canonical_name":"Glue Hub","aliases":["Glue"],"type":"dex","status":"active","death_reason":null,"launch_date":null,"death_date":null,"country_or_origin":"Glue ecosystem","summary":"Wallet-connected Glue ecosystem trading hub providing market discovery, crypto buy and sell execution, asset research, on-chain transaction history, and Glue-denominated transaction-fee handling.","official_url_original":"https://hub.glue.net/","official_domain_original":"hub.glue.net","official_url_status":"live_verified","archived_url":"https://web.archive.org/web/*/https://hub.glue.net/","predecessor_id":null,"successor_id":null,"confidence":"medium","last_verified_at":"2026-07-09","notes":"Current first-party Glue Hub market and trading surfaces are reachable in beta and expose market overview, Buy & Sell Crypto, price and volume fields, buy/sell controls, wallet connection, price impact, estimated GLUE fees, and address-linked transaction history. Confidence is medium because public protocol documentation for the exchange boundary is limited; the June 2026 exchange candidate corpus independently identifies Glue Hub as an exchange-like venue."},"events":[],"evidence":[{"id":"hei_src_011578","exchange_id":"hei_ex_000756","event_id":null,"source_type":"official_statement","title":"Glue Hub market overview","url":"https://hub.glue.net/market/market-overview","publisher":"Glue","published_at":null,"archived_url":"https://web.archive.org/web/*/https://hub.glue.net/market/market-overview","accessed_at":"2026-07-09","reliability":"high","claim_scope":"status","notes":"Current first-party Glue Hub market surface is reachable in beta and exposes Market, Buy & Sell, History, account, transfer, and blockchain-explorer navigation."},{"id":"hei_src_011579","exchange_id":"hei_ex_000756","event_id":null,"source_type":"official_statement","title":"Glue Hub Buy & Sell Crypto","url":"https://hub.glue.net/trading","publisher":"Glue","published_at":null,"archived_url":"https://web.archive.org/web/*/https://hub.glue.net/trading","accessed_at":"2026-07-09","reliability":"high","claim_scope":"entity","notes":"Current first-party trading page exposes Buy and Sell controls, market prices, 24-hour high and low, volume, wallet connection, price impact, estimated transaction fee in GLUE, available balances, and transaction history fields."},{"id":"hei_src_011580","exchange_id":"hei_ex_000756","event_id":null,"source_type":"database_reference","title":"Glue Hub exchange discovery entry","url":"https://api.coingecko.com/api/v3/exchanges?per_page=250&page=3","publisher":"CoinGecko","published_at":null,"archived_url":null,"accessed_at":"2026-07-09","reliability":"medium","claim_scope":"entity","notes":"June 2026 exchange candidate corpus identifies Glue Hub under the hub.glue.net domain, corroborating the current first-party market and trading surfaces."}]}
+{
+  "entity": {
+    "id": "hei_ex_000756",
+    "slug": "glue-hub",
+    "canonical_name": "Glue Hub",
+    "aliases": ["Glue"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Glue ecosystem",
+    "summary": "Self-custodial on-chain trading and DeFi hub in the Glue ecosystem. Glue describes the Hub as a decentralized system that aggregates protocols and lets users buy, sell and route trades while retaining control of their own assets.",
+    "official_url_original": "https://hub.glue.net/",
+    "official_domain_original": "hub.glue.net",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://hub.glue.net/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-09-01",
+    "notes": "Current first-party Glue material now makes the exchange boundary explicit: Glue Hub is a fully decentralized, on-chain interface that aggregates protocols and routes users toward execution prices while users retain control of their funds. The live Hub exposes market and buy/sell surfaces, and CoinGecko currently reports an active Glue Hub market pair and exchange volume. HEI therefore retains active DEX classification with high confidence. No exact first-party launch day is established, so launch_date remains null and no routine activity event is fabricated."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_011578",
+      "exchange_id": "hei_ex_000756",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Glue Hub live trading interface",
+      "url": "https://hub.glue.net/",
+      "publisher": "Glue",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://hub.glue.net/",
+      "accessed_at": "2026-09-01",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party Hub is live and exposes market, buy-and-sell, earn, transfer/pay, history and account surfaces, supporting active operating status."
+    },
+    {
+      "id": "hei_src_011579",
+      "exchange_id": "hei_ex_000756",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Glue Hub architecture and exchange boundary",
+      "url": "https://docs.glue.net/learn/glue-hub",
+      "publisher": "Glue",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://docs.glue.net/learn/glue-hub",
+      "accessed_at": "2026-09-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation says Glue Hub aggregates protocols into one interface, routes users toward best execution prices and is fully decentralized rather than a centralized exchange."
+    },
+    {
+      "id": "hei_src_011580",
+      "exchange_id": "hei_ex_000756",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Glue Hub current exchange market listing",
+      "url": "https://www.coingecko.com/en/exchanges/glue",
+      "publisher": "CoinGecko",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.coingecko.com/en/exchanges/glue",
+      "accessed_at": "2026-09-01",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "CoinGecko currently lists Glue Hub with an active trading pair and reported 24-hour exchange volume, corroborating current exchange activity."
+    }
+  ]
+}


### PR DESCRIPTION
Continues Lane A on current main by reconciling backlog candidate `hei_unadded_0863 Glue Hub` with existing canonical `hei_ex_000756`.

- preserves existing entity identity; no duplicate ID allocation
- refreshes first-party Glue Hub operating and architecture evidence
- keeps active DEX classification and raises confidence to high
- consumes candidate 0863 against the existing record
- keeps `launch_date: null` and adds no routine-activity lifecycle event
- no schema, validator, allowlist, or quality-gate weakening