### PR TITLE
BX98: refresh existing Gravity Finance canonical record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX98_2026-09-01.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX98_2026-09-01.md
@@ -1,0 +1,34 @@
+# HEI post-D1000 growth audit — BX98 Gravity Finance canonical refresh
+
+Date: 2026-09-01
+
+## Scope
+
+Review backlog candidate `hei_unadded_0885 Gravity Finance` against current main and preserve entity-first deduplication.
+
+## Current-main finding
+
+`Gravity Finance` is already represented as canonical `hei_ex_000834` in `records/exchanges/gravity-finance.json`. No new entity ID is allocated.
+
+## Evidence refresh
+
+- Current first-party Gravity Finance documentation identifies the platform as deployed on Polygon and lists Swap Exchange among its current features.
+- The current first-party whitepaper likewise defines Swap Exchange as part of the platform scope and supports the Polygon identity boundary.
+- Current DefiLlama data identifies Gravity Finance as a Polygon AMM DEX and reports non-zero TVL, fees and 30-day, 7-day and 24-hour DEX volume.
+
+## Canonical decision
+
+- entity: `hei_ex_000834`
+- type: `dex`
+- status: `active`
+- confidence: `high`
+- launch_date: `null`
+- events: unchanged (`[]`)
+
+No exact first-party launch day is established, so no exact launch date is inferred. Routine current trading activity is not converted into a lifecycle event.
+
+## Backlog handling
+
+`hei_unadded_0885` is consumed against existing `hei_ex_000834`, preventing the stale scan row from producing a duplicate canonical entity.
+
+No schema, validator, allowlist or quality-gate weakening is introduced.

--- a/docs/backlog/consumed/hei_unadded_0885-gravity-finance.md
+++ b/docs/backlog/consumed/hei_unadded_0885-gravity-finance.md
@@ -1,0 +1,12 @@
+# Consumed backlog candidate — hei_unadded_0885 Gravity Finance
+
+Reviewed: 2026-09-01
+
+- candidate: `hei_unadded_0885 Gravity Finance`
+- canonical slug: `gravity-finance`
+- canonical entity: `hei_ex_000834`
+- result: existing canonical entity refreshed; no duplicate ID allocated
+- type: `dex`
+- status: `active`
+
+Current-main review confirms that the June backlog row is already represented by canonical `hei_ex_000834`. Current first-party Gravity Finance documentation explicitly lists a Swap Exchange on Polygon, while current DefiLlama metrics report non-zero DEX volume and TVL. The candidate is therefore consumed against the existing entity rather than promoted as a new record.

