### PR TITLE
BX102: repair BITFRONT and Coinbase Pro lifecycle evidence

### DIFF
--- a/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX102_2026-09-03.md
+++ b/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX102_2026-09-03.md
@@ -1,0 +1,46 @@
+# HEI material-concerns correction BX102 — 2026-09-03
+
+Status: COMPLETE / bounded canonical evidence repair
+Issue: #858
+Scope: BITFRONT and Coinbase Pro only
+
+## BITFRONT
+
+Canonical entity `hei_ex_000128` already classified BITFRONT as a dead CEX with a 2023-03-31 terminal marker but contained no canonical events or evidence.
+
+First-party source recovered:
+- LINE Blockchain / Finschia, `[NOTICE] BITFRONT Exchange to Close`, 2022-11-28
+- https://medium.com/lineblockchain/notice-bitfront-exchange-to-close-5a887f5402c2
+
+The notice identifies BITFRONT as operated by LVC USA Inc., states that the termination process had begun, immediately ended new registrations and credit-card payments, and says all services would be fully ended by March 2023.
+
+Canonical action:
+- preserve entity status `dead`;
+- preserve `death_reason: voluntary_shutdown`;
+- preserve existing `death_date: 2023-03-31` rather than infer a different exact day from month-only first-party wording;
+- add `hei_ev_010217` (`shutdown_announced`, 2022-11-28);
+- add `hei_ev_010218` (`shutdown_effective`, 2023-03-31);
+- add first-party evidence `hei_src_012760`–`hei_src_012761`.
+
+## Coinbase Pro
+
+Canonical entity `hei_ex_000159` already classified Coinbase Pro as `rebranded` but contained no canonical lifecycle events or evidence and used 2023-12-31 as a terminal marker.
+
+First-party sources recovered:
+- Coinbase, `Hello Advanced Trade, goodbye Coinbase Pro`, published 2022-06-22 and updated 2023-11-20
+- https://www.coinbase.com/blog/hello-advanced-trade-goodbye-coinbase-pro
+- Coinbase Help, `Transitioning from Coinbase Pro to Coinbase Advanced`
+- https://help.coinbase.com/en/pro/managing-my-account/account-information/transitioning-to-advanced-trade
+
+The 2022 Coinbase announcement establishes the intended sunset and replacement by Coinbase Advanced. Its 2023-11-20 update states that phased migration was complete, Coinbase Pro was no longer supported on web or mobile, and customers could no longer log in.
+
+Canonical action:
+- preserve `status: rebranded` and `death_reason: rebrand`;
+- correct `death_date` from 2023-12-31 to 2023-11-20 because the first-party update establishes the effective support/login cutoff;
+- add `hei_ev_010219` (`shutdown_announced`, 2022-06-22);
+- add `hei_ev_010220` (`rebranded`, 2023-11-20);
+- add first-party evidence `hei_src_012762`–`hei_src_012763`.
+
+## Boundary
+
+No new exchange entity is created. No schema, validator, workflow, or gate is changed. This batch only repairs lifecycle evidence and one terminal date where current first-party evidence is stronger than the existing proxy marker.

--- a/records/exchanges/bitfront.json
+++ b/records/exchanges/bitfront.json
@@ -14,7 +14,7 @@
     "launch_date": "2020-02-01",
     "death_date": "2023-03-31",
     "country_or_origin": "United States",
-    "summary": "LINE-backed global centralized cryptocurrency exchange operated by LVC USA Inc. It announced a phased voluntary shutdown in late 2022 and scheduled withdrawals to end on 2023-03-31.",
+    "summary": "LINE-backed global centralized cryptocurrency exchange operated by LVC USA Inc. It announced a phased voluntary shutdown on 2022-11-28 and ended its remaining service in March 2023.",
     "official_url_original": "https://www.bitfront.me/",
     "official_domain_original": "bitfront.me",
     "official_url_status": "unknown",
@@ -22,11 +22,73 @@
     "predecessor_id": "hei_ex_000302",
     "successor_id": null,
     "confidence": "high",
