### PR TITLE
BX111: repair McxNOW lifecycle evidence

### DIFF
--- a/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX111_MCXNOW_2026-09-09.md
+++ b/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX111_MCXNOW_2026-09-09.md
@@ -1,0 +1,44 @@
+# HEI material-concerns correction — BX111 McxNOW — 2026-09-09
+
+## Scope
+
+This correction is limited to `hei_ex_000218` (McxNOW), one of the zero-evidence legacy records tracked under #857.
+
+## Findings
+
+- McxNOW was operating during 2013 and publicly suspended trading in November 2013 because of growth/support pressure.
+- The exchange later returned; therefore the 2013 suspension is not a terminal event.
+- McxNOW announced another maintenance period beginning 2014-11-15. Users were instructed to withdraw before that cutoff because existing exchange wallets/backups would be removed during the wallet-system replacement.
+- Historical reporting described a planned successor/rebrand named mtMOX after the 2014 shutdown, but later reporting says the replacement never became a functioning durable exchange.
+- The reviewed evidence supports a historical terminal state for McxNOW, but it does not establish an exact permanent-closure date or a specific terminal cause such as insolvency, hack, enforcement, acquisition, or voluntary wind-down.
+- The reviewed evidence supports operation in 2013, but not the prior exact `2013-01-01` launch date.
+
+## Canonical corrections
+
+- preserve `status: dead`
+- preserve `death_reason: unknown`
+- `launch_date: 2013-01-01 -> null`
+- `death_date: 2014-11-15 -> null`
+- preserve `country_or_origin: Unknown`
+- refresh summary/notes and `last_verified_at`
+
+## Canonical additions
+
+- `hei_ev_010234` — McxNOW entered maintenance and removed exchange wallets on 2014-11-15
+- `hei_src_012785` — CoinDesk contemporaneous 2013 trading-suspension report
+- `hei_src_012786` — CCN report preserving the 2014-11-15 operator maintenance/wallet-removal announcement and mtMOX replacement plan
+- `hei_src_012787` — Bitcoin Wiki historical corroboration of the 2014-11-15 maintenance/wallet cutoff
+
+## Non-inferences
+
+This repair does **not** infer:
+
+- that 2014-11-15 was the exact permanent-closure date;
+- insolvency, theft, hack, enforcement, or acquisition as the terminal cause;
+- that the mtMOX announcement produced a functioning successor exchange;
+- an exact McxNOW launch day;
+- an Australian or New South Wales operating jurisdiction from community-level references.
+
+## Disposition
+
+The zero-evidence material concern for `hei_ex_000218` is resolved with evidence-backed lifecycle context. The entity remains historically dead, but the artificial exact launch/death dates are removed and the 2014-11-15 cutoff is represented as a service event rather than a fabricated permanent-death date.

--- a/records/exchanges/mcxnow.json
+++ b/records/exchanges/mcxnow.json
@@ -7,10 +7,10 @@
     "type": "cex",
     "status": "dead",
     "death_reason": "unknown",
-    "launch_date": "2013-01-01",
-    "death_date": "2014-11-15",
+    "launch_date": null,
+    "death_date": null,
     "country_or_origin": "Unknown",
-    "summary": "Early cryptocurrency exchange offering bitcoin and altcoin trading that suspended trading in 2013 and later entered a 2014 maintenance period after which unwithdrawn coins were to be destroyed.",
+    "summary": "Early cryptocurrency exchange offering bitcoin and altcoin trading. McxNOW suspended trading in 2013, later returned, and on 2014-11-15 entered another maintenance period that required users to withdraw before its wallets were removed. The exchange did not establish a durable successor service afterward.",
     "official_url_original": "https://mcxnow.com/",
     "official_domain_original": "mcxnow.com",
     "official_url_status": "dead_domain",
@@ -18,20 +18,85 @@
     "predecessor_id": null,
     "successor_id": null,
     "confidence": "medium",
-    "last_verified_at": "2026-06-20",
-    "notes": "Terminal handling uses the 2014-11-15 maintenance / withdrawal-deadline marker from public exchange references. Death reason is kept as unknown because the current evidence shows operator-announced suspension / maintenance but does not establish a clean permanent-closure cause such as insolvency, hack, enforcement, or acquisition. The 2026-06-20 explicit-origin review retained Unknown. Historical community posts and registration references point toward Australia or New South Wales, but they are not sufficiently primary, stable, or attributable to the operating entity to support a country assignment."
+    "last_verified_at": "2026-09-09",
+    "notes": "HEI retains dead / unknown because reviewed historical sources show that McxNOW ceased operating and did not establish a durable replacement exchange. The prior 2014-11-15 death_date is removed because that date is specifically documented as the start of a maintenance period and wallet-removal cutoff, not as a proven permanent-closure date. The prior 2013-01-01 launch_date is also removed because reviewed evidence supports operation in 2013 but not that exact day. A planned rebrand to mtMOX was reported after the 2014 shutdown, but later historical reporting states that the rebrand never became a functioning successor exchange. Country/origin remains Unknown."
   },
