### PR TITLE
BX109: repair CHBTC to ZB.com lifecycle evidence

### DIFF
--- a/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX109_CHBTC_2026-09-08.md
+++ b/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX109_CHBTC_2026-09-08.md
@@ -1,0 +1,56 @@
+# HEI Material Concerns Correction — BX109 CHBTC — 2026-09-08
+
+## Scope
+
+This batch repairs only `hei_ex_000271` (CHBTC) under the zero-evidence legacy-material-concerns work tracked by #857.
+
+No schema, validator, workflow, monitoring, Phase 9, or unrelated canonical changes are included.
+
+## Pre-repair state
+
+The CHBTC record was already classified `rebranded` with successor `hei_ex_000290` (ZB.com), but it had no linked events or evidence. It also carried two exact dates that were not adequately tied to reviewed source evidence:
+
+- `launch_date: 2013-06-01`
+- `death_date: 2017-12-31`
+
+The record notes explicitly described the latter as an end-of-year transition marker rather than an observed event date.
+
+## Evidence review
+
+### South China Morning Post — 2017-10-31
+
+Contemporaneous reporting states that ZB.com was an overseas platform operated by Chinese digital-currency exchange CHBTC and that international trading would become available from 2017-11-01.
+
+This supports service/brand continuity between CHBTC and ZB.com without requiring an inference of legal-entity dissolution.
+
+### A5站长网 — 2017-11-02
+
+Contemporaneous domain/platform reporting states that ZB.com formally went live on 2017-11-01 and that the new platform/domain replaced the original `chbtc.com` domain for the trading service.
+
+This corroborates 2017-11-01 as an observable transition point.
+
+## Canonical corrections
+
+- preserve `status: rebranded`
+- preserve `death_reason: rebrand`
+- preserve successor `hei_ex_000290`
+- change `launch_date` from `2013-06-01` to `null`; reviewed material supports 2013 / early-2013 operation but not that exact day
+- change `death_date` from synthetic marker `2017-12-31` to documented transition date `2017-11-01`
+- refresh summary, notes, and `last_verified_at`
+
+## Canonical additions
+
+- `hei_ev_010233` — CHBTC transitioned to the ZB.com overseas platform on 2017-11-01
+- `hei_src_012781` — South China Morning Post contemporaneous report
+- `hei_src_012782` — A5 contemporaneous ZB.com launch/domain-transition report
+
+## Explicit non-inferences
+
+- The 2017-11-01 brand transition is not treated as legal-entity dissolution.
+- No terminal failure, insolvency, or asset-loss event is inferred.
+- No exact CHBTC launch day is introduced.
+- The separate later status of ZB.com remains governed by the ZB.com canonical record.
+
+## Disposition
+
+The zero-evidence material concern for CHBTC is repaired with a documented lifecycle transition and with unsupported exact-date precision removed.

--- a/records/exchanges/chbtc.json
+++ b/records/exchanges/chbtc.json
@@ -10,10 +10,10 @@
     "type": "cex",
     "status": "rebranded",
     "death_reason": "rebrand",
-    "launch_date": "2013-06-01",
-    "death_date": "2017-12-31",
+    "launch_date": null,
+    "death_date": "2017-11-01",
     "country_or_origin": "China",
-    "summary": "China-based centralized cryptocurrency exchange founded in 2013. CHBTC ceased China-market trading activity around September 2017 amid Chinese regulatory pressure and later transitioned into the overseas ZB.com brand at the end of 2017.",
+    "summary": "China-based centralized cryptocurrency exchange brand that operated from 2013 and transitioned to the overseas ZB.com service in 2017. Contemporary reporting identified ZB.com as an overseas platform operated by CHBTC and said international trading would become available on 2017-11-01.",
     "official_url_original": "https://chbtc.com/",
     "official_domain_original": "chbtc.com",
     "official_url_status": "unknown",
@@ -21,18 +21,74 @@
     "predecessor_id": null,
     "successor_id": "hei_ex_000290",
     "confidence": "medium",
-    "last_verified_at": "2026-04-29",
-    "notes": "HEI models CHBTC as rebranded rather than dead because multiple profile sources describe the China-market trading stop followed by a name change / overseas transition to ZB.com. The death_date is stored as 2017-12-31 as an end-of-year brand-transition marker, while the 2017-09-30 China-market trading stop is recorded as a separate regulatory event."
+    "last_verified_at": "2026-09-08",
+    "notes": "HEI models CHBTC as the historical predecessor brand of ZB.com. The prior 2017-12-31 death_date was only an end-of-year marker and is removed. The replacement 2017-11-01 date is tied to the documented ZB.com international-service launch and brand/domain transition, not to legal-entity dissolution. The previous exact launch_date 2013-06-01 is also removed because reviewed sources support 2013 / early-2013 operation but not that exact day."
   },
