### PR TITLE
Fix redundant BCC entity correction fields

### DIFF
--- a/records/exchanges/bcc-exchange-bitconnect-coin.json
+++ b/records/exchanges/bcc-exchange-bitconnect-coin.json
@@ -138,9 +138,6 @@
     },
     "changes": {
       "launch_date": null,
-      "death_date": "2018-01-16",
-      "status": "dead",
-      "death_reason": "regulation",
       "last_verified_at": "2026-09-09"
     }
   }

--- a/records/exchanges/bcc-exchange-bitconnect-coin.json
+++ b/records/exchanges/bcc-exchange-bitconnect-coin.json
@@ -131,7 +131,7 @@
     "entity_id": "hei_ex_000300",
     "expected": {
       "launch_date": "2016-11-01",
-      "last_verified_at": "2026-06-20"
+      "last_verified_at": "2026-05-11"
     },
     "changes": {
       "launch_date": null,

--- a/records/exchanges/bcc-exchange-bitconnect-coin.json
+++ b/records/exchanges/bcc-exchange-bitconnect-coin.json
@@ -131,9 +131,6 @@
     "entity_id": "hei_ex_000300",
     "expected": {
       "launch_date": "2016-11-01",
-      "death_date": "2018-01-16",
-      "status": "dead",
-      "death_reason": "regulation",
       "last_verified_at": "2026-06-20"
     },
     "changes": {


### PR DESCRIPTION
Removes unchanged `death_date`, `status`, and `death_reason` keys from the BCC Exchange record's `entity_correction.changes` block. The actual correction remains limited to removing the unsupported exact launch date and refreshing verification time. No canonical lifecycle fact is changed by this fix.