### PR TITLE
BX113: repair Crypto-Trade identity and lifecycle evidence

### DIFF
--- a/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX113_CRYPTO_TRADE_2026-09-09.md
+++ b/docs/audits/HEI_MATERIAL_CONCERNS_CORRECTION_BX113_CRYPTO_TRADE_2026-09-09.md
@@ -1,0 +1,55 @@
+# HEI Material-Concerns Correction — BX113 Crypto-Trade — 2026-09-09
+
+## Scope
+
+This batch repairs the zero-evidence legacy record `hei_ex_000246` (Crypto-Trade) under issue #857. No schema, workflow, validator, monitoring, Phase 9, or unrelated canonical records are changed.
+
+## Identity correction
+
+The reviewed 2013-2015 exchange operated at `crypto-trade.com` and was promoted in the Bitcoin Forum thread `[CRYPTO-TRADE] Crypto-trade.com IPO and official thread!` by project/operator accounts associated with Esecurity S.A.
+
+The prior canonical record incorrectly used `crypto-trade.net`. That domain belongs to a later service whose own 2016 announcement described itself as newly alive after more than a year of development. Treating that later service as the 2013-2015 exchange conflated two separate identities.
+
+Correction:
+
+- `official_url_original`: `https://crypto-trade.net/` -> `https://crypto-trade.com/`
+- `official_domain_original`: `crypto-trade.net` -> `crypto-trade.com`
+- archived URL moved from `.net` to `.com`
+- alias `Crypto-Trade.net` -> `Crypto-Trade.com`
+
+## Launch date
+
+The prior exact `2013-01-01` is unsupported. The original project thread begins in March 2013 and contains multiple planned launch dates in April 2013, including an initially planned 1 April launch, then 2 April, and later a statement that the project would be launched by 15 April. Those are planning statements, not proof of an exact first-live day.
+
+Correction: `launch_date` -> `null`.
+
+No `launched` event is emitted.
+
+## Terminal lifecycle
+
+A contemporaneous Bitcoin Forum post on 2015-01-28 preserves Crypto-Trade's shutdown notice. The notice stated that low volume and weak user growth left the exchange unable to cover server rental, staff salary, and promotion expenses; users were asked to withdraw within 48 hours; and the site would go offline on 2015-01-29 at 06:00 UTC.
+
+A separate contemporaneous fund thread on 2015-01-27 independently referred to the closure of `crypto-trade.com` and repeated the same 2015-01-29 06:00 UTC cutoff.
+
+Therefore:
+
+- `status: dead` retained
+- `death_reason: voluntary_shutdown` retained
+- `death_date: 2015-01-29` retained
+- event `hei_ev_010238` added as `shutdown_effective`
+
+The shutdown notice is treated as evidence of the operator-announced permanent closure and economic rationale. Allegations by community posters about fraud, theft, or mishandling of shareholder assets are not promoted into canonical findings because this batch does not establish those claims through authoritative adjudication or primary evidence.
+
+## Origin
+
+Historical material associates Crypto-Trade with Esecurity S.A. and includes a Hong Kong address. This batch does not convert that address into a definitive operating jurisdiction for the exchange. `country_or_origin` remains `Unknown`.
+
+## Evidence added
+
+- `hei_src_012792` — operator-originated Bitcoin Forum project thread; identity and launch-planning context
+- `hei_src_012793` — contemporaneous Bitcoin Forum preservation of the shutdown notice
+- `hei_src_012794` — independent contemporaneous closure/cutoff corroboration
+
+## Result
+
+The record now identifies the correct historical domain, removes an unsupported exact launch date, preserves the evidence-supported terminal date and voluntary-shutdown classification, and adds lifecycle/evidence links without importing allegations as findings.

--- a/records/exchanges/crypto-trade.json
+++ b/records/exchanges/crypto-trade.json
@@ -3,35 +3,106 @@
     "id": "hei_ex_000246",
     "slug": "crypto-trade",
     "canonical_name": "Crypto-Trade",
-    "aliases": ["CryptoTrade", "Crypto-Trade.net"],
+    "aliases": ["CryptoTrade", "Crypto-Trade.com"],
     "type": "cex",
     "status": "dead",
     "death_reason": "voluntary_shutdown",
-    "launch_date": "2013-01-01",
+    "launch_date": null,
     "death_date": "2015-01-29",
     "country_or_origin": "Unknown",
-    "summary": "Early cryptocurrency exchange that announced permanent shutdown in January 2015 because low volume and weak user growth left it unable to cover operating costs.",
-    "official_url_original": "https://crypto-trade.net/",
-    "official_domain_original": "crypto-trade.net",
+    "summary": "Early cryptocurrency and securities exchange operated at crypto-trade.com. Its operators announced a permanent shutdown in January 2015, citing low trading volume, weak user growth, and inability to cover operating costs, with the site scheduled to go offline on 2015-01-29 at 06:00 UTC.",
+    "official_url_original": "https://crypto-trade.com/",
+    "official_domain_original": "crypto-trade.com",
     "official_url_status": "dead_domain",
-    "archived_url": "https://web.archive.org/web/*/https://crypto-trade.net/",
+    "archived_url": "https://web.archive.org/web/*/https://crypto-trade.com/",
     "predecessor_id": null,
     "successor_id": null,
     "confidence": "medium",
-    "last_verified_at": "2026-06-20",
-    "notes": "Terminal handling uses 2015-01-29 because the quoted shutdown notice said the site would go offline on 2015-01-29 at 06:00 UTC. Death reason is mapped to voluntary_shutdown because the exchange announced a planned permanent shutdown citing low volume, weak userbase, and inability to cover operating costs. The 2026-06-20 explicit-origin review retained Unknown: the original project announcement, shutdown material, archived pages, and historical exchange references do not identify a legal entity, headquarters, founding jurisdiction, or ecosystem origin. Later unrelated services using similar names or domains are excluded."
+    "last_verified_at": "2026-09-09",
+    "notes": "The canonical identity is the 2013-2015 exchange at crypto-trade.com, not the later crypto-trade.net service that announced its own launch in 2016. The prior crypto-trade.net URL/domain/alias were therefore removed as an identity conflation. status dead, death_reason voluntary_shutdown, and death_date 2015-01-29 are retained because contemporaneous community records preserve the exchange's shutdown notice stating that the site would go offline on that date at 06:00 UTC after a 48-hour withdrawal window. The prior launch_date 2013-01-01 is removed because operator posts establish the project in March 2013 and show planned launch dates in April 2013, but the reviewed evidence does not prove an exact first-live day. Country/origin remains Unknown: historical material associates the project with Esecurity S.A. and a Hong Kong address, but that is not sufficient here to establish a single operating jurisdiction for the exchange itself."
   },
+  "events": [
+    {
+      "id": "hei_ev_010238",
+      "exchange_id": "hei_ex_000246",
+      "event_type": "shutdown_effective",
+      "event_date": "2015-01-29",
+      "title": "Crypto-Trade scheduled permanent shutdown",
+      "description": "Crypto-Trade's shutdown notice instructed users to withdraw funds within 48 hours and stated that the site would go offline on 2015-01-29 at 06:00 UTC because low volume and weak user growth left the operation unable to cover its expenses.",
+      "confidence": "high",
+      "impact_level": "critical",
+      "event_status_effect": "dead",
+      "source_count": 2,
+      "sort_order": 1,
+      "notes": "The exact date is supported as the announced site-offline cutoff. The record does not infer insolvency, enforcement, theft, or another unproven terminal cause."
+    }
+  ],
+  "evidence": [
+    {
+      "id": "hei_src_012792",
+      "exchange_id": "hei_ex_000246",
+      "event_id": null,
+      "source_type": "community_reference",
+      "title": "[CRYPTO-TRADE] Crypto-trade.com IPO and official thread!",
+      "url": "https://bitcointalk.org/index.php?topic=149458.0",
+      "publisher": "Bitcoin Forum",
+      "published_at": "2013-03-05",
+      "archived_url": "https://web.archive.org/web/*/https://bitcointalk.org/index.php?topic=149458.0",
+      "accessed_at": "2026-09-09",
+      "reliability": "medium",
+      "claim_scope": "entity",
+      "notes": "Operator-originated project thread identifies the historical exchange as crypto-trade.com, describes the planned cryptocurrency trading platform, and associates it with Esecurity S.A. It supports entity identity and operation planning, but reviewed posts only provide planned April 2013 launch dates rather than a proven exact live date."
+    },
+    {
+      "id": "hei_src_012793",
+      "exchange_id": "hei_ex_000246",
+      "event_id": "hei_ev_010238",
+      "source_type": "community_reference",
+      "title": "List of Major Bitcoin Heists, Thefts, Hacks, Scams, and Losses — Crypto-Trade closure notice preserved",
+      "url": "https://bitcointalk.org/index.php?topic=576337.msg10291712",
+      "publisher": "Bitcoin Forum",
+      "published_at": "2015-01-28",
+      "archived_url": "https://web.archive.org/web/*/https://bitcointalk.org/index.php?topic=576337.msg10291712",
+      "accessed_at": "2026-09-09",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Contemporaneous post preserves the exchange's shutdown notice: permanent shutdown due to low volume, weak userbase, and inability to cover server, staff, and promotion costs; users were given 48 hours to withdraw and the site was to go offline on 2015-01-29 at 06:00 UTC. Used for the terminal event without adopting the surrounding poster's allegations as findings."
+    },
+    {
+      "id": "hei_src_012794",
+      "exchange_id": "hei_ex_000246",
+      "event_id": "hei_ev_010238",
+      "source_type": "community_reference",
+      "title": "[Cryptostocks] BBBB Bitcoin Emerging Market Fund — Crypto-Trade closure reference",
+      "url": "https://bitcointalk.org/index.php?topic=95441.0%3Ball",
+      "publisher": "Bitcoin Forum",
+      "published_at": "2015-01-27",
+      "archived_url": "https://web.archive.org/web/*/https://bitcointalk.org/index.php?topic=95441.0%3Ball",
+      "accessed_at": "2026-09-09",
+      "reliability": "medium",
+      "claim_scope": "event",
+      "notes": "Independent contemporaneous participant reference corroborates the closure of crypto-trade.com and repeats the 2015-01-29 06:00 UTC offline cutoff while liquidating assets held on the exchange."
+    }
+  ],
   "entity_correction": {
     "entity_id": "hei_ex_000246",
     "expected": {
-      "last_verified_at": "2026-04-25",
-      "notes": "Terminal handling uses 2015-01-29 because the quoted shutdown notice said the site would go offline on 2015-01-29 at 06:00 UTC. Death reason is mapped to voluntary_shutdown because the exchange announced a planned permanent shutdown citing low volume, weak userbase, and inability to cover operating costs. Country/origin remains Unknown because the current evidence set does not establish an operating jurisdiction."
+      "aliases": ["CryptoTrade", "Crypto-Trade.net"],
+      "launch_date": "2013-01-01",
+      "death_date": "2015-01-29",
+      "official_url_original": "https://crypto-trade.net/",
+      "official_domain_original": "crypto-trade.net",
+      "archived_url": "https://web.archive.org/web/*/https://crypto-trade.net/",
+      "last_verified_at": "2026-06-20"
     },
     "changes": {
-      "last_verified_at": "2026-06-20",
-      "notes": "Terminal handling uses 2015-01-29 because the quoted shutdown notice said the site would go offline on 2015-01-29 at 06:00 UTC. Death reason is mapped to voluntary_shutdown because the exchange announced a planned permanent shutdown citing low volume, weak userbase, and inability to cover operating costs. The 2026-06-20 explicit-origin review retained Unknown: the original project announcement, shutdown material, archived pages, and historical exchange references do not identify a legal entity, headquarters, founding jurisdiction, or ecosystem origin. Later unrelated services using similar names or domains are excluded."
+      "aliases": ["CryptoTrade", "Crypto-Trade.com"],
+      "launch_date": null,
+      "death_date": "2015-01-29",
+      "official_url_original": "https://crypto-trade.com/",
+      "official_domain_original": "crypto-trade.com",
+      "archived_url": "https://web.archive.org/web/*/https://crypto-trade.com/",
+      "last_verified_at": "2026-09-09"
     }
-  },
-  "events": [],
-  "evidence": []
+  }
 }


### PR DESCRIPTION
## Summary
- resolve Crypto-Trade zero-evidence legacy bundle under #857
- correct historical identity from the unrelated later `crypto-trade.net` service to the 2013-2015 `crypto-trade.com` exchange
- preserve `status: dead`, `death_reason: voluntary_shutdown`, and `death_date: 2015-01-29`
- remove unsupported exact `launch_date: 2013-01-01`
- add the exact 2015-01-29 shutdown event and three contemporaneous evidence records
- keep community allegations separate from canonical findings

## Scope
Crypto-Trade only. No schema, workflow, validator, monitoring, Phase 9, or unrelated canonical changes.