--- a/records/exchanges/gravity-finance.json
+++ b/records/exchanges/gravity-finance.json
@@ -1,1 +1,72 @@
-{"entity":{"id":"hei_ex_000834","slug":"gravity-finance","canonical_name":"Gravity Finance","aliases":["Gravity","GFI"],"type":"dex","status":"active","death_reason":null,"launch_date":null,"death_date":null,"country_or_origin":"Polygon ecosystem","summary":"Polygon automated-market-maker decentralized exchange and DeFi platform with current liquidity, swap volume, fees, and active spot trading.","official_url_original":"https://gravityfinance.io/","official_domain_original":"gravityfinance.io","official_url_status":"live_verified","archived_url":"https://web.archive.org/web/*/https://gravityfinance.io/","predecessor_id":null,"successor_id":null,"confidence":"high","last_verified_at":"2026-07-10","notes":"Current first-party Gravity Finance domain remains reachable. DefiLlama independently identifies Gravity Finance as a Polygon AMM DEX and reports current TVL, fees, and non-zero 30-day, 7-day, and 24-hour DEX volume, supporting active classification."},"events":[],"evidence":[{"id":"hei_src_011812","exchange_id":"hei_ex_000834","event_id":null,"source_type":"official_statement","title":"Gravity Finance official website","url":"https://gravityfinance.io/","publisher":"Gravity Finance","published_at":null,"archived_url":"https://web.archive.org/web/*/https://gravityfinance.io/","accessed_at":"2026-07-10","reliability":"high","claim_scope":"status","notes":"Current dedicated first-party Gravity Finance domain remains reachable at review time."},{"id":"hei_src_011813","exchange_id":"hei_ex_000834","event_id":null,"source_type":"database_reference","title":"Gravity Finance metrics and protocol information","url":"https://defillama.com/protocol/gravity-finance","publisher":"DefiLlama","published_at":null,"archived_url":null,"accessed_at":"2026-07-10","reliability":"medium","claim_scope":"status","notes":"Protocol registry identifies Gravity Finance as a Polygon AMM DEX and reports current TVL, fees, and non-zero 30-day, 7-day, and 24-hour DEX volume."},{"id":"hei_src_011814","exchange_id":"hei_ex_000834","event_id":null,"source_type":"database_reference","title":"Gravity Finance DEX discovery entry","url":"https://api.llama.fi/overview/dexs?excludeTotalDataChart=true&excludeTotalDataChartBreakdown=true&dataType=dailyVolume","publisher":"DefiLlama","published_at":null,"archived_url":null,"accessed_at":"2026-07-10","reliability":"medium","claim_scope":"entity","notes":"DEX candidate corpus independently identifies Gravity Finance as a Polygon decentralized exchange."}]}
+{
+  "entity": {
+    "id": "hei_ex_000834",
+    "slug": "gravity-finance",
+    "canonical_name": "Gravity Finance",
+    "aliases": ["Gravity", "GFI"],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": null,
+    "death_date": null,
+    "country_or_origin": "Polygon ecosystem",
+    "summary": "Polygon automated-market-maker decentralized exchange and DeFi platform with current liquidity, swap volume, fees, and active spot trading.",
+    "official_url_original": "https://gravityfinance.io/",
+    "official_domain_original": "gravityfinance.io",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://gravityfinance.io/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-09-01",
+    "notes": "Current first-party Gravity Finance documentation identifies the platform as deployed on Polygon and offering a Swap Exchange alongside farms, vaults and launchpad functionality. Current DefiLlama data independently identifies Gravity Finance as a Polygon AMM DEX and reports non-zero TVL, fees and DEX volume, supporting active classification. No exact first-party launch day was established, so launch_date remains null."
+  },
+  "events": [],
+  "evidence": [
+    {
+      "id": "hei_src_011812",
+      "exchange_id": "hei_ex_000834",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Gravity Finance official documentation",
+      "url": "https://inthenextversion.gitbook.io/gravity-finance",
+      "publisher": "Gravity Finance",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://inthenextversion.gitbook.io/gravity-finance",
+      "accessed_at": "2026-09-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party documentation describes Gravity Finance as a DeFi platform deployed on Polygon and lists Swap Exchange among its current features."
+    },
+    {
+      "id": "hei_src_011813",
+      "exchange_id": "hei_ex_000834",
+      "event_id": null,
+      "source_type": "database_reference",
+      "title": "Gravity Finance metrics and protocol information",
+      "url": "https://defillama.com/protocol/gravity-finance",
+      "publisher": "DefiLlama",
+      "published_at": null,
+      "archived_url": null,
+      "accessed_at": "2026-09-01",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "DefiLlama identifies Gravity Finance as a Polygon AMM DEX and reports current non-zero TVL, fees, and 30-day, 7-day and 24-hour DEX volume, supporting active status."
+    },
+    {
+      "id": "hei_src_011814",
+      "exchange_id": "hei_ex_000834",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Gravity Finance whitepaper",
+      "url": "https://api.gravityfinance.io/documents/GravityFinanceWhitePaper.pdf",
+      "publisher": "Gravity Finance",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://api.gravityfinance.io/documents/GravityFinanceWhitePaper.pdf",
+      "accessed_at": "2026-09-01",
+      "reliability": "high",
+      "claim_scope": "entity",
+      "notes": "First-party whitepaper describes Gravity Finance's Polygon deployment and includes Swap Exchange among the platform features. It is used for identity and exchange-boundary support, not for an exact launch date."
+    }
+  ]
+}


### PR DESCRIPTION
Continues Lane A from current main by reconciling backlog candidate `hei_unadded_0885 Gravity Finance` with existing canonical `hei_ex_000834`.

- preserves existing entity identity; no duplicate ID allocation
- refreshes current first-party Gravity Finance documentation and whitepaper evidence
- refreshes current DefiLlama AMM/volume evidence
- keeps active DEX classification and high confidence
- consumes candidate 0885 against the existing record
- keeps `launch_date: null` and adds no routine-activity lifecycle event
- no schema, validator, allowlist, or quality-gate weakening