-  "events": [],
-  "evidence": [],
+  "events": [
+    {
+      "id": "hei_ev_010233",
+      "exchange_id": "hei_ex_000271",
+      "event_type": "rebranded",
+      "event_date": "2017-11-01",
+      "title": "CHBTC transitioned to the ZB.com overseas platform",
+      "description": "ZB.com began international trading as an overseas platform operated by CHBTC, marking the transition from the CHBTC brand/domain to the ZB.com successor service.",
+      "confidence": "medium",
+      "impact_level": "high",
+      "event_status_effect": "rebranded",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "The exact date is tied to contemporaneous reports that ZB.com would open international trading on 2017-11-01 and that the ZB.com domain formally went live that day. This does not imply legal-entity dissolution."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012781",
+      "exchange_id": "hei_ex_000271",
+      "event_id": "hei_ev_010233",
+      "source_type": "news_article",
+      "title": "As China closes its doors to cryptocurrencies, exchanges shift their attention overseas",
+      "url": "https://www.scmp.com/business/companies/article/2117806/china-closes-its-doors-cryptocurrencies-exchanges-shift-their",
+      "publisher": "South China Morning Post",
+      "published_at": "2017-10-31",
+      "archived_url": "https://web.archive.org/web/*/https://www.scmp.com/business/companies/article/2117806/china-closes-its-doors-cryptocurrencies-exchanges-shift-their",
+      "accessed_at": "2026-09-08",
+      "reliability": "high",
+      "claim_scope": "event",
+      "notes": "Contemporaneous report identifies ZB.com as an overseas platform operated by CHBTC and says international trading would become available from 2017-11-01."
+    },
+    {
+      "id": "hei_src_012782",
+      "exchange_id": "hei_ex_000271",
+      "event_id": "hei_ev_010233",
+      "source_type": "news_article",
+      "title": "域名ZB.com正式上线 搭建区块链资产交易平台",
+      "url": "https://www.admin5.com/article/20171102/796312.shtml",
+      "publisher": "A5站长网",
+      "published_at": "2017-11-02",
+      "archived_url": "https://web.archive.org/web/*/https://www.admin5.com/article/20171102/796312.shtml",
+      "accessed_at": "2026-09-08",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Contemporaneous report states that ZB.com formally went live on 2017-11-01 and that the new domain/platform replaced the original chbtc.com domain for the blockchain-asset trading service."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000271",
     "expected": {
-      "successor_id": null
+      "launch_date": "2013-06-01",
+      "death_date": "2017-12-31",
+      "summary": "China-based centralized cryptocurrency exchange founded in 2013. CHBTC ceased China-market trading activity around September 2017 amid Chinese regulatory pressure and later transitioned into the overseas ZB.com brand at the end of 2017.",
+      "successor_id": "hei_ex_000290",
+      "last_verified_at": "2026-04-29",
+      "notes": "HEI models CHBTC as rebranded rather than dead because multiple profile sources describe the China-market trading stop followed by a name change / overseas transition to ZB.com. The death_date is stored as 2017-12-31 as an end-of-year brand-transition marker, while the 2017-09-30 China-market trading stop is recorded as a separate regulatory event."
     },
     "changes": {
-      "successor_id": "hei_ex_000290"
+      "launch_date": null,
+      "death_date": "2017-11-01",
+      "summary": "China-based centralized cryptocurrency exchange brand that operated from 2013 and transitioned to the overseas ZB.com service in 2017. Contemporary reporting identified ZB.com as an overseas platform operated by CHBTC and said international trading would become available on 2017-11-01.",
+      "successor_id": "hei_ex_000290",
+      "last_verified_at": "2026-09-08",
+      "notes": "HEI models CHBTC as the historical predecessor brand of ZB.com. The prior 2017-12-31 death_date was only an end-of-year marker and is removed. The replacement 2017-11-01 date is tied to the documented ZB.com international-service launch and brand/domain transition, not to legal-entity dissolution. The previous exact launch_date 2013-06-01 is also removed because reviewed sources support 2013 / early-2013 operation but not that exact day."
     }
   }
 }


### PR DESCRIPTION
## Summary
- resolve CHBTC's zero-evidence legacy bundle under #857
- add the documented 2017-11-01 CHBTC -> ZB.com overseas platform transition event
- add two contemporaneous independent sources
- preserve `status: rebranded`, `death_reason: rebrand`, and successor `hei_ex_000290`
- replace synthetic `death_date: 2017-12-31` with documented transition date `2017-11-01`
- remove unsupported exact `launch_date: 2013-06-01`; reviewed evidence supports only 2013 / early-2013 operation

## Scope
CHBTC only. No schema, workflow, validator, monitoring, Phase 9, or unrelated canonical changes.