+  "events": [
+    {
+      "id": "hei_ev_010234",
+      "exchange_id": "hei_ex_000218",
+      "event_type": "trading_halted",
+      "event_date": "2014-11-15",
+      "title": "McxNOW entered maintenance and removed exchange wallets",
+      "description": "McxNOW announced a maintenance period beginning 2014-11-15 and required users to withdraw cryptocurrency before existing online wallets and backups were removed as part of a wallet-system replacement.",
+      "confidence": "high",
+      "impact_level": "high",
+      "event_status_effect": "limited",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "This date is an exact service cutoff / maintenance start. It is not treated as the exchange's proven permanent-closure date."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012785",
+      "exchange_id": "hei_ex_000218",
+      "event_id": null,
+      "source_type": "news_article",
+      "title": "McxNOW Cryptoexchange Suspends Trading Following Support Request Overload",
+      "url": "https://www.coindesk.com/markets/2013/11/27/mcxnow-cryptoexchange-suspends-trading-following-support-request-overload",
+      "publisher": "CoinDesk",
+      "published_at": "2013-11-27",
+      "archived_url": "https://web.archive.org/web/*/https://www.coindesk.com/markets/2013/11/27/mcxnow-cryptoexchange-suspends-trading-following-support-request-overload",
+      "accessed_at": "2026-09-09",
+      "reliability": "high",
+      "claim_scope": "status",
+      "notes": "Contemporaneous report documents McxNOW's 2013 trading suspension and operator explanation tied to rapid growth and support load. It supports operation during 2013 but not an exact launch date."
+    },
+    {
+      "id": "hei_src_012786",
+      "exchange_id": "hei_ex_000218",
+      "event_id": "hei_ev_010234",
+      "source_type": "news_article",
+      "title": "McxNOW Bitcoin Exchange Undergoing Possibly the Worst Rebrand in Bitcoin History: Introducing MtMOX",
+      "url": "https://www.ccn.com/mcxnow-bitcoin-exchange-undergoing-possibly-worst-rebrand-bitcoin-history-introducing-mtmox/",
+      "publisher": "CCN",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://www.ccn.com/mcxnow-bitcoin-exchange-undergoing-possibly-worst-rebrand-bitcoin-history-introducing-mtmox/",
+      "accessed_at": "2026-09-09",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Preserves the operator announcement that maintenance would begin 2014-11-15, that users had to withdraw before the cutoff, and that existing wallets/backups would be removed. It also documents the announced mtMOX replacement plan."
+    },
+    {
+      "id": "hei_src_012787",
+      "exchange_id": "hei_ex_000218",
+      "event_id": "hei_ev_010234",
+      "source_type": "database_reference",
+      "title": "McxNOW",
+      "url": "https://en.bitcoin.it/wiki/McxNOW",
+      "publisher": "Bitcoin Wiki",
+      "published_at": null,
+      "archived_url": "https://web.archive.org/web/*/https://en.bitcoin.it/wiki/McxNOW",
+      "accessed_at": "2026-09-09",
+      "reliability": "medium",
+      "claim_scope": "status",
+      "notes": "Historical reference records the maintenance period beginning 2014-11-15 and the planned destruction/removal of unwithdrawn wallet data. Used as corroboration, not as proof of an exact permanent-closure date or cause."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000218",
     "expected": {
-      "last_verified_at": "2026-04-25",
-      "notes": "Terminal handling uses the 2014-11-15 maintenance / withdrawal-deadline marker from public exchange references. Death reason is kept as unknown because the current evidence shows operator-announced suspension / maintenance but does not establish a clean permanent-closure cause such as insolvency, hack, enforcement, or acquisition. Country/origin remains Unknown because the current evidence set does not establish an operating jurisdiction."
+      "launch_date": "2013-01-01",
+      "death_date": "2014-11-15",
+      "summary": "Early cryptocurrency exchange offering bitcoin and altcoin trading that suspended trading in 2013 and later entered a 2014 maintenance period after which unwithdrawn coins were to be destroyed.",
+      "last_verified_at": "2026-06-20"
     },
     "changes": {
-      "last_verified_at": "2026-06-20",
-      "notes": "Terminal handling uses the 2014-11-15 maintenance / withdrawal-deadline marker from public exchange references. Death reason is kept as unknown because the current evidence shows operator-announced suspension / maintenance but does not establish a clean permanent-closure cause such as insolvency, hack, enforcement, or acquisition. The 2026-06-20 explicit-origin review retained Unknown. Historical community posts and registration references point toward Australia or New South Wales, but they are not sufficiently primary, stable, or attributable to the operating entity to support a country assignment."
+      "launch_date": null,
+      "death_date": null,
+      "summary": "Early cryptocurrency exchange offering bitcoin and altcoin trading. McxNOW suspended trading in 2013, later returned, and on 2014-11-15 entered another maintenance period that required users to withdraw before its wallets were removed. The exchange did not establish a durable successor service afterward.",
+      "last_verified_at": "2026-09-09"
     }
-  },
-  "events": [],
-  "evidence": []
+  }
 }


### PR DESCRIPTION
## Summary
- resolve McxNOW's zero-evidence legacy bundle under #857
- preserve `status: dead` / `death_reason: unknown`
- remove unsupported exact `launch_date: 2013-01-01`
- remove unsupported exact `death_date: 2014-11-15`
- represent 2014-11-15 as the documented maintenance / wallet-removal cutoff instead of a fabricated permanent-death date
- add evidence for the 2013 suspension, 2014 maintenance cutoff, and failed mtMOX successor plan

## Scope
McxNOW only. No schema, workflow, validator, monitoring, Phase 9, or unrelated canonical changes.