### PR TITLE
Add data_breach event type for exchange customer-data incidents

### DIFF
--- a/scripts/audit-legacy-enums.mjs
+++ b/scripts/audit-legacy-enums.mjs
@@ -14,7 +14,7 @@ const allowed = {
     'repurposed', 'unsafe', 'unknown',
   ]),
   event_type: new Set([
-    'launched', 'rebranded', 'acquired', 'merged', 'hack', 'exploit',
+    'launched', 'rebranded', 'acquired', 'merged', 'hack', 'exploit', 'data_breach',
     'withdrawal_suspended', 'deposit_suspended', 'trading_halted',
     'service_outage', 'regulatory_action', 'lawsuit', 'bankruptcy_filed',
     'insolvency_declared', 'shutdown_announced', 'shutdown_effective',

--- a/scripts/monitoring/core/constants.mjs
+++ b/scripts/monitoring/core/constants.mjs
@@ -63,6 +63,7 @@ export const EVENT_TYPE_VALUES = [
   'merged',
   'hack',
   'exploit',
+  'data_breach',
   'withdrawal_suspended',
   'deposit_suspended',
   'trading_halted',

--- a/src/i18n/locales/en/enums.json
+++ b/src/i18n/locales/en/enums.json
@@ -36,6 +36,7 @@
   "eventType.merged": "Merged",
   "eventType.hack": "Hack",
   "eventType.exploit": "Exploit",
+  "eventType.data_breach": "Data breach",
   "eventType.withdrawal_suspended": "Withdrawals suspended",
   "eventType.deposit_suspended": "Deposits suspended",
   "eventType.trading_halted": "Trading halted",

--- a/src/i18n/locales/ja/enums.json
+++ b/src/i18n/locales/ja/enums.json
@@ -36,6 +36,7 @@
   "eventType.merged": "合併",
   "eventType.hack": "ハッキング",
   "eventType.exploit": "脆弱性悪用",
+  "eventType.data_breach": "データ侵害",
   "eventType.withdrawal_suspended": "出金停止",
   "eventType.deposit_suspended": "入金停止",
   "eventType.trading_halted": "取引停止",

--- a/src/lib/data/build-incident-timeline.ts
+++ b/src/lib/data/build-incident-timeline.ts
@@ -8,6 +8,7 @@ import { loadEvidence } from './load-evidence'
 const INCIDENT_EVENT_TYPES = new Set<EventType>([
   'hack',
   'exploit',
+  'data_breach',
   'withdrawal_suspended',
   'deposit_suspended',
   'trading_halted',
@@ -24,6 +25,7 @@ const INCIDENT_EVENT_TYPES = new Set<EventType>([
 export const INCIDENT_EVENT_TYPE_LABELS: Partial<Record<EventType, string>> = {
   hack: 'Hack',
   exploit: 'Exploit',
+  data_breach: 'Data breach',
   withdrawal_suspended: 'Withdrawals suspended',
   deposit_suspended: 'Deposits suspended',
   trading_halted: 'Trading halted',

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -7,6 +7,7 @@ export type EventType =
   | 'merged'
   | 'hack'
   | 'exploit'
+  | 'data_breach'
   | 'withdrawal_suspended'
   | 'deposit_suspended'
   | 'trading_halted'


### PR DESCRIPTION
## Summary

Adds a dedicated `data_breach` event type so HEI can represent customer/database compromise separately from asset-wallet hacks and smart-contract exploits.

### Included
- EventType union support
- canonical enum audit support
- monitoring enum support
- Incidents timeline inclusion and label
- English label: `Data breach`
- Japanese label: `データ侵害`

## Why

The current HTX monitoring signal in #978 alleges a customer database compromise. It is **not verified** and is **not added to canonical data by this PR**. If independently confirmed later, it should not be collapsed into HTX's existing 2023 hot-wallet `hack` event.

## Safety boundary

This PR changes schema/UI plumbing only.

It does **not**:
- modify `records/exchanges/htx.json`
- add a canonical HTX event
- change HTX `status=active`
- assert that 6.5M+ records were actually exposed
- assert that password / Google Authenticator / KYC fields contain usable secrets

Closes no investigation issue; #978 remains the verification gate.