-    "last_verified_at": "2026-05-22",
-    "notes": "Entity death date uses the end of withdrawals and service termination rather than the announcement date."
+    "last_verified_at": "2026-09-03",
+    "notes": "The 2022-11-28 LINE Blockchain/Finschia notice states that BITFRONT had begun terminating service and that all services would be fully ended by March 2023. The existing 2023-03-31 terminal marker is retained; HEI does not move it earlier to the announcement date."
   },
-  "events": [],
-  "evidence": [],
+  "events": [
+    {
+      "id": "hei_ev_010217",
+      "exchange_id": "hei_ex_000128",
+      "event_type": "shutdown_announced",
+      "event_date": "2022-11-28",
+      "title": "BITFRONT announced a phased shutdown",
+      "description": "LINE Blockchain announced that the LVC USA-operated BITFRONT exchange had begun its termination process, with new account registration and credit-card payments ending immediately and all services scheduled to end by March 2023.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "limited",
+      "source_count": 1,
+      "sort_order": 1,
+      "is_major_event": true,
+      "notes": "First-party ecosystem notice. The announcement date is not treated as the effective shutdown date."
+    },
+    {
+      "id": "hei_ev_010218",
+      "exchange_id": "hei_ex_000128",
+      "event_type": "shutdown_effective",
+      "event_date": "2023-03-31",
+      "title": "BITFRONT service terminated",
+      "description": "BITFRONT's phased closure reached its terminal service date after the operator had announced that all services would end by March 2023.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "dead",
+      "source_count": 1,
+      "sort_order": 2,
+      "is_major_event": true,
+      "notes": "The canonical terminal date is preserved from the reviewed record. The first-party closure notice establishes the March 2023 terminal window and staged shutdown."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012760",
+      "exchange_id": "hei_ex_000128",
+      "event_id": "hei_ev_010217",
+      "source_type": "official_statement",
+      "title": "[NOTICE] BITFRONT Exchange to Close",
+      "url": "https://medium.com/lineblockchain/notice-bitfront-exchange-to-close-5a887f5402c2",
+      "publisher": "LINE Blockchain / Finschia",
+      "published_at": "2022-11-28",
+      "archived_url": "https://web.archive.org/web/*/https://medium.com/lineblockchain/notice-bitfront-exchange-to-close-5a887f5402c2",
+      "accessed_at": "2026-09-03",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party ecosystem notice identifies BITFRONT as operated by LVC USA Inc., states that the termination process had begun, and says all services would be fully ended by March 2023."
+    },
+    {
+      "id": "hei_src_012761",
+      "exchange_id": "hei_ex_000128",
+      "event_id": "hei_ev_010218",
+      "source_type": "official_statement",
+      "title": "[NOTICE] BITFRONT Exchange to Close",
+      "url": "https://medium.com/lineblockchain/notice-bitfront-exchange-to-close-5a887f5402c2",
+      "publisher": "LINE Blockchain / Finschia",
+      "published_at": "2022-11-28",
+      "archived_url": "https://web.archive.org/web/*/https://medium.com/lineblockchain/notice-bitfront-exchange-to-close-5a887f5402c2",
+      "accessed_at": "2026-09-03",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Same first-party closure notice supports the staged terminal shutdown context; HEI retains the already-reviewed 2023-03-31 terminal date rather than inventing a new date from the month-only wording."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000128",
     "expected": {

--- a/records/exchanges/coinbase-pro.json
+++ b/records/exchanges/coinbase-pro.json
@@ -8,9 +8,9 @@
     "status": "rebranded",
     "death_reason": "rebrand",
     "launch_date": null,
-    "death_date": "2023-12-31",
+    "death_date": "2023-11-20",
     "country_or_origin": "United States",
-    "summary": "Advanced trading surface under Coinbase that was replaced by Coinbase Advanced, with customer history access ending after December 2023.",
+    "summary": "Advanced trading surface under Coinbase that was replaced by Coinbase Advanced. Coinbase announced the sunset in June 2022 and completed the phased customer migration by 2023-11-20, after which Coinbase Pro was no longer supported on web or mobile.",
     "official_url_original": "https://pro.coinbase.com/",
     "official_domain_original": "pro.coinbase.com",
     "official_url_status": "redirected",
@@ -18,11 +18,73 @@
     "predecessor_id": null,
     "successor_id": null,
     "confidence": "high",
-    "last_verified_at": "2026-06-19",
-    "notes": "Lineage-sensitive product transition. After balance migration, customers could no longer deposit, withdraw, or trade on Coinbase Pro, and transaction history remained accessible only until the end of 2023."
+    "last_verified_at": "2026-09-03",
+    "notes": "Coinbase's first-party 2022 announcement states that Coinbase Pro would be sunset in favor of Coinbase Advanced. The same post was updated on 2023-11-20 to state that the phased migration was complete and Coinbase Pro would no longer be supported on web or mobile and users could no longer log in. The terminal marker is therefore corrected from the prior 2023-12-31 history-access proxy to 2023-11-20."
   },
-  "events": [],
-  "evidence": [],
+  "events": [
+    {
+      "id": "hei_ev_010219",
+      "exchange_id": "hei_ex_000159",
+      "event_type": "shutdown_announced",
+      "event_date": "2022-06-22",
+      "title": "Coinbase announced the Coinbase Pro sunset",
+      "description": "Coinbase announced that Coinbase Pro would be sunset and advanced trading would move into Coinbase Advanced as part of a unified Coinbase account experience.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "limited",
+      "source_count": 1,
+      "sort_order": 1,
+      "is_major_event": true,
+      "notes": "This is the transition announcement, not the effective terminal date."
+    },
+    {
+      "id": "hei_ev_010220",
+      "exchange_id": "hei_ex_000159",
+      "event_type": "rebranded",
+      "event_date": "2023-11-20",
+      "title": "Coinbase completed migration from Coinbase Pro to Coinbase Advanced",
+      "description": "Coinbase updated its transition notice to state that the phased migration of Coinbase Pro customers to Coinbase Advanced was complete and that Coinbase Pro was no longer supported on web or mobile, with login disabled.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "rebranded",
+      "source_count": 1,
+      "sort_order": 2,
+      "is_major_event": true,
+      "notes": "This first-party update supplies the effective product-transition date used for the entity's terminal rebrand marker."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012762",
+      "exchange_id": "hei_ex_000159",
+      "event_id": "hei_ev_010219",
+      "source_type": "official_statement",
+      "title": "Hello Advanced Trade, goodbye Coinbase Pro",
+      "url": "https://www.coinbase.com/blog/hello-advanced-trade-goodbye-coinbase-pro",
+      "publisher": "Coinbase",
+      "published_at": "2022-06-22",
+      "archived_url": "https://web.archive.org/web/*/https://www.coinbase.com/blog/hello-advanced-trade-goodbye-coinbase-pro",
+      "accessed_at": "2026-09-03",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party Coinbase announcement that Coinbase Pro would be sunset and replaced by Coinbase Advanced."
+    },
+    {
+      "id": "hei_src_012763",
+      "exchange_id": "hei_ex_000159",
+      "event_id": "hei_ev_010220",
+      "source_type": "official_statement",
+      "title": "Hello Advanced Trade, goodbye Coinbase Pro — 2023-11-20 update",
+      "url": "https://www.coinbase.com/blog/hello-advanced-trade-goodbye-coinbase-pro",
+      "publisher": "Coinbase",
+      "published_at": "2023-11-20",
+      "archived_url": "https://web.archive.org/web/*/https://www.coinbase.com/blog/hello-advanced-trade-goodbye-coinbase-pro",
+      "accessed_at": "2026-09-03",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "The updated first-party post states that phased migration was complete on 2023-11-20 and Coinbase Pro would no longer be supported on web or mobile and customers could not log in."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000159",
     "expected": {


### PR DESCRIPTION
## Summary
- restore canonical lifecycle events/evidence for BITFRONT and Coinbase Pro under #858
- BITFRONT: add shutdown announcement/effective events with LINE Blockchain/Finschia first-party evidence
- Coinbase Pro: add 2022 sunset announcement and 2023-11-20 completed migration event with Coinbase first-party evidence
- correct Coinbase Pro terminal date from 2023-12-31 to 2023-11-20 based on Coinbase's updated first-party notice

## Scope
Bounded Lane A evidence repair only. No schema, workflow, validator, or gate changes.

Closes #858