### PR TITLE
BX101: add Velodrome Finance canonical record

### DIFF
--- a/docs/audits/HEI_POST_D1000_GROWTH_BX101_VELODROME_2026-09-02.md
+++ b/docs/audits/HEI_POST_D1000_GROWTH_BX101_VELODROME_2026-09-02.md
@@ -1,0 +1,44 @@
+# HEI post-D1000 growth BX101 — Velodrome Finance — 2026-09-02
+
+## Scope
+
+Lane A canonical growth review for Velodrome Finance, prompted by the representation gap identified in issue #888.
+
+This promotion is based on Velodrome's independent exchange identity and current first-party operating evidence. It is not a projection of Lisk Chain's announced shutdown into a whole-entity Velodrome lifecycle event.
+
+## Identity and current state
+
+Current first-party Velodrome documentation describes Velodrome as an automated-market-maker protocol designed to enable token swaps and liquidity provision, and states that Velodrome first launched on 2022-06-02.
+
+The current first-party application remains live and explicitly presents Velodrome as a decentralized exchange where users can execute token swaps and deposit liquidity.
+
+Canonical decision:
+
+- create new exchange entity `hei_ex_001191`;
+- canonical name `Velodrome Finance`;
+- aliases `Velodrome`, `VELO`;
+- type `dex`;
+- status `active`;
+- launch date `2022-06-02`;
+- origin `Optimism ecosystem`;
+- confidence `high`;
+- no death date or death reason.
+
+## Lifecycle event
+
+Create `hei_ev_010216` for the first-party exact launch date, 2022-06-02.
+
+No Lisk migration/shutdown event is added. Current HEI modeling remains entity-level; issue #888 separately tracks the Lisk deployment/support disposition ahead of the 2026-10-31 Lisk Chain shutdown.
+
+## Evidence
+
+- `hei_src_012758` — Velodrome first-party documentation, `https://velodrome.finance/docs`, supporting exchange identity and exact launch date.
+- `hei_src_012759` — current Velodrome first-party exchange application, `https://velodrome.finance/`, supporting active DEX status.
+
+## Duplicate and modeling boundary
+
+Current repository search before allocation found no canonical Velodrome entity and no use of `hei_ex_001191`, `hei_ev_010216`, `hei_src_012758`, or `hei_src_012759`.
+
+Aerodrome remains a separate canonical entity. Velodrome is not collapsed into Aerodrome merely because the protocols are related in Superchain liquidity infrastructure.
+
+The Lisk Chain dependency is not used to mark Velodrome `limited`, `inactive`, or `dead` because Velodrome has independent operating surfaces and multi-network presence. Deployment-level changes remain outside current entity-level lifecycle semantics unless they materially change the whole exchange entity.

--- a/records/exchanges/velodrome-finance.json
+++ b/records/exchanges/velodrome-finance.json
@@ -1,0 +1,75 @@
+{
+  "entity": {
+    "id": "hei_ex_001191",
+    "slug": "velodrome-finance",
+    "canonical_name": "Velodrome Finance",
+    "aliases": [
+      "Velodrome",
+      "VELO"
+    ],
+    "type": "dex",
+    "status": "active",
+    "death_reason": null,
+    "launch_date": "2022-06-02",
+    "death_date": null,
+    "country_or_origin": "Optimism ecosystem",
+    "summary": "Decentralized automated-market-maker exchange and liquidity marketplace for the Superchain. Velodrome launched on 2022-06-02 and remains an active token-swap and liquidity protocol.",
+    "official_url_original": "https://velodrome.finance/",
+    "official_domain_original": "velodrome.finance",
+    "official_url_status": "live_verified",
+    "archived_url": "https://web.archive.org/web/*/https://velodrome.finance/",
+    "predecessor_id": null,
+    "successor_id": null,
+    "confidence": "high",
+    "last_verified_at": "2026-09-02",
+    "notes": "First-party documentation states that Velodrome launched on 2022-06-02 and describes it as an AMM designed to enable token swaps and liquidity provision. The current first-party application remains live and identifies Velodrome as a decentralized exchange. Lisk documentation separately identifies a Lisk-network Velodrome deployment, but HEI does not treat the announced 2026-10-31 Lisk Chain shutdown as a whole-entity Velodrome shutdown; deployment-level disposition remains tracked under issue #888."
+  },
+  "events": [
+    {
+      "id": "hei_ev_010216",
+      "exchange_id": "hei_ex_001191",
+      "event_type": "launched",
+      "event_date": "2022-06-02",
+      "title": "Velodrome Finance launched",
+      "description": "Velodrome Finance launched as an automated-market-maker exchange and liquidity protocol on 2022-06-02.",
+      "confidence": "high",
+      "impact_level": "medium",
+      "event_status_effect": "active",
+      "source_count": 1,
+      "sort_order": 1,
+      "notes": "Exact launch date is stated in current first-party Velodrome documentation."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012758",
+      "exchange_id": "hei_ex_001191",
+      "event_id": "hei_ev_010216",
+      "source_type": "official_statement",
+      "title": "About Velodrome",
+      "url": "https://velodrome.finance/docs",
+      "publisher": "Velodrome Finance",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://velodrome.finance/docs",
+      "accessed_at": "2026-09-02",
+      "reliability": "high",
+      "claim_scope": "entity_event",
+      "notes": "First-party documentation describes Velodrome as an AMM for token swaps and states that it first launched on 2022-06-02."
+    },
+    {
+      "id": "hei_src_012759",
+      "exchange_id": "hei_ex_001191",
+      "event_id": null,
+      "source_type": "official_statement",
+      "title": "Velodrome Finance exchange application",
+      "url": "https://velodrome.finance/",
+      "publisher": "Velodrome Finance",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://velodrome.finance/",
+      "accessed_at": "2026-09-02",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Current first-party application identifies Velodrome as a decentralized exchange offering token swaps and liquidity deposits, supporting active status."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Velodrome Finance as new canonical DEX `hei_ex_001191`
- record first-party launch date 2022-06-02 as `hei_ev_010216`
- add first-party evidence `hei_src_012758`–`hei_src_012759`
- classify current entity as `active`
- keep Lisk deployment/shutdown disposition separate under #888; no whole-entity lifecycle inference from the Lisk Chain shutdown

## Scope
Lane A canonical exchange growth. No schema, workflow, validator, or gate changes.

Related: #888