### PR TITLE
Monitor chain infrastructure outages and review Robinhood Chain incident

### DIFF
--- a/docs/audits/HEI_ROBINHOOD_CHAIN_INCIDENT_REVIEW_2026-09-05.md
+++ b/docs/audits/HEI_ROBINHOOD_CHAIN_INCIDENT_REVIEW_2026-09-05.md
@@ -1,0 +1,76 @@
+# HEI Robinhood Chain incident review — 2026-09-05
+
+Status: **HOLD — monitoring/research only; no canonical mutation**  
+Scope: reported Robinhood Chain disruption on 2026-09-04 and HEI exchange records that explicitly depend on Robinhood Chain
+
+## Trigger
+
+A public social alert on 2026-09-04 reported that Robinhood Chain was down and pointed to the Robinhood Chain Blockscout explorer. The social post is treated as a discovery trigger only, not as canonical HEI evidence.
+
+## Reviewed public reporting
+
+Two current reports materially disagree about what happened:
+
+- BeInCrypto reports that Robinhood Chain stopped producing blocks for at least 14 minutes and that transactions stalled. It says Robinhood had not disclosed the cause at publication time: `https://beincrypto.com/robinhood-chain-outage-blocks-stalled/`.
+- Crypto Briefing reports the opposite interpretation: Robinhood Chain continued producing L2 blocks while Ethereum blob submissions stopped for roughly 14 minutes, with the sequencer continuing to run: `https://cryptobriefing.com/robinhood-chain-blob-gap-ethereum-disruption/`.
+
+The relevant public explorer is `https://robinhoodchain.blockscout.com/`.
+
+This review did not capture a reproducible first-party incident statement or a durable block-level proof that resolves the conflict between an L2 execution halt and an L1 data-posting/blob gap. HEI therefore must not turn the headline into a reviewed lifecycle event yet.
+
+## HEI scope
+
+Robinhood Chain is infrastructure, not an exchange entity, so no new HEI entity should be created for the chain itself.
+
+Current reviewed exchange bundles that explicitly name Robinhood Chain are:
+
+- `records/exchanges/arcus.json` — Arcus is modeled as an active DEX on the Robinhood Chain ecosystem.
+- `records/exchanges/rialto.json` — Rialto is modeled as an active DEX spanning Robinhood Chain and Arbitrum ecosystems.
+- `records/exchanges/based.json` — Based is modeled as an active DEX/trading interface spanning Hyperliquid, Polygon, and Robinhood Chain ecosystems.
+
+HEI already supports `chain_shutdown_impact` as a reviewed event type. `records/exchanges/mantra-finance.json` provides the existing precedent: a chain-level halt can be recorded as `chain_shutdown_impact` without reclassifying the exchange itself as hacked or dead when the evidence supports only infrastructure disruption.
+
+## Canonical decision
+
+Do **not** add a Robinhood Chain incident event to Arcus, Rialto, or Based in this review.
+
+Do **not** change any of their entity statuses. They remain `active` unless separate reviewed evidence establishes a status change.
+
+Do **not** assign `death_reason`.
+
+The canonical gate is:
+
+1. obtain a first-party Robinhood/Robinhood Chain incident statement, or durable direct block-level evidence, that resolves whether L2 execution actually stopped;
+2. establish the material impact on each exchange record individually rather than propagating one chain headline to every multi-chain venue;
+3. only then open a separate reviewed canonical PR.
+
+If a true L2 execution halt is proven:
+
+- Arcus is the strongest `chain_shutdown_impact` candidate because its reviewed record is explicitly Robinhood-Chain based;
+- Rialto requires evidence that its Robinhood venue/execution path was affected; its Arbitrum presence means the whole entity must not be assumed unavailable;
+- Based requires evidence that its Robinhood-connected trading surface or routing was materially affected; its multi-ecosystem platform must not be marked broadly limited from the chain event alone.
+
+If the evidence instead confirms only an Ethereum blob/data-posting gap while L2 execution continued, no exchange lifecycle event should be added from this incident.
+
+## Monitoring gap found
+
+The current monitoring news query set covers exchange shutdowns, hacks, suspensions, regulatory events, and acquisition/migration/rebrand events, but it has no dedicated chain/sequencer/block-production outage category even though `chain_shutdown_impact` is a supported canonical event type.
+
+A second query-selection problem also exists: the normal news query cap is 20 while the pre-change query groups contain 25 queries. The old flatten-then-slice implementation can therefore silently starve categories placed later in the list.
+
+This branch repairs both monitoring gaps by:
+
+- adding a `chain_infrastructure_outage` query group mapped to `chain_shutdown_impact`;
+- changing capped query selection to balanced round-robin category coverage;
+- adding a smoke regression that requires every current news category, including chain infrastructure, to survive the normal 20-query cap;
+- updating the monitoring operations runbook.
+
+## Canonical impact
+
+```text
+entities: 0
+events:   0
+evidence: 0
+```
+
+This audit is intentionally monitoring/research only. Canonical lifecycle changes, if later justified, must be made in a separate reviewed data PR.

--- a/docs/monitoring-operations.md
+++ b/docs/monitoring-operations.md
@@ -63,15 +63,18 @@ expanding candidate discovery
 
 ### `enable_news_rss`
 
-Enables Google News RSS monitoring for shutdowns, hacks, withdrawal suspensions, regional exits, acquisition/migration/rebrand, and general exchange incidents.
+Enables Google News RSS monitoring for shutdowns, hacks, withdrawal suspensions, chain/sequencer/block-production outages that may interrupt exchange execution, regional exits, acquisition/migration/rebrand, and general exchange incidents.
 
 Use when:
 
 ```txt
 looking for recent negative CEX/DEX news
+looking for chain infrastructure outages that may affect DEX execution
 preparing a weekly exchange watch review
 checking if new incidents should become HEI records/events
 ```
+
+The default news query cap is shared across query categories using balanced round-robin selection. Adding a later category must not silently remove acquisition/rebrand or chain-infrastructure coverage from the normal capped scan.
 
 ### `enable_domain_checks`
 
@@ -167,7 +170,7 @@ news_query_limit = 20
 regulatory_query_limit = 25
 ```
 
-Use this when searching for recent closure, hack, withdrawal suspension, regional exit, or regulatory stories.
+Use this when searching for recent closure, hack, withdrawal suspension, chain/sequencer/block-production outage, regional exit, or regulatory stories.
 
 ### 4.3 Evidence maintenance scan
 

--- a/scripts/monitoring/core/news-extract.mjs
+++ b/scripts/monitoring/core/news-extract.mjs
@@ -96,6 +96,10 @@ function sourceQuality(item) {
 
 export function inferEventCategory(textValue, fallbackCategory = 'unknown') {
   const text = normalizeText(textValue);
+  if (
+    /\b(block production|producing blocks|sequencer|chain outage|network outage|blob submission|blob submissions|batch submission|batch submissions)\b/.test(text)
+    && /\b(halt|halted|stopped|stop|pause|paused|outage|gap|down|offline|stall|stalled)\b/.test(text)
+  ) return 'chain_infrastructure_outage';
   if (/\b(shutdown|shut down|closed|closure|cease operations|ceased operations|wind down|service ended|service discontinued)\b/.test(text)) return 'shutdown';
   if (/\b(hack|hacked|exploit|breach|unauthorized withdrawal|hot wallet|stolen|drained|suspicious outflows)\b/.test(text)) return 'hack_incident';
   if (/\b(withdrawals suspended|deposits suspended|trading halted|paused withdrawals|halted trading|withdrawal only|close only)\b/.test(text)) return 'withdrawal_deposit_trading_suspension';
@@ -107,6 +111,7 @@ export function inferEventCategory(textValue, fallbackCategory = 'unknown') {
 export function extractCandidateNameFromNews(item) {
   const text = `${item.title || ''} ${item.snippet || ''}`;
   const patterns = [
+    /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2}\s+Chain)\s+(?:[Ss]tops?|[Ss]topped|[Hh]alts?|[Hh]alted|[Pp]auses?|[Pp]aused|[Ss]uffers?|[Ww]ent)\b/,
     /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,2})\s+(?:(?:[Ss]huts|[Ww]ill [Ss]hut|[Tt]o [Ss]hut) [Dd]own|[Cc]eases [Oo]perations|[Hh]alts [Tt]rading|[Ss]uspends [Ww]ithdrawals|[Ii]s [Hh]acked|[Ww]as [Hh]acked|[Rr]ebrands|[Ii]s [Aa]cquired|[Ww]arning|[Ee]nforcement [Aa]ction|[Ss]anctioned)\b/,
     /\b(?:exchange|platform|protocol|DEX)\s+([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\b/,
     /\b([A-Z][A-Za-z0-9.&-]{2,}(?:\s+[A-Z][A-Za-z0-9.&-]{1,}){0,3})\s+(?:exchange|DEX|protocol|platform)\b/,

--- a/scripts/monitoring/monitors/news-and-event-watch.mjs
+++ b/scripts/monitoring/monitors/news-and-event-watch.mjs
@@ -96,6 +96,12 @@ function isResolvedCandidate(candidate, resolutions) {
   return resolutions?.resolvedNames?.has(normalizeName(candidate?.canonical_name || '')) || false;
 }
 
+export function isChainInfrastructureCandidate(candidate) {
+  const categories = new Set(candidate?.news_event_categories || []);
+  const eventTypes = new Set(candidate?.likely_event_types || []);
+  return categories.has('chain_infrastructure_outage') || eventTypes.has('chain_shutdown_impact');
+}
+
 function isActionableNewsCandidate(candidate, resolutions) {
   if (!candidate || isGenericCandidateName(candidate.canonical_name)) return false;
   if (isResolvedCandidate(candidate, resolutions)) return false;
@@ -104,6 +110,13 @@ function isActionableNewsCandidate(candidate, resolutions) {
 
   const sourceUrls = candidate.source_urls || [];
   if (sourceUrls.length === 0) return false;
+
+  // Chain infrastructure is not an exchange entity. Retain a credible chain-level
+  // outage only as monitoring context so operators can review dependent exchange
+  // records for a possible chain_shutdown_impact event.
+  if (isChainInfrastructureCandidate(candidate)) {
+    return candidate.source_quality !== 'low';
+  }
 
   // Existing canonical entities should not be auto-promoted into watchlist noise.
   // They are useful raw monitoring context, but event updates need manual review.
@@ -286,10 +299,11 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
       };
     });
   const candidates = allCandidates.filter((candidate) => isActionableNewsCandidate(candidate, resolutions) || isActionableRegulatoryCandidate(candidate, resolutions));
-  const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A');
+  const chainInfrastructureCandidates = candidates.filter(isChainInfrastructureCandidate);
+  const aCandidates = candidates.filter((candidate) => candidate.candidate_class === 'A' && !isChainInfrastructureCandidate(candidate));
   const regulatoryCandidates = candidates.filter((candidate) => candidate.source_category === 'regulatory_source');
-  const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity);
-  const missingInHei = candidates.filter((candidate) => !candidate.duplicate_check.matched_existing_entity);
+  const matchedExisting = candidates.filter((candidate) => candidate.duplicate_check.matched_existing_entity && !isChainInfrastructureCandidate(candidate));
+  const missingInHei = candidates.filter((candidate) => !candidate.duplicate_check.matched_existing_entity && !isChainInfrastructureCandidate(candidate));
 
   if (newsQueries.length > 0 && newsItems.length === 0) {
     findings.push(createFinding({
@@ -314,6 +328,20 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
       recommended_action: 'inspect_regulatory_source_queries_or_network',
       confidence: 'medium',
       dedupe_key: `${monitor}:rss_zero_regulatory`,
+    }));
+  }
+
+  for (const candidate of chainInfrastructureCandidates) {
+    findings.push(createFinding({
+      monitor,
+      severity: candidate.is_new_candidate ? 'medium' : 'low',
+      category: candidate.is_new_candidate ? 'chain_infrastructure_signal_new' : 'chain_infrastructure_signal_recurring',
+      title: `${candidate.is_new_candidate ? 'New' : 'Recurring'} chain infrastructure signal: ${candidate.canonical_name}`,
+      summary: 'Infrastructure outage signal only. Review whether any canonical exchange record depends on the affected chain and whether exchange execution was materially interrupted; do not create the chain itself as an exchange entity.',
+      recommended_action: 'review_chain_shutdown_impact_dependencies',
+      source_urls: candidate.source_urls,
+      confidence: candidate.source_quality === 'high' ? 'medium' : 'low',
+      dedupe_key: `${monitor}:chain_infrastructure:${candidate.candidate_key}`,
     }));
   }
 
@@ -351,6 +379,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
       filtering_summary: {
         raw_candidates: allCandidates.length,
         retained_candidates: candidates.length,
+        chain_infrastructure_candidates: chainInfrastructureCandidates.length,
         new_candidates: candidates.filter((candidate) => candidate.is_new_candidate).length,
         recurring_candidates: candidates.filter((candidate) => !candidate.is_new_candidate).length,
         dropped_candidates: allCandidates.length - candidates.length,
@@ -361,6 +390,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
         total: candidates.length,
         missing_in_hei: missingInHei.length,
         matched_existing: matchedExisting.length,
+        chain_infrastructure_candidates: chainInfrastructureCandidates.length,
         regulatory_candidates: regulatoryCandidates.length,
         A: candidates.filter((candidate) => candidate.candidate_class === 'A').length,
         B: candidates.filter((candidate) => candidate.candidate_class === 'B').length,
@@ -382,6 +412,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
         queries: newsQueries.length,
         items: newsItems.length,
         candidates: candidates.length - regulatoryCandidates.length,
+        chain_infrastructure_candidates: chainInfrastructureCandidates.length,
       },
       regulatory_summary: {
         ...regulatorySourceSummary,
@@ -393,6 +424,7 @@ export async function runNewsAndEventWatch(context, { startedAt } = {}) {
         items: allItems.length,
         raw_candidates: allCandidates.length,
         candidates: candidates.length,
+        chain_infrastructure_candidates: chainInfrastructureCandidates.length,
         dropped_candidates: allCandidates.length - candidates.length,
         resolved_candidate_names: resolutions.resolvedNames.size,
         missing_in_hei: missingInHei.length,

--- a/scripts/monitoring/sources/news-queries.mjs
+++ b/scripts/monitoring/sources/news-queries.mjs
@@ -53,6 +53,17 @@ export const NEWS_QUERY_GROUPS = [
     ],
   },
   {
+    category: 'chain_infrastructure_outage',
+    likely_event_types: ['chain_shutdown_impact'],
+    queries: [
+      'blockchain block production halted DEX exchange',
+      'L2 sequencer outage DEX trading',
+      'chain outage decentralized exchange transactions stalled',
+      'rollup outage exchange trading halted',
+      'blockchain network halt crypto exchange users',
+    ],
+  },
+  {
     category: 'regulatory',
     likely_event_types: ['regulatory_action'],
     queries: [
@@ -77,18 +88,32 @@ export const NEWS_QUERY_GROUPS = [
 ];
 
 export function getNewsQueries() {
-  const maxQueries = Number.parseInt(process.env.HEI_MONITORING_NEWS_QUERY_LIMIT || '20', 10);
+  const parsedLimit = Number.parseInt(process.env.HEI_MONITORING_NEWS_QUERY_LIMIT || '20', 10);
+  const maxQueries = Number.isFinite(parsedLimit) ? Math.max(0, parsedLimit) : 20;
+  if (maxQueries === 0) return [];
+
+  const groupedQueries = NEWS_QUERY_GROUPS.map((group) => group.queries.map((query) => ({
+    query,
+    category: group.category,
+    likely_event_types: group.likely_event_types,
+  })));
   const queries = [];
 
-  for (const group of NEWS_QUERY_GROUPS) {
-    for (const query of group.queries) {
-      queries.push({
-        query,
-        category: group.category,
-        likely_event_types: group.likely_event_types,
-      });
+  // Select queries round-robin by category so a global query cap cannot silently
+  // starve later categories. With the normal limit of 20, every current group
+  // receives coverage, including chain-infrastructure and acquisition signals.
+  for (let queryIndex = 0; queries.length < maxQueries; queryIndex += 1) {
+    let addedThisRound = false;
+
+    for (const groupQueries of groupedQueries) {
+      if (queries.length >= maxQueries) break;
+      if (queryIndex >= groupQueries.length) continue;
+      queries.push(groupQueries[queryIndex]);
+      addedThisRound = true;
     }
+
+    if (!addedThisRound) break;
   }
 
-  return queries.slice(0, Number.isFinite(maxQueries) ? maxQueries : 20);
+  return queries;
 }

--- a/scripts/monitoring/test-news-extract-noise.mjs
+++ b/scripts/monitoring/test-news-extract-noise.mjs
@@ -1,4 +1,5 @@
-import { extractCandidateNameFromNews } from './core/news-extract.mjs';
+import { extractCandidateNameFromNews, inferEventCategory } from './core/news-extract.mjs';
+import { isChainInfrastructureCandidate } from './monitors/news-and-event-watch.mjs';
 import { NEWS_QUERY_GROUPS, getNewsQueries } from './sources/news-queries.mjs';
 
 function assertNullCandidate(item, label) {
@@ -31,6 +32,30 @@ function assertNewsQueryCoverage() {
   } finally {
     if (previousLimit === undefined) delete process.env.HEI_MONITORING_NEWS_QUERY_LIMIT;
     else process.env.HEI_MONITORING_NEWS_QUERY_LIMIT = previousLimit;
+  }
+}
+
+function assertChainInfrastructureExtraction() {
+  const item = {
+    title: 'Robinhood Chain Stops Producing Blocks. What Happened?',
+    snippet: 'A network outage stalled transactions for at least 14 minutes.',
+    source_name: 'BeInCrypto',
+  };
+  const candidate = extractCandidateNameFromNews(item);
+  if (candidate !== 'Robinhood Chain') {
+    throw new Error(`chain outage extraction must identify Robinhood Chain: ${candidate}`);
+  }
+
+  const category = inferEventCategory(`${item.title} ${item.snippet}`, 'unknown');
+  if (category !== 'chain_infrastructure_outage') {
+    throw new Error(`chain outage category regression: ${category}`);
+  }
+
+  if (!isChainInfrastructureCandidate({
+    news_event_categories: [category],
+    likely_event_types: ['chain_shutdown_impact'],
+  })) {
+    throw new Error('chain outage monitor signal must be retained as chain infrastructure context');
   }
 }
 
@@ -80,5 +105,6 @@ assertNullCandidate(
 );
 
 assertNewsQueryCoverage();
+assertChainInfrastructureExtraction();
 
 console.log('HEI news candidate noise regressions passed.');

--- a/scripts/monitoring/test-news-extract-noise.mjs
+++ b/scripts/monitoring/test-news-extract-noise.mjs
@@ -1,9 +1,36 @@
 import { extractCandidateNameFromNews } from './core/news-extract.mjs';
+import { NEWS_QUERY_GROUPS, getNewsQueries } from './sources/news-queries.mjs';
 
 function assertNullCandidate(item, label) {
   const candidate = extractCandidateNameFromNews(item);
   if (candidate !== null) {
     throw new Error(`${label}: expected null candidate, received ${candidate}`);
+  }
+}
+
+function assertNewsQueryCoverage() {
+  const previousLimit = process.env.HEI_MONITORING_NEWS_QUERY_LIMIT;
+  process.env.HEI_MONITORING_NEWS_QUERY_LIMIT = '20';
+
+  try {
+    const queries = getNewsQueries();
+    if (queries.length !== 20) {
+      throw new Error(`news query cap regression: expected 20 queries, received ${queries.length}`);
+    }
+
+    const selectedCategories = new Set(queries.map((query) => query.category));
+    for (const group of NEWS_QUERY_GROUPS) {
+      if (!selectedCategories.has(group.category)) {
+        throw new Error(`news query cap starved category: ${group.category}`);
+      }
+    }
+
+    if (!queries.some((query) => query.category === 'chain_infrastructure_outage' && query.likely_event_types.includes('chain_shutdown_impact'))) {
+      throw new Error('chain infrastructure query coverage must map to chain_shutdown_impact');
+    }
+  } finally {
+    if (previousLimit === undefined) delete process.env.HEI_MONITORING_NEWS_QUERY_LIMIT;
+    else process.env.HEI_MONITORING_NEWS_QUERY_LIMIT = previousLimit;
   }
 }
 
@@ -51,5 +78,7 @@ assertNullCandidate(
   },
   'count word used as exchange identity',
 );
+
+assertNewsQueryCoverage();
 
 console.log('HEI news candidate noise regressions passed.');


### PR DESCRIPTION
## Roadmap / lane

Ongoing Lane C monitoring coverage + Lane A lifecycle review under the current post-v1 / AI-era operating baseline.

## Relevant authority

- `docs/monitoring-operations.md`
- `docs/HEI_AI_ERA_REGISTRY_SPEC.md`
- `docs/HEI_AI_ERA_EXECUTION_SCHEDULE.md`
- existing `chain_shutdown_impact` event contract and MANTRA Finance precedent

## What this changes

- adds a `chain_infrastructure_outage` news-query group mapped to `chain_shutdown_impact`;
- changes capped news-query selection from flatten-and-slice to balanced round-robin so the normal 20-query cap cannot silently starve later categories;
- recognizes named chain outage headlines and classifies block-production / sequencer / blob-posting / network-halt language as chain-infrastructure signals;
- retains credible chain-infrastructure findings as **monitoring context only**, even though a chain is out of HEI exchange-entity scope;
- explicitly excludes those infrastructure findings from `missing_in_hei` exchange counts and tells the operator to review dependent exchange records instead of creating a chain entity;
- adds smoke regressions for query-cap category coverage, Robinhood Chain headline extraction, chain-event categorization, and `chain_shutdown_impact` routing;
- updates the monitoring runbook;
- records a reviewed Robinhood Chain incident audit with a canonical HOLD decision because current public reports conflict on whether L2 block production stopped or only Ethereum blob posting paused.

## Robinhood Chain disposition

No canonical event is added in this PR.

Current public reporting conflicts:

- BeInCrypto reports a >=14-minute block-production halt with stalled transactions.
- Crypto Briefing reports uninterrupted L2 block production and a ~14-minute Ethereum blob-submission gap.

Until first-party or durable direct block-level evidence resolves that conflict, HEI must not convert the headline into `chain_shutdown_impact` on Arcus, Rialto, or Based.

If a true L2 execution halt is later established, affected exchange records must be reviewed individually. Robinhood Chain itself is infrastructure and must not be created as an exchange entity.

## Canonical count impact

- entities: 0
- events: 0
- evidence: 0

## Deployment impact

No public product output is changed. This PR changes `scripts/monitoring/**` and `docs/**` only. Cloudflare preview is **not required** under the repository deployment policy.

## Validation

GitHub CI must pass on the exact PR head, including:

- lint / repository policy checks;
- `monitor:smoke`, which now exercises capped query coverage and chain-outage extraction/routing;
- monitoring completion tests;
- existing canonical-data guards and record/public validation.

## Production verification

Not applicable: no public site or machine-readable canonical output changes.