### PR TITLE
Repair HEI locale SEO output and govern Pages build command

### DIFF
--- a/config/cloudflare-pages-project.json
+++ b/config/cloudflare-pages-project.json
@@ -2,6 +2,9 @@
   "schema_version": "1.0.0",
   "project_name": "historical-exchange-index",
   "production_branch": "main",
+  "build_config": {
+    "build_command": "npm run build"
+  },
   "source_config": {
     "production_deployments_enabled": true,
     "preview_deployment_setting": "none",

--- a/config/cloudflare-pages-project.json
+++ b/config/cloudflare-pages-project.json
@@ -16,6 +16,7 @@
       "records/*",
       "scripts/build-machine-readable-layer.mjs",
       "scripts/build-record-level-machine-readable.mjs",
+      "scripts/localize-static-html.mjs",
       "scripts/register-stats-machine-readable.mjs",
       "scripts/lib/*",
       "package.json",

--- a/docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md
+++ b/docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md
@@ -14,11 +14,12 @@ Preserve development speed while reducing unnecessary Cloudflare Pages builds on
 3. Preview deployment is allowed only when Cloudflare-specific behavior must be verified, such as routing, redirects, metadata, build configuration, or major UI changes.
 4. Production deployment targets the latest reviewed `main` state, not every intermediate commit.
 5. Documentation, monitoring output, staging data, backlog work, and internal audit changes must not trigger a Pages deployment unless they also change public output.
-6. While Git integration remains enabled, intermediate commits that must not deploy use the `[CF-Pages-Skip]` commit prefix.
+6. While Git integration remains enabled, intermediate commits that must not deploy use `[CF-Pages-Skip]` commit prefix.
 7. A stale production result is not automatically a code failure. Compare `/version.json` with the expected Git commit before diagnosing the build.
 8. Production verification begins only after the deployed commit matches the expected `main` commit.
 9. Do not create temporary audit PRs that trigger Cloudflare builds unless preview deployment is explicitly required.
 10. Any change to deployment-sensitive files must review this policy in the same PR.
+11. The Pages production build command must be `npm run build`; this is required because the package build includes the deterministic Japanese static-HTML localization and reciprocal-locale postprocess after `next build`.
 
 ## Machine-readable project policy
 
@@ -28,7 +29,7 @@ The desired Cloudflare Pages project state is stored in:
 config/cloudflare-pages-project.json
 ```
 
-The JSON file, not a copied dashboard screenshot or old conversation, is the machine-readable authority for branch controls and build watch paths. Changes to it require review under this policy.
+The JSON file, not a copied dashboard screenshot or old conversation, is the machine-readable authority for branch controls, the governed build command, and build watch paths. Changes to it require review under this policy.
 
 ## Deployment-sensitive files
 
@@ -50,10 +51,11 @@ The JSON file, not a copied dashboard screenshot or old conversation, is the mac
 - Production branch: `main`
 - Production deployments: enabled
 - Preview deployments: disabled
+- Build command: `npm run build`
 - Build watch paths: include public-output paths and exclude docs, staging, monitoring reports, and internal audits
 - Pull request deployment comments: disabled while automatic previews are disabled
 
-The exact include and exclude arrays are defined in `config/cloudflare-pages-project.json`.
+The exact governed values are defined in `config/cloudflare-pages-project.json`. The configurator preserves unrelated existing build-config fields such as destination/root directory while enforcing the repository-owned build command.
 
 Cloudflare wildcard `*` matches nested path separators, so repository configuration uses patterns such as `src/*` and `docs/*`.
 
@@ -69,7 +71,7 @@ npm run cloudflare:config:apply
 
 - `print` shows the desired state without credentials.
 - `plan` reads the current Pages project and reports whether it differs.
-- `apply` reads the current project, preserves GitHub source identity fields, patches only the governed settings, then reads the project again and verifies the result.
+- `apply` reads the current project, preserves GitHub source identity and unrelated build-config fields, patches only the governed settings, then reads the project again and verifies the result.
 
 The former dedicated `Configure Cloudflare Pages` workflow wrapper was intentionally removed during workflow consolidation. Do not reintroduce a one-off configuration workflow merely to invoke these commands. Run `plan` or `apply` only from an authorized operator environment when Cloudflare configuration actually needs review or change.
 
@@ -117,6 +119,7 @@ After deployment, verify:
 6. `/sitemap.xml` and `/robots.txt` return HTTP 200.
 7. Legacy routes redirect as defined.
 8. No obsolete count is presented as current.
+9. Representative `/ja/` output emits `html lang="ja"` and reciprocal `en`/`ja` hreflang links after the governed `npm run build` postprocess.
 
 ## Future controlled deployment
 
@@ -140,6 +143,7 @@ For the wider ledger series, a shared deployment queue should eventually seriali
 - using a Global API key when a scoped Pages token is sufficient
 - increasing Cloudflare plan cost before reducing unnecessary builds
 - restoring deleted one-off workflow wrappers without a reviewed operational need
+- setting a Pages build command that bypasses the repository `npm run build` contract and therefore skips required static-output postprocessing
 
 ## PR checklist
 

--- a/docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md
+++ b/docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md
@@ -20,6 +20,7 @@ Preserve development speed while reducing unnecessary Cloudflare Pages builds on
 9. Do not create temporary audit PRs that trigger Cloudflare builds unless preview deployment is explicitly required.
 10. Any change to deployment-sensitive files must review this policy in the same PR.
 11. The Pages production build command must be `npm run build`; this is required because the package build includes the deterministic Japanese static-HTML localization and reciprocal-locale postprocess after `next build`.
+12. Keep the account-level permanent redirect from `historical-exchange-index.pages.dev/*` to the path-equivalent `https://hei.badjoke-lab.com/*` active throughout the search migration; do not restore the legacy Pages hostname as an independently served canonical surface.
 
 ## Machine-readable project policy
 

--- a/scripts/configure-cloudflare-pages-project.mjs
+++ b/scripts/configure-cloudflare-pages-project.mjs
@@ -26,6 +26,12 @@ function readConfig() {
   if (parsed.schema_version !== '1.0.0') fail('Unsupported Cloudflare policy schema_version.')
   if (!parsed.project_name) fail('Cloudflare policy requires project_name.')
   if (!parsed.production_branch) fail('Cloudflare policy requires production_branch.')
+  if (!parsed.build_config || typeof parsed.build_config !== 'object') {
+    fail('Cloudflare policy requires build_config.')
+  }
+  if (!parsed.build_config.build_command) {
+    fail('Cloudflare policy requires build_config.build_command.')
+  }
   if (!parsed.source_config || typeof parsed.source_config !== 'object') {
     fail('Cloudflare policy requires source_config.')
   }
@@ -71,6 +77,7 @@ function selectedState(project) {
     project_name: project?.name ?? null,
     production_branch: project?.production_branch ?? null,
     source_type: source?.type ?? null,
+    build_command: project?.build_config?.build_command ?? null,
     production_deployments_enabled: config.production_deployments_enabled ?? null,
     preview_deployment_setting: config.preview_deployment_setting ?? null,
     pr_comments_enabled: config.pr_comments_enabled ?? null,
@@ -84,6 +91,7 @@ function desiredState(policy) {
     project_name: policy.project_name,
     production_branch: policy.production_branch,
     source_type: 'github',
+    build_command: policy.build_config.build_command,
     ...policy.source_config,
   }
 }
@@ -100,6 +108,10 @@ function buildPatch(currentProject, policy) {
 
   return {
     production_branch: policy.production_branch,
+    build_config: {
+      ...(currentProject.build_config ?? {}),
+      build_command: policy.build_config.build_command,
+    },
     source: {
       type: source.type,
       config: {

--- a/scripts/localize-static-html.mjs
+++ b/scripts/localize-static-html.mjs
@@ -5,6 +5,7 @@ import process from 'node:process'
 
 const root = process.cwd()
 const selfTest = process.argv.includes('--self-test')
+const canonicalOrigin = (process.env.NEXT_PUBLIC_SITE_URL || 'https://hei.badjoke-lab.com').replace(/\/$/, '')
 
 function assert(condition, message) {
   if (!condition) throw new Error(`static locale postprocess failed: ${message}`)
@@ -27,18 +28,73 @@ function listHtmlFiles(directory) {
   return files
 }
 
+function routeFromOutputFile(filePath, outRoot) {
+  const relative = path.relative(outRoot, filePath).split(path.sep).join('/')
+  if (relative === 'index.html') return '/'
+  if (!relative.endsWith('/index.html')) return null
+  return `/${relative.slice(0, -'index.html'.length)}`
+}
+
+function localizedRoutePair(route) {
+  if (!route) return null
+  if (route === '/ja/') return { en: '/', ja: '/ja/' }
+  if (route.startsWith('/ja/')) return { en: route.slice(3), ja: route }
+  if (route === '/') return { en: '/', ja: '/ja/' }
+  return { en: route, ja: `/ja${route}` }
+}
+
+function routeToOutputFile(route, outRoot) {
+  if (route === '/') return path.join(outRoot, 'index.html')
+  const relative = route.replace(/^\//, '').replace(/\/$/, '')
+  return path.join(outRoot, relative, 'index.html')
+}
+
+function ensureLocaleAlternates(html, pair) {
+  if (!pair) return html
+
+  let output = html
+  const tags = [
+    ['en', `${canonicalOrigin}${pair.en}`],
+    ['ja', `${canonicalOrigin}${pair.ja}`],
+  ]
+
+  const additions = []
+  for (const [locale, href] of tags) {
+    const hasLocale = new RegExp(`hreflang=["']${locale}["']`, 'i').test(output)
+    if (!hasLocale) additions.push(`<link rel="alternate" hreflang="${locale}" href="${href}"/>`)
+  }
+
+  if (additions.length > 0) {
+    assert(/<\/head>/i.test(output), 'cannot inject hreflang without a closing head tag')
+    output = output.replace(/<\/head>/i, `${additions.join('')}</head>`)
+  }
+
+  return output
+}
+
 function runSelfTest() {
-  const sample = '<html lang="en"><body><script>{"inLanguage":"en"}</script><a hreflang="en">English</a></body></html>'
+  const sample = '<html lang="en"><head></head><body><script>{"inLanguage":"en"}</script><a hreflang="en">English</a></body></html>'
   const localized = localizeJapaneseHtml(sample)
   assert(localized.includes('<html lang="ja">'), 'html lang replacement failed')
   assert(localized.includes('"inLanguage":"ja"'), 'JSON-LD inLanguage replacement failed')
-  assert(localized.includes('hreflang="en"'), 'hreflang must not be rewritten')
+  assert(localized.includes('hreflang="en"'), 'existing hreflang must not be rewritten')
+
+  const withAlternates = ensureLocaleAlternates('<html lang="en"><head></head><body></body></html>', {
+    en: '/stats/',
+    ja: '/ja/stats/',
+  })
+  assert(withAlternates.includes(`hreflang="en" href="${canonicalOrigin}/stats/"`), 'English hreflang injection failed')
+  assert(withAlternates.includes(`hreflang="ja" href="${canonicalOrigin}/ja/stats/"`), 'Japanese hreflang injection failed')
+  const idempotent = ensureLocaleAlternates(withAlternates, { en: '/stats/', ja: '/ja/stats/' })
+  assert(idempotent === withAlternates, 'hreflang injection must be idempotent')
 
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hei-ja-html-'))
   fs.mkdirSync(path.join(tempRoot, 'nested'))
   fs.writeFileSync(path.join(tempRoot, 'index.html'), sample)
   fs.writeFileSync(path.join(tempRoot, 'nested', 'index.html'), sample)
   assert(listHtmlFiles(tempRoot).length === 2, 'recursive HTML discovery failed')
+  assert(routeFromOutputFile(path.join(tempRoot, 'index.html'), tempRoot) === '/', 'root route mapping failed')
+  assert(routeFromOutputFile(path.join(tempRoot, 'nested', 'index.html'), tempRoot) === '/nested/', 'nested route mapping failed')
   fs.rmSync(tempRoot, { recursive: true, force: true })
 
   console.log('Static locale postprocess self-test: pass')
@@ -49,23 +105,51 @@ if (selfTest) {
   process.exit(0)
 }
 
-const jaRoot = path.join(root, 'out', 'ja')
+const outRoot = path.join(root, 'out')
+const jaRoot = path.join(outRoot, 'ja')
+assert(fs.existsSync(outRoot), 'out does not exist; static site was not built')
 assert(fs.existsSync(jaRoot), 'out/ja does not exist; Japanese public route family was not built')
 assert(fs.existsSync(path.join(jaRoot, 'index.html')), 'Japanese root output is missing')
 
-const files = listHtmlFiles(jaRoot)
-assert(files.length > 0, 'no Japanese HTML output files found')
+const japaneseFiles = listHtmlFiles(jaRoot)
+assert(japaneseFiles.length > 0, 'no Japanese HTML output files found')
 
-let changed = 0
-for (const filePath of files) {
+let localizedChanged = 0
+for (const filePath of japaneseFiles) {
   const before = fs.readFileSync(filePath, 'utf8')
   const after = localizeJapaneseHtml(before)
   assert(/<html\s+lang=["']ja["']/i.test(after), `${path.relative(root, filePath)} still lacks html lang=ja`)
   if (before !== after) {
     fs.writeFileSync(filePath, after)
-    changed += 1
+    localizedChanged += 1
   }
 }
 
-assert(changed > 0, 'no Japanese HTML files required localization; verify build contract before removing this postprocessor')
-console.log(`Localized Japanese static HTML: ${changed}/${files.length} files updated.`)
+assert(localizedChanged > 0, 'no Japanese HTML files required localization; verify build contract before removing this postprocessor')
+
+const allFiles = listHtmlFiles(outRoot)
+let alternateChanged = 0
+let reciprocalPairs = 0
+for (const filePath of allFiles) {
+  const route = routeFromOutputFile(filePath, outRoot)
+  const pair = localizedRoutePair(route)
+  if (!pair) continue
+
+  const enFile = routeToOutputFile(pair.en, outRoot)
+  const jaFile = routeToOutputFile(pair.ja, outRoot)
+  if (!fs.existsSync(enFile) || !fs.existsSync(jaFile)) continue
+
+  reciprocalPairs += 1
+  const before = fs.readFileSync(filePath, 'utf8')
+  const after = ensureLocaleAlternates(before, pair)
+  assert(/hreflang=["']en["']/i.test(after), `${path.relative(root, filePath)} lacks reciprocal hreflang=en`)
+  assert(/hreflang=["']ja["']/i.test(after), `${path.relative(root, filePath)} lacks reciprocal hreflang=ja`)
+  if (before !== after) {
+    fs.writeFileSync(filePath, after)
+    alternateChanged += 1
+  }
+}
+
+assert(reciprocalPairs > 0, 'no reciprocal English/Japanese route pairs were found')
+console.log(`Localized Japanese static HTML: ${localizedChanged}/${japaneseFiles.length} files updated.`)
+console.log(`Ensured reciprocal locale alternates: ${reciprocalPairs} route outputs checked, ${alternateChanged} files updated.`)

--- a/src/app/ja/page.tsx
+++ b/src/app/ja/page.tsx
@@ -16,7 +16,7 @@ export default function JapaneseHomePage() {
       <section className="hero compact-hero">
         <div className="panel hero-main">
           <div className="eyebrow">{presentation.eyebrow}</div>
-          <h2>{presentation.heading}</h2>
+          <h1>{presentation.heading}</h1>
           <p>{presentation.intro}</p>
           <div className="hero-actions">
             <Link className="btn btn-primary" href="/ja/dead/">終了側を見る</Link>


### PR DESCRIPTION
## Roadmap item
L-2 Localization Evaluation Gate — HOLD / EVIDENCE CAPTURE, specifically repair of the already-public Japanese Pilot SEO surface while external indexing evidence is being collected.

## Specification authority
- `docs/HEI_LOCALIZATION_STRATEGY_AND_FOUNDATION_SPEC.md` §14 — correct document language, locale-specific canonical metadata, reciprocal hreflang, deliberate sitemap coverage.
- `docs/HEI_L1_JAPANESE_PILOT_IMPLEMENTATION_PLAN.md` §3/§4 — Japanese output must emit `html lang="ja"`; the deterministic static-output postprocessor is the approved static-export approach.
- `docs/operations/CLOUDFLARE_DEPLOYMENT_POLICY.md` — deployment-sensitive changes require CI and an explicit production verification plan.

## Changes
- change the Japanese home hero heading from `h2` to the page-level `h1` required by the public SEO/accessibility contract;
- extend the existing deterministic static HTML postprocessor so every English/Japanese route pair has reciprocal `hreflang=en` and `hreflang=ja`, while continuing to rewrite Japanese document language and JSON-LD `inLanguage`;
- extend the postprocessor self-test for hreflang injection, idempotence, and route mapping;
- make `npm run build` an explicit repository-owned Cloudflare Pages build-command requirement, because that package command is what runs the required post-build locale processing;
- extend the existing Cloudflare project configurator so `plan/apply` audits and enforces that build command while preserving unrelated build-config fields.

## Canonical count impact
None. No entity, event, evidence, status, slug, or reviewed factual field changes.

## Deployment impact
Yes. Public HTML metadata/document-language output changes, and the repository-owned Pages project policy now governs the build command.

Preview decision: preview remains disabled under current policy. This repair uses the existing static-export/postprocess architecture rather than introducing a new route/runtime architecture. Merge is gated on GitHub CI; production is then verified against the exact deployed main commit.

## Validation
Pending normal GitHub CI. The updated static-output self-test is part of the existing repository test surface and now covers reciprocal locale alternates.

## Production verification plan
After merge/deploy:
1. verify `/version.json` reports the merged main commit;
2. verify `/ja/` and `/ja/exchange/mt-gox/` emit `html lang="ja"`;
3. verify representative reciprocal alternates on `/`, `/stats/`, `/methodology/`, `/exchange/mt-gox/` and their `/ja/` counterparts;
4. verify `/sitemap.xml` and `/robots.txt` remain HTTP 200;
5. verify the already-configured `historical-exchange-index.pages.dev/* -> https://hei.badjoke-lab.com/*` 301 remains intact;
6. re-run on-page SEO checks after the exact commit is live.

If the production project currently bypasses the repository package build command, run `npm run cloudflare:config:plan` / `npm run cloudflare:config:apply` from an authorized operator environment (or set the dashboard Build command to `npm run build`) before declaring the locale repair live.