### PR TITLE
BX106: restore BitBay rebrand lifecycle evidence

### DIFF
--- a/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX106_2026-09-04.md
+++ b/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX106_2026-09-04.md
@@ -1,0 +1,30 @@
+# HEI material-concerns correction — BX106 BitBay — 2026-09-04
+
+## Scope
+
+This batch repairs only the zero-evidence legacy bundle for `hei_ex_000127` BitBay under #857.
+
+No schema, workflow, validator, monitoring, Phase 9, or unrelated canonical changes are included.
+
+## Evidence recovered
+
+- Contemporary 2021-11-08 reporting records BitBay's announcement that the exchange was becoming Zonda, including the new name, strategy and leadership.
+- A later first-party Zonda API migration notice explicitly ties the rebranding to retirement of legacy `bitbay.net` API endpoints while retaining existing account/API credentials, supporting service continuity across the brand transition.
+
+## Canonical disposition
+
+- Preserve `status: rebranded`.
+- Preserve `death_reason: rebrand`.
+- Preserve `death_date: 2021-11-08` because the exact date is supported by contemporaneous reporting.
+- Preserve `successor_id: hei_ex_000216` as the already-reviewed reciprocal lineage edge.
+- Do not introduce a launch date; this repair did not recover an equally strong exact launch-date source.
+
+## Canonical additions
+
+- `hei_ev_010228` — BitBay rebranded to Zonda on 2021-11-08.
+- `hei_src_012772` — contemporaneous rebrand report.
+- `hei_src_012773` — Zonda first-party legacy BitBay API migration notice.
+
+## Material-concerns guardrails
+
+The recovered material supports a brand transition and service continuity. It does not establish or negate unrelated allegations or findings involving insolvency, hacks, fraud, enforcement, ownership misconduct, or customer losses. No absence-of-evidence inference is made for those dimensions.

--- a/records/exchanges/bitbay.json
+++ b/records/exchanges/bitbay.json
@@ -10,7 +10,7 @@
     "launch_date": null,
     "death_date": "2021-11-08",
     "country_or_origin": "Poland",
-    "summary": "European exchange brand that rebranded from BitBay to Zonda on 2021-11-08.",
+    "summary": "European cryptocurrency exchange brand that rebranded from BitBay to Zonda on 2021-11-08. Zonda later migrated legacy BitBay API endpoints to Zonda infrastructure, confirming service continuity across the brand transition.",
     "official_url_original": "https://bitbay.net/",
     "official_domain_original": "bitbay.net",
     "official_url_status": "redirected",
@@ -18,11 +18,57 @@
     "predecessor_id": null,
     "successor_id": "hei_ex_000216",
     "confidence": "high",
-    "last_verified_at": "2026-04-10",
-    "notes": "HEI models BitBay as the historical predecessor brand of zondacrypto. The reviewed reciprocal lineage link preserves the separate historical brand record while preventing the transition from being treated as two unrelated exchange identities."
+    "last_verified_at": "2026-09-04",
+    "notes": "HEI models BitBay as the historical predecessor brand of Zonda / zondacrypto. Contemporary reporting dated 2021-11-08 records the BitBay-to-Zonda rebrand, while Zonda's later first-party API migration notice confirms continuity from legacy BitBay endpoints. Launch date remains null because this repair does not introduce a separately verified exact launch date."
   },
-  "events": [],
-  "evidence": [],
+  "events": [
+    {
+      "id": "hei_ev_010228",
+      "exchange_id": "hei_ex_000127",
+      "event_type": "rebranded",
+      "event_date": "2021-11-08",
+      "title": "BitBay rebranded to Zonda",
+      "description": "BitBay adopted the Zonda name, website and brand identity while continuing the exchange service under the new brand.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "rebranded",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "The exact 2021-11-08 date is supported by contemporaneous coverage of the exchange announcement. A later Zonda first-party API notice independently confirms the legacy BitBay-to-Zonda migration and service continuity."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012772",
+      "exchange_id": "hei_ex_000127",
+      "event_id": "hei_ev_010228",
+      "source_type": "news_article",
+      "title": "BitBay announces plans to become ‘Zonda’, and appoints new board of directors including Przemysław Kral as CEO",
+      "url": "https://ffnews.com/news/bitbay-announces-plans-to-become-zonda-and-appoints-new-board-of-directors-including-przemyslaw-kral-as-ceo/",
+      "publisher": "FF News",
+      "published_at": "2021-11-08",
+      "archived_url": "https://web.archive.org/web/*/https://ffnews.com/news/bitbay-announces-plans-to-become-zonda-and-appoints-new-board-of-directors-including-przemyslaw-kral-as-ceo/",
+      "accessed_at": "2026-09-04",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Contemporaneous report of BitBay's announcement of the Zonda name, new strategy and new leadership on 2021-11-08."
+    },
+    {
+      "id": "hei_src_012773",
+      "exchange_id": "hei_ex_000127",
+      "event_id": "hei_ev_010228",
+      "source_type": "official_blog",
+      "title": "IMPORTANT - API update",
+      "url": "https://zondacrypto.com/hu/news/important-api-update-1",
+      "publisher": "Zonda Team",
+      "published_at": "2022-01-27",
+      "archived_url": "https://web.archive.org/web/*/https://zondacrypto.com/hu/news/important-api-update-1",
+      "accessed_at": "2026-09-04",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "First-party post states that, because of the rebranding and URL updates, legacy BitBay API addresses were being disabled while existing login and API credentials continued on Zonda infrastructure."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000127",
     "expected": {


### PR DESCRIPTION
## Summary
- resolve BitBay's zero-evidence legacy bundle under #857
- add the 2021-11-08 BitBay-to-Zonda rebrand event
- add contemporaneous rebrand coverage plus a later first-party Zonda API migration notice linking legacy BitBay endpoints to the new brand
- preserve `status: rebranded`, `death_reason: rebrand`, `death_date: 2021-11-08`, and the reviewed Zonda successor linkage
- leave launch date null because this repair did not recover an equally strong exact launch-date source

## Scope
BitBay only. No schema, workflow, validator, monitoring, Phase 9, or unrelated canonical changes.