### PR TITLE
Fix CCLR public project-network URL

### DIFF
--- a/config/public-project-network.json
+++ b/config/public-project-network.json
@@ -10,6 +10,6 @@
     { "id": "bir", "name": "Bridge Incident Registry", "url": "https://bir.badjoke-lab.com/" },
     { "id": "mag", "name": "Minted & Gone", "url": "https://mag.badjoke-lab.com/" },
     { "id": "wlr", "name": "Wallet Lifecycle Registry", "url": "https://wlr.badjoke-lab.com/" },
-    { "id": "cclr", "name": "Crypto Card Lifecycle Registry", "url": "https://badjoke-lab.github.io/crypto-card-lifecycle-registry/" }
+    { "id": "cclr", "name": "Crypto Card Lifecycle Registry", "url": "https://cclr.badjoke-lab.com/" }
   ]
 }


### PR DESCRIPTION
Corrects the CCLR member URL in the public project-network authority from the deprecated GitHub Pages path to the canonical public domain `https://cclr.badjoke-lab.com/`.

This resolves the conflict where CCLR's own validation explicitly rejects the GitHub Pages URL while the shared network-integrity workflow was still requiring it.