### PR TITLE
Repair BTCChina correction preconditions after BX108

### DIFF
--- a/config/maintainer-recovery-contract.json
+++ b/config/maintainer-recovery-contract.json
@@ -7,8 +7,8 @@
   "next_item": "Language Selection Gate",
   "reviewed_counts": {
     "entities": 1071,
-    "events": 1114,
-    "evidence": 4050
+    "events": 1115,
+    "evidence": 4052
   },
   "authoritative_paths": {
     "agent_instructions": "AGENTS.md",

--- a/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
+++ b/docs/HEI_L2_LOCALIZATION_EVALUATION_PLAN.md
@@ -52,12 +52,12 @@ Completion authority:
 docs/audits/HEI_D1000_MILESTONE_COMPLETION_2026-08-09.md
 ```
 
-Reviewed canonical growth continues after D-1000. BX62 established 1034 reviewed entities and later reviewed growth, lifecycle, regulatory, correction, and evidence work has continued through normal record bundles. The current reviewed state derived on 2026-09-04 under the same public build aggregation semantics is:
+Reviewed canonical growth continues after D-1000. BX62 established 1034 reviewed entities and later reviewed growth, lifecycle, regulatory, correction, and evidence work has continued through normal record bundles. The current reviewed state derived on 2026-09-05 under the same public build aggregation semantics is:
 
 ```text
 Entities: 1071
-Events:   1114
-Evidence: 4050
+Events:   1115
+Evidence: 4052
 ```
 
 Post-D-1000 entity-growth authority remains:

--- a/docs/operations/HEI_MAINTAINER_RECOVERY_RUNBOOK.md
+++ b/docs/operations/HEI_MAINTAINER_RECOVERY_RUNBOOK.md
@@ -222,12 +222,12 @@ scripts/lib/reviewed-bundle-aggregation.mjs
 scripts/lib/entity-corrections.mjs
 ```
 
-Reviewed counts re-derived on 2026-09-04 from the current reviewed bundle state are:
+Reviewed counts re-derived on 2026-09-05 from the current reviewed bundle state are:
 
 ```text
 Entities: 1071
-Events:   1114
-Evidence: 4050
+Events:   1115
+Evidence: 4052
 ```
 
 These numbers remain a checkpoint only. Re-derive them after later reviewed growth instead of copying them forward blindly.

--- a/records/exchanges/btcchina.json
+++ b/records/exchanges/btcchina.json
@@ -77,9 +77,9 @@
     "expected": {
       "launch_date": "2011-06-01",
       "summary": "China-based Bitcoin exchange founded in 2011 and widely described as China's first Bitcoin exchange. In September 2015, BTCChina rebranded to BTCC as the company shifted toward a more global identity.",
-      "successor_id": "hei_ex_000410",
+      "successor_id": null,
       "last_verified_at": "2026-04-29",
-      "notes": "HEI models this as the historical BTCChina brand record and links it reciprocally to the existing BTCC record. The 2015-09-15 rebrand is used as the terminal BTCChina brand marker; later BTCC trading restrictions and ownership changes remain part of the BTCC record."
+      "notes": "HEI models this as the historical BTCChina brand record. The 2015-09-15 rebrand to BTCC is used as the terminal brand marker. Later BTCC trading restrictions and ownership changes should be handled separately if a BTCC successor record is modeled."
     },
     "changes": {
       "launch_date": null,


### PR DESCRIPTION
## Scope

Repairs the broken `main` validation baseline left by BX108 / PR #963.

Two independent stale-checkpoint failures were exposed once current `main` was revalidated:

1. BTCChina's `entity_correction.expected` values did not match the reviewed base entity before BX108's correction was applied.
2. The maintainer recovery contract still reported pre-BX108 reviewed event/evidence counts.

This PR therefore makes only baseline-repair changes:

### BTCChina correction preconditions

- `expected.successor_id`: `hei_ex_000410` -> `null`
- `expected.notes`: restored to the exact base-entity notes from `data/entities.json`

The reviewed BX108 target values, lifecycle event, evidence, IDs, status, and public semantics are unchanged.

### Recovery checkpoint

Refresh reviewed counts to the values produced by current public build aggregation after BX108:

- entities: `1071` (unchanged)
- events: `1114` -> `1115`
- evidence: `4050` -> `4052`

## Canonical count impact

No new records are introduced by this repair. The count change above only synchronizes recovery metadata with the already merged BX108 reviewed state.

## Deployment impact

No new product behavior is introduced. Cloudflare preview is not required; exact-head GitHub CI is required.

## Validation target

- `records:validate`
- recovery self-test and recovery validation
- full build/lint/counts/machine/public validation

all must complete green on the exact PR head before merge.

## Production verification

No new public semantic output is expected. This PR repairs validator/checkpoint metadata for already merged reviewed state.