### PR TITLE
BX100: record BTCBOX yen-withdrawal restoration

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX100_BTCBOX_2026-09-02.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX100_BTCBOX_2026-09-02.md
@@ -1,0 +1,41 @@
+# HEI post-D1000 growth BX100 — BTCBOX restoration review — 2026-09-02
+
+## Scope
+
+Lane A lifecycle follow-up for existing canonical entity `hei_ex_000602` BTCBOX under issue #768.
+
+No new exchange entity is created. The review is limited to the staged restoration of BTCBOX services after the 2026-01-29 full-service suspension.
+
+## Current first-party evidence
+
+BTCBOX's 2026-08-07 notice states that Japanese-yen withdrawal service would resume at 10:00 JST on 2026-08-10 after the operator confirmed that implemented safety and risk-reduction measures were functioning and the system was stable.
+
+The same notice states that services still unavailable would be restored sequentially from September after the necessary checks were completed.
+
+A review of the current BTCBOX official notice index on 2026-09-02 found later notices for individual crypto-asset deposit maintenance/resumption, but no first-party announcement establishing restoration of crypto withdrawals, exchange trading, or easy-buy service.
+
+## Canonical decision
+
+- keep entity status `limited`;
+- add `hei_ev_010215` for the 2026-08-10 Japanese-yen withdrawal restoration;
+- add first-party evidence `hei_src_012757`;
+- update summary, notes, and `last_verified_at`;
+- do not mark BTCBOX globally active;
+- do not infer restoration of crypto withdrawals, exchange trading, or easy-buy service from the calendar reaching September.
+
+## Evidence boundary
+
+The 2026-08-07 first-party notice is sufficient to record the scheduled effective restoration of Japanese-yen withdrawals because it is a specific operator decision with an exact effective timestamp and no contrary later first-party notice was found during this review.
+
+The remaining services stay unresolved until a first-party or equivalently strong post-effective source confirms restoration.
+
+## IDs
+
+- entity: existing `hei_ex_000602`
+- event: `hei_ev_010215`
+- evidence: `hei_src_012757`
+
+## Source
+
+- BTCBOX, `弊社一部サービスの再開時期について（日本円出金）`, 2026-08-07: `https://blog.btcbox.jp/?p=18784`
+- BTCBOX official notice index reviewed 2026-09-02: `https://blog.btcbox.jp/archives/category/notice`

--- a/records/exchanges/btcbox.json
+++ b/records/exchanges/btcbox.json
@@ -14,7 +14,7 @@
     "launch_date": "2014-03-01",
     "death_date": null,
     "country_or_origin": "Japan",
-    "summary": "Japanese centralized cryptocurrency exchange operated by BTCBOX Co. Ltd. After a full-service suspension beginning on 2026-01-29, BTCBOX partially resumed login and crypto-asset deposit access on 2026-08-03; crypto withdrawals, exchange trading, and easy-buy services remained unavailable.",
+    "summary": "Japanese centralized cryptocurrency exchange operated by BTCBOX Co. Ltd. After a full-service suspension beginning on 2026-01-29, BTCBOX partially resumed login and crypto-asset deposits on 2026-08-03 and Japanese-yen withdrawals on 2026-08-10; crypto withdrawals, exchange trading, and easy-buy services were still awaiting sequential restoration from September.",
     "official_url_original": "https://www.btcbox.co.jp/",
     "official_domain_original": "btcbox.co.jp",
     "official_url_status": "live_verified",
@@ -22,8 +22,8 @@
     "predecessor_id": null,
     "successor_id": null,
     "confidence": "high",
-    "last_verified_at": "2026-08-03",
-    "notes": "Launch date is stored at month precision from exchange-profile sources. BTCBOX suspended all services on 2026-01-29. Its 2026-07-31 official notice set 2026-08-03 at 10:00 JST for the resumption of login and crypto-asset deposits, while crypto withdrawals, exchange trading, and easy-buy services remained suspended; Japanese-yen withdrawals were planned for 2026-08-10. HEI therefore classifies BTCBOX as limited rather than active or inactive. No death date or death reason is assigned."
+    "last_verified_at": "2026-09-02",
+    "notes": "Launch date is stored at month precision from exchange-profile sources. BTCBOX suspended all services on 2026-01-29. Login and crypto-asset deposits partially resumed on 2026-08-03. A 2026-08-07 first-party notice states that Japanese-yen withdrawals would resume on 2026-08-10 at 10:00 JST after the operator confirmed its safety and stability measures were functioning as intended. As of the 2026-09-02 review, BTCBOX's current official notices did not show a later announcement restoring crypto withdrawals, exchange trading, or easy-buy services; the operator had said those remaining services would restart sequentially from September after further checks. HEI therefore keeps BTCBOX limited rather than active or inactive. No death date or death reason is assigned."
   },
   "events": [
     {
@@ -69,6 +69,21 @@
       "sort_order": 3,
       "is_major_event": true,
       "notes": "This is a partial reopening rather than restoration of normal exchange operation. The operator scheduled Japanese-yen withdrawals for 2026-08-10 and the remaining services for sequential reopening from September after further safety checks."
+    },
+    {
+      "id": "hei_ev_010215",
+      "exchange_id": "hei_ex_000602",
+      "event_type": "reopened",
+      "event_date": "2026-08-10",
+      "title": "BTCBOX resumed Japanese-yen withdrawals",
+      "description": "BTCBOX announced that Japanese-yen withdrawal service would resume at 10:00 JST on 2026-08-10 after confirming that recently implemented safety and risk-reduction measures were operating properly and the system was stable.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "limited",
+      "source_count": 1,
+      "sort_order": 4,
+      "is_major_event": true,
+      "notes": "This restoration does not establish full exchange-service recovery. The same first-party notice says other unavailable services would be restored sequentially from September after the necessary checks were completed."
     }
   ],
   "evidence": [
@@ -146,6 +161,21 @@
       "reliability": "high",
       "claim_scope": "event",
       "notes": "First-party notice sets 2026-08-03 at 10:00 JST for login and crypto-asset deposit resumption, while stating that crypto withdrawals, exchange trading, and easy-buy services remain unavailable."
+    },
+    {
+      "id": "hei_src_012757",
+      "exchange_id": "hei_ex_000602",
+      "event_id": "hei_ev_010215",
+      "source_type": "official_statement",
+      "title": "Japanese-yen withdrawal service reopening",
+      "url": "https://blog.btcbox.jp/?p=18784",
+      "publisher": "BTCBOX",
+      "published_at": "2026-08-07",
+      "archived_url": "https://web.archive.org/web/*/https://blog.btcbox.jp/?p=18784",
+      "accessed_at": "2026-09-02",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party notice states that Japanese-yen withdrawal service would resume on 2026-08-10 at 10:00 JST after BTCBOX confirmed its new safety and risk-reduction measures were functioning and its system was stable. It separately says remaining unavailable services would restart sequentially from September as checks were completed."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- keep existing BTCBOX entity `hei_ex_000602` at `limited`
- add the 2026-08-10 Japanese-yen withdrawal restoration event
- add first-party BTCBOX evidence from the 2026-08-07 notice
- refresh summary/notes/verification date
- do not infer restoration of crypto withdrawals, exchange trading, or easy-buy service

## Scope
Lane A lifecycle follow-up for #768. No new entity, no schema change, no workflow/gate work.

Closes the BTCBOX September checkpoint portion of #768; the issue itself remains open for the other scheduled follow